### PR TITLE
scraper: Bayerische Staatsoper (München)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Missing your favorite venue? PRs welcome! Read **[CONTRIBUTING.md](CONTRIBUTING.
 | Oper Frankfurt | Frankfurt |
 | San Francisco Opera | San Francisco |
 | Gran Teatre del Liceu | Barcelona |
+| Bayerische Staatsoper | München |
 
 ## How it works
 

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -13,6 +13,7 @@ import { WienerStaatsoperScraper } from './scrapers/wiener-staatsoper.js';
 import { OperFrankfurtScraper } from './scrapers/oper-frankfurt.js';
 import { SanFranciscoOperaScraper } from './scrapers/san-francisco-opera.js';
 import { LiceuBarcelonaScraper } from './scrapers/liceu-barcelona.js';
+import { BayerischeStaatsoperScraper } from './scrapers/bayerische-staatsoper.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -42,6 +43,7 @@ const scrapers: Scraper[] = [
   new OperFrankfurtScraper(),
   new SanFranciscoOperaScraper(),
   new LiceuBarcelonaScraper(),
+  new BayerischeStaatsoperScraper(),
 ];
 
 export async function runAllScrapers(): Promise<void> {

--- a/src/scrapers/__fixtures__/bayerische-staatsoper.html
+++ b/src/scrapers/__fixtures__/bayerische-staatsoper.html
@@ -1,0 +1,2073 @@
+<html lang="de" class="schedule-nav-open" style="--window-inner-height: 1459px; --additional-height: 46px; --month-item-height: 58.59375px;"><head><style>:root{--litepicker-container-months-color-bg: #fff;--litepicker-container-months-box-shadow-color: #ddd;--litepicker-footer-color-bg: #fafafa;--litepicker-footer-box-shadow-color: #ddd;--litepicker-tooltip-color-bg: #fff;--litepicker-month-header-color: #333;--litepicker-button-prev-month-color: #9e9e9e;--litepicker-button-next-month-color: #9e9e9e;--litepicker-button-prev-month-color-hover: #2196f3;--litepicker-button-next-month-color-hover: #2196f3;--litepicker-month-width: calc(var(--litepicker-day-width) * 7);--litepicker-month-weekday-color: #9e9e9e;--litepicker-month-week-number-color: #9e9e9e;--litepicker-day-width: 38px;--litepicker-day-color: #333;--litepicker-day-color-hover: #2196f3;--litepicker-is-today-color: #f44336;--litepicker-is-in-range-color: #bbdefb;--litepicker-is-locked-color: #9e9e9e;--litepicker-is-start-color: #fff;--litepicker-is-start-color-bg: #2196f3;--litepicker-is-end-color: #fff;--litepicker-is-end-color-bg: #2196f3;--litepicker-button-cancel-color: #fff;--litepicker-button-cancel-color-bg: #9e9e9e;--litepicker-button-apply-color: #fff;--litepicker-button-apply-color-bg: #2196f3;--litepicker-button-reset-color: #909090;--litepicker-button-reset-color-hover: #2196f3;--litepicker-highlighted-day-color: #333;--litepicker-highlighted-day-color-bg: #ffeb3b}.show-week-numbers{--litepicker-month-width: calc(var(--litepicker-day-width) * 8)}.litepicker{font-family:-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;font-size:0.8em;display:none}.litepicker button{border:none;background:none}.litepicker .container__main{display:-webkit-box;display:-ms-flexbox;display:flex}.litepicker .container__months{display:-webkit-box;display:-ms-flexbox;display:flex;-ms-flex-wrap:wrap;flex-wrap:wrap;background-color:var(--litepicker-container-months-color-bg);border-radius:5px;-webkit-box-shadow:0 0 5px var(--litepicker-container-months-box-shadow-color);box-shadow:0 0 5px var(--litepicker-container-months-box-shadow-color);width:calc(var(--litepicker-month-width) + 10px);-webkit-box-sizing:content-box;box-sizing:content-box}.litepicker .container__months.columns-2{width:calc((var(--litepicker-month-width) * 2) + 20px)}.litepicker .container__months.columns-3{width:calc((var(--litepicker-month-width) * 3) + 30px)}.litepicker .container__months.columns-4{width:calc((var(--litepicker-month-width) * 4) + 40px)}.litepicker .container__months.split-view .month-item-header .button-previous-month,.litepicker .container__months.split-view .month-item-header .button-next-month{visibility:visible}.litepicker .container__months .month-item{padding:5px;width:var(--litepicker-month-width);-webkit-box-sizing:content-box;box-sizing:content-box}.litepicker .container__months .month-item-header{display:-webkit-box;display:-ms-flexbox;display:flex;-webkit-box-pack:justify;-ms-flex-pack:justify;justify-content:space-between;font-weight:500;padding:10px 5px;text-align:center;-webkit-box-align:center;-ms-flex-align:center;align-items:center;color:var(--litepicker-month-header-color)}.litepicker .container__months .month-item-header div{-webkit-box-flex:1;-ms-flex:1;flex:1}.litepicker .container__months .month-item-header div>.month-item-name{margin-right:5px}.litepicker .container__months .month-item-header div>.month-item-year{padding:0}.litepicker .container__months .month-item-header .reset-button{color:var(--litepicker-button-reset-color)}.litepicker .container__months .month-item-header .reset-button>svg{fill:var(--litepicker-button-reset-color)}.litepicker .container__months .month-item-header .reset-button *{pointer-events:none}.litepicker .container__months .month-item-header .reset-button:hover{color:var(--litepicker-button-reset-color-hover)}.litepicker .container__months .month-item-header .reset-button:hover>svg{fill:var(--litepicker-button-reset-color-hover)}.litepicker .container__months .month-item-header .button-previous-month,.litepicker .container__months .month-item-header .button-next-month{visibility:hidden;text-decoration:none;padding:3px 5px;border-radius:3px;-webkit-transition:color 0.3s, border 0.3s;transition:color 0.3s, border 0.3s;cursor:default}.litepicker .container__months .month-item-header .button-previous-month *,.litepicker .container__months .month-item-header .button-next-month *{pointer-events:none}.litepicker .container__months .month-item-header .button-previous-month{color:var(--litepicker-button-prev-month-color)}.litepicker .container__months .month-item-header .button-previous-month>svg,.litepicker .container__months .month-item-header .button-previous-month>img{fill:var(--litepicker-button-prev-month-color)}.litepicker .container__months .month-item-header .button-previous-month:hover{color:var(--litepicker-button-prev-month-color-hover)}.litepicker .container__months .month-item-header .button-previous-month:hover>svg{fill:var(--litepicker-button-prev-month-color-hover)}.litepicker .container__months .month-item-header .button-next-month{color:var(--litepicker-button-next-month-color)}.litepicker .container__months .month-item-header .button-next-month>svg,.litepicker .container__months .month-item-header .button-next-month>img{fill:var(--litepicker-button-next-month-color)}.litepicker .container__months .month-item-header .button-next-month:hover{color:var(--litepicker-button-next-month-color-hover)}.litepicker .container__months .month-item-header .button-next-month:hover>svg{fill:var(--litepicker-button-next-month-color-hover)}.litepicker .container__months .month-item-weekdays-row{display:-webkit-box;display:-ms-flexbox;display:flex;justify-self:center;-webkit-box-pack:start;-ms-flex-pack:start;justify-content:flex-start;color:var(--litepicker-month-weekday-color)}.litepicker .container__months .month-item-weekdays-row>div{padding:5px 0;font-size:85%;-webkit-box-flex:1;-ms-flex:1;flex:1;width:var(--litepicker-day-width);text-align:center}.litepicker .container__months .month-item:first-child .button-previous-month{visibility:visible}.litepicker .container__months .month-item:last-child .button-next-month{visibility:visible}.litepicker .container__months .month-item.no-previous-month .button-previous-month{visibility:hidden}.litepicker .container__months .month-item.no-next-month .button-next-month{visibility:hidden}.litepicker .container__days{display:-webkit-box;display:-ms-flexbox;display:flex;-ms-flex-wrap:wrap;flex-wrap:wrap;justify-self:center;-webkit-box-pack:start;-ms-flex-pack:start;justify-content:flex-start;text-align:center;-webkit-box-sizing:content-box;box-sizing:content-box}.litepicker .container__days>div,.litepicker .container__days>a{padding:5px 0;width:var(--litepicker-day-width)}.litepicker .container__days .day-item{color:var(--litepicker-day-color);text-align:center;text-decoration:none;border-radius:3px;-webkit-transition:color 0.3s, border 0.3s;transition:color 0.3s, border 0.3s;cursor:default}.litepicker .container__days .day-item:hover{color:var(--litepicker-day-color-hover);-webkit-box-shadow:inset 0 0 0 1px var(--litepicker-day-color-hover);box-shadow:inset 0 0 0 1px var(--litepicker-day-color-hover)}.litepicker .container__days .day-item.is-today{color:var(--litepicker-is-today-color)}.litepicker .container__days .day-item.is-locked{color:var(--litepicker-is-locked-color)}.litepicker .container__days .day-item.is-locked:hover{color:var(--litepicker-is-locked-color);-webkit-box-shadow:none;box-shadow:none;cursor:default}.litepicker .container__days .day-item.is-in-range{background-color:var(--litepicker-is-in-range-color);border-radius:0}.litepicker .container__days .day-item.is-start-date{color:var(--litepicker-is-start-color);background-color:var(--litepicker-is-start-color-bg);border-top-left-radius:5px;border-bottom-left-radius:5px;border-top-right-radius:0;border-bottom-right-radius:0}.litepicker .container__days .day-item.is-start-date.is-flipped{border-top-left-radius:0;border-bottom-left-radius:0;border-top-right-radius:5px;border-bottom-right-radius:5px}.litepicker .container__days .day-item.is-end-date{color:var(--litepicker-is-end-color);background-color:var(--litepicker-is-end-color-bg);border-top-left-radius:0;border-bottom-left-radius:0;border-top-right-radius:5px;border-bottom-right-radius:5px}.litepicker .container__days .day-item.is-end-date.is-flipped{border-top-left-radius:5px;border-bottom-left-radius:5px;border-top-right-radius:0;border-bottom-right-radius:0}.litepicker .container__days .day-item.is-start-date.is-end-date{border-top-left-radius:5px;border-bottom-left-radius:5px;border-top-right-radius:5px;border-bottom-right-radius:5px}.litepicker .container__days .day-item.is-highlighted{color:var(--litepicker-highlighted-day-color);background-color:var(--litepicker-highlighted-day-color-bg)}.litepicker .container__days .week-number{display:-webkit-box;display:-ms-flexbox;display:flex;-webkit-box-align:center;-ms-flex-align:center;align-items:center;-webkit-box-pack:center;-ms-flex-pack:center;justify-content:center;color:var(--litepicker-month-week-number-color);font-size:85%}.litepicker .container__footer{text-align:right;padding:10px 5px;margin:0 5px;background-color:var(--litepicker-footer-color-bg);-webkit-box-shadow:inset 0px 3px 3px 0px var(--litepicker-footer-box-shadow-color);box-shadow:inset 0px 3px 3px 0px var(--litepicker-footer-box-shadow-color);border-bottom-left-radius:5px;border-bottom-right-radius:5px}.litepicker .container__footer .preview-date-range{margin-right:10px;font-size:90%}.litepicker .container__footer .button-cancel{background-color:var(--litepicker-button-cancel-color-bg);color:var(--litepicker-button-cancel-color);border:0;padding:3px 7px 4px;border-radius:3px}.litepicker .container__footer .button-cancel *{pointer-events:none}.litepicker .container__footer .button-apply{background-color:var(--litepicker-button-apply-color-bg);color:var(--litepicker-button-apply-color);border:0;padding:3px 7px 4px;border-radius:3px;margin-left:10px;margin-right:10px}.litepicker .container__footer .button-apply:disabled{opacity:0.7}.litepicker .container__footer .button-apply *{pointer-events:none}.litepicker .container__tooltip{position:absolute;margin-top:-4px;padding:4px 8px;border-radius:4px;background-color:var(--litepicker-tooltip-color-bg);-webkit-box-shadow:0 1px 3px rgba(0,0,0,0.25);box-shadow:0 1px 3px rgba(0,0,0,0.25);white-space:nowrap;font-size:11px;pointer-events:none;visibility:hidden}.litepicker .container__tooltip:before{position:absolute;bottom:-5px;left:calc(50% - 5px);border-top:5px solid rgba(0,0,0,0.12);border-right:5px solid transparent;border-left:5px solid transparent;content:""}.litepicker .container__tooltip:after{position:absolute;bottom:-4px;left:calc(50% - 4px);border-top:4px solid var(--litepicker-tooltip-color-bg);border-right:4px solid transparent;border-left:4px solid transparent;content:""}
+</style>
+
+<meta charset="utf-8">
+<!-- 
+	This website is powered by TYPO3 - inspiring people to share!
+	TYPO3 is a free open source Content Management Framework initially created by Kasper Skaarhoj and licensed under GNU/GPL.
+	TYPO3 is copyright 1998-2026 of Kasper Skaarhoj. Extensions are copyright of their respective owners.
+	Information and contribution at https://typo3.org/
+-->
+
+
+<link rel="shortcut icon" href="/typo3conf/ext/sfsitepackage/Resources/Public/Favicons/favicon.ico" type="image/vnd.microsoft.icon">
+<title>Spielplan  - Bayerische Staatsoper</title>
+<meta http-equiv="x-ua-compatible" content="IE=edge">
+<meta name="generator" content="TYPO3 CMS">
+<meta name="robots" content="index,follow">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta property="og:title" content="Spielplan - Bayerische Staatsoper">
+<meta property="og:site_name" content="Bayerische Staatsoper">
+<meta property="og:image" content="https://www.staatsoper.de/media/_processed_/3/2/csm_1920x1080_Original_NEU_2_c7eb7efcc0.jpg">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:title" content="Spielplan - Bayerische Staatsoper">
+<meta name="apple-mobile-web-app-capable" content="no">
+
+
+<link rel="stylesheet" type="text/css" href="/typo3conf/ext/femanager/Resources/Public/Css/Main.min.css?1774004245" media="all">
+<link rel="stylesheet" type="text/css" href="/typo3conf/ext/sfsitepackage/Resources/Public/Css/main.css?1774004424" media="all">
+
+
+
+
+
+
+<link rel="apple-touch-icon" sizes="180x180" href="/typo3conf/ext/sfsitepackage/Resources/Public/Favicons/apple-touch-icon.png">
+<link rel="icon" type="image/png" sizes="32x32" href="/typo3conf/ext/sfsitepackage/Resources/Public/Favicons/favicon-32x32.png">
+<link rel="icon" type="image/png" sizes="16x16" href="/typo3conf/ext/sfsitepackage/Resources/Public/Favicons/favicon-16x16.png">
+<link rel="icon" href="/typo3conf/ext/sfsitepackage/Resources/Public/Favicons/favicon.ico" type="image/x-icon">
+<link rel="shortcut icon" href="/typo3conf/ext/sfsitepackage/Resources/Public/Favicons/favicon.ico" type="image/x-icon">
+<link rel="manifest" href="/typo3conf/ext/sfsitepackage/Resources/Public/Favicons/manifest.json" crossorigin="use-credentials">
+<link rel="manifest" href="/site.webmanifest">
+<link rel="mask-icon" href="/typo3conf/ext/sfsitepackage/Resources/Public/Favicons/safari-pinned-tab.svg" color="#3199cc">
+<meta name="msapplication-TileColor" content="#2b5797">
+<meta name="theme-color" content="#ffffff">
+<meta name="format-detection" content="telephone=no">
+
+
+
+
+<link rel="preconnect" href="//privacy-proxy.usercentrics.eu">
+<link rel="preload" href="//privacy-proxy.usercentrics.eu/latest/uc-block.bundle.js" as="script">
+
+<script async="" src="https://www.googletagmanager.com/gtm.js?id=GTM-5DNSGGJ"></script><script id="usercentrics-cmp" src="https://app.usercentrics.eu/browser-ui/latest/loader.js" data-settings-id="SrWbMsdvoZyg5Z" async="" data-avoid-prefetch-services=""></script>
+<script type="application/javascript" src="https://privacy-proxy.usercentrics.eu/latest/uc-block.bundle.js"></script><style id="uc-block-styles">.uc-social-embedding{background:#ececec; border:1px solid #dadada; padding:6px 22px; border-radius:6px; color:#909090; margin:10px; font-weight:200; font-size:14px; cursor:pointer;}.not-existing-service{display:none;}.uc-social-embedding .description-text{margin:0; margin-bottom:12px; line-height:1.5; font-family:BlinkMacSystemFont,-apple-system,Segoe UI,Roboto,Oxygen-Sans,Ubuntu,Cantarell,Fira Sans,Droid Sans,Helvetica Neue,Helvetica,Arial,sans-serif,BlinkMacSystemFont,-apple-system,Segoe UI,Roboto,Oxygen-Sans,Ubuntu,Cantarell,Fira Sans,Droid Sans,Helvetica Neue,Helvetica,Arial,sans-serif; font-size:14px;}.consent-not-exists .description-text{display:none; color:#595959;}.consent-not-exists .not-existing-service{display:inline;}.consent-not-exists .uc-embedding-buttons{display:none;}.uc-embedding-buttons{display:-webkit-box; display:-ms-flexbox; display:flex; justify-content:center; flex-wrap:wrap;}.uc-embedding-container-rtl{direction:rtl;}.uc-embedding-container{min-height:320px; max-height:500px; max-width:100%; width:100%; height:100%; font-size:0; position:relative; overflow:hidden; background:transparent; white-space:normal;}.uc-embedding-wrapper{width:372px; max-width:calc(100% - 70px); max-height:calc(100% - 35px); background:#FFF; border-radius:8px; box-shadow:0 3px 6px rgba(0, 0, 0, 0.5); position:absolute; padding:12px 24px; top:50%; left:50%; text-align:center; font-size:14px; line-height:1.5; transform:translateX(-50%) translateY(-50%); display:-webkit-box; display:-ms-flexbox; display:flex; flex-direction:column; overflow:auto; font-family:BlinkMacSystemFont,-apple-system,Segoe UI,Roboto,Oxygen-Sans,Ubuntu,Cantarell,Fira Sans,Droid Sans,Helvetica Neue,Helvetica,Arial,sans-serif,BlinkMacSystemFont,-apple-system,Segoe UI,Roboto,Oxygen-Sans,Ubuntu,Cantarell,Fira Sans,Droid Sans,Helvetica Neue,Helvetica,Arial,sans-serif;}.uc-embedding-wrapper h3{line-height:1.33; font-size:18px; font-weight:bold; margin:12px auto; color:#303030;}.uc-embedding-more-info{cursor:pointer; border:none; box-shadow:none; font-size:14px; font-weight:bold; display:inline-block; height:40px; border-radius:4px; padding:0; background:#F5F5F5; width:174px; margin:6px 12px 6px 0;}.uc-embedding-more-info.uc-button-primary{background:#0045A5; color:#fff;}.uc-embedding-accept{cursor:pointer; border:none; box-shadow:none; font-size:14px; font-weight:bold; display:inline-block; height:40px; padding:0; border-radius:4px; background:#0045A5; color:#fff; width:174px; margin:6px 12px 6px 0;}.uc-text-embedding{font-family:BlinkMacSystemFont,-apple-system,Segoe UI,Roboto,Oxygen-Sans,Ubuntu,Cantarell,Fira Sans,Droid Sans,Helvetica Neue,Helvetica,Arial,sans-serif,BlinkMacSystemFont,-apple-system,Segoe UI,Roboto,Oxygen-Sans,Ubuntu,Cantarell,Fira Sans,Droid Sans,Helvetica Neue,Helvetica,Arial,sans-serif; font-size:14px;}.uc-text-embedding-inline-button{text-decoration:underline; cursor:pointer; display:inline-block; padding:0; margin:0; background:inherit; font-family:BlinkMacSystemFont,-apple-system,Segoe UI,Roboto,Oxygen-Sans,Ubuntu,Cantarell,Fira Sans,Droid Sans,Helvetica Neue,Helvetica,Arial,sans-serif,BlinkMacSystemFont,-apple-system,Segoe UI,Roboto,Oxygen-Sans,Ubuntu,Cantarell,Fira Sans,Droid Sans,Helvetica Neue,Helvetica,Arial,sans-serif; font-size:14px; color:#0045A5; border:0;}a.uc-embedding-powered-by{color:#333;}</style>
+
+
+
+
+    <script type="text/javascript">
+        (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+            new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+            j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+            'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+        })(window,document,'script','dataLayer','GTM-5DNSGGJ');
+    </script>
+
+<noscript><style>.preload * { visibility: initial }</style></noscript><script type="text/javascript">setTimeout(function() { var doc = document.querySelector('.preload'); if (doc) { doc.classList.remove('preload', 'no-js')}; }, 90);</script>
+<link rel="canonical" href="https://www.staatsoper.de/spielplan">
+
+<link rel="alternate" hreflang="de" href="https://www.staatsoper.de/spielplan">
+<link rel="alternate" hreflang="en" href="https://www.staatsoper.de/en/schedule">
+<link rel="alternate" hreflang="x-default" href="https://www.staatsoper.de/en/schedule">
+<script type="module" src="https://app.usercentrics.eu/browser-ui/3.96.0/index.module.js"></script><script charset="utf-8" src="/typo3conf/ext/sfsitepackage/Resources/Public/JavaScript/02_atoms-PreFilter-701e8fe030849d1cdde8.js"></script><script charset="utf-8" src="/typo3conf/ext/sfsitepackage/Resources/Public/JavaScript/03_molecules-MainNavHeader-701e8fe030849d1cdde8.js"></script><script charset="utf-8" src="/typo3conf/ext/sfsitepackage/Resources/Public/JavaScript/03_molecules-MenuButton-701e8fe030849d1cdde8.js"></script><script charset="utf-8" src="/typo3conf/ext/sfsitepackage/Resources/Public/JavaScript/02_atoms-BrandSwitchObserver-701e8fe030849d1cdde8.js"></script><script charset="utf-8" src="/typo3conf/ext/sfsitepackage/Resources/Public/JavaScript/03_molecules-BrandSwitch-701e8fe030849d1cdde8.js"></script><script charset="utf-8" src="/typo3conf/ext/sfsitepackage/Resources/Public/JavaScript/02_atoms-A11yButton-701e8fe030849d1cdde8.js"></script><script charset="utf-8" src="/typo3conf/ext/sfsitepackage/Resources/Public/JavaScript/03_molecules-ScheduleButton-701e8fe030849d1cdde8.js"></script><script charset="utf-8" src="/typo3conf/ext/sfsitepackage/Resources/Public/JavaScript/03_molecules-PageHeaderAction-701e8fe030849d1cdde8.js"></script><script charset="utf-8" src="/typo3conf/ext/sfsitepackage/Resources/Public/JavaScript/03_molecules-MainNav-701e8fe030849d1cdde8.js"></script><script charset="utf-8" src="/typo3conf/ext/sfsitepackage/Resources/Public/JavaScript/03_molecules-ScheduleSearch-701e8fe030849d1cdde8.js"></script><script charset="utf-8" src="/typo3conf/ext/sfsitepackage/Resources/Public/JavaScript/03_molecules-FilterContent-701e8fe030849d1cdde8.js"></script><script charset="utf-8" src="/typo3conf/ext/sfsitepackage/Resources/Public/JavaScript/03_molecules-SeasonFilter-701e8fe030849d1cdde8.js"></script><script charset="utf-8" src="/typo3conf/ext/sfsitepackage/Resources/Public/JavaScript/vendors~00_utilities-plugins-LitePickerEvents~00_utilities-plugins-LitePickerStartMonth~02_atoms-Get~43a11c0b-701e8fe030849d1cdde8.js"></script><script charset="utf-8" src="/typo3conf/ext/sfsitepackage/Resources/Public/JavaScript/03_molecules-Calendar-701e8fe030849d1cdde8.js"></script><script charset="utf-8" src="/typo3conf/ext/sfsitepackage/Resources/Public/JavaScript/03_molecules-ActivityNavigation-701e8fe030849d1cdde8.js"></script><script charset="utf-8" src="/typo3conf/ext/sfsitepackage/Resources/Public/JavaScript/02_atoms-CalendarReset-701e8fe030849d1cdde8.js"></script><script charset="utf-8" src="/typo3conf/ext/sfsitepackage/Resources/Public/JavaScript/03_molecules-ScheduleMonthFilter-701e8fe030849d1cdde8.js"></script><script charset="utf-8" src="/typo3conf/ext/sfsitepackage/Resources/Public/JavaScript/03_molecules-FilterLightbox-701e8fe030849d1cdde8.js"></script><script charset="utf-8" src="/typo3conf/ext/sfsitepackage/Resources/Public/JavaScript/03_molecules-ScheduleFilter-701e8fe030849d1cdde8.js"></script><script charset="utf-8" src="/typo3conf/ext/sfsitepackage/Resources/Public/JavaScript/02_atoms-ScheduleFilterInfo-701e8fe030849d1cdde8.js"></script><script charset="utf-8" src="/typo3conf/ext/sfsitepackage/Resources/Public/JavaScript/02_atoms-ScheduleFilterClose-701e8fe030849d1cdde8.js"></script><script charset="utf-8" src="/typo3conf/ext/sfsitepackage/Resources/Public/JavaScript/02_atoms-ScheduleFilterReset-701e8fe030849d1cdde8.js"></script></head>
+<body class="schedule-nav-persistent"><div><svg xmlns="http://www.w3.org/2000/svg" style="position:absolute; width: 0; height: 0"><symbol viewBox="0 0 11.214 12.816" id="icon-account"><path fill="currentColor" d="M8.01 3.2a2.4 2.4 0 1 0-2.4 2.4 2.4 2.4 0 0 0 2.4-2.4zm-5.61 0a3.2 3.2 0 1 1 3.2 3.2 3.2 3.2 0 0 1-3.2-3.2zm-1.316 8.815h9.046l-1.109-3.6H2.193zM1.6 7.61h8.01l1.357 4.406.245.8H0l.245-.8z"></path></symbol><symbol viewBox="0 0 496 502" id="icon-anniversary-logo-plain"><g fill-rule="nonzero"><path d="M229.38 12.154c-3.6 5.5-4.3 13.1-1.5 18.5 2.3 4.4 5.8 7.9 12 11.9 2.3 1.5 4.2 2.9 4.2 3 0 .1-1.8 1.5-3.9 2.9-11.1 7.7-14 22.1-6.1 30.9 3.5 4 4.5 3.2 2.4-1.9-2-4.7-1.5-15.4.9-20 .9-1.7 3.8-5.2 6.4-7.9l4.8-4.7-2.5-1.7c-5.5-3.6-9.1-7.5-11.6-12.7-2.3-4.6-2.6-6.3-2.2-12.1.3-3.8.8-7.6 1.3-8.6 1.4-3.3-1.5-1.7-4.2 2.4zM290.68 16.554c-8.3 8.2-6.5 21.8 4.3 31.9l3.1 2.9-5.7 2.3c-9.8 4-14.3 10-14.3 19 0 4.9 1.8 12.4 3 12.4.4 0 .9-3.5 1.2-7.9.7-11.9 5.7-18.9 16.6-23.3l3.3-1.3-2.6-3.5c-8.6-11.4-10.3-21.4-5.2-30.4 3.2-5.7 3.1-5.6 1.2-5.6-.8 0-3 1.6-4.9 3.5zM248.08 22.554c0 5 3.5 10.9 8.4 14.2 5.2 3.4 16.8 7.5 18 6.3.5-.5.5-3.4.2-6.4-1.1-8.7-7.3-14.5-17.1-16.1-2.2-.3-5.2-.9-6.7-1.1-2.6-.5-2.8-.4-2.8 3.1zM167.98 24.754c-1.7 4.3-1.4 11.4.5 15.1 2.3 4.4 8.4 8.6 16.3 11.3l6.5 2.1-2.5 2.7c-7.1 7.6-9 18.6-4.4 26.3 2.4 4.1 7.5 8.8 9.6 8.8.5 0-.7-3.2-2.7-7.1-5.7-11-5-19.4 2.4-29.6 1.6-2.2 1.5-2.3-3.9-4.7-10.9-4.8-17.8-13.8-18.1-23.6-.1-4.7-2.1-5.4-3.7-1.3zM190.28 26.754c-2 .4-2.3.9-1.7 3.1 1.7 7.4 10.4 12.8 22 13.7 8.8.8 10.3-.1 8.5-4.7-3.8-9.3-9.3-12.9-19.7-12.7-3.7.1-7.9.4-9.1.6zM307.08 33.154c0 6.2 2.2 11.1 7.2 16.1 3.5 3.5 10.5 7.8 12.7 7.8 1.7 0 3.3-7.9 2.6-12.2-1.2-7.2-12.8-16.8-20.2-16.8-2.1 0-2.3.5-2.3 5.1zM349.48 35.954c-6.8 3.9-8.8 8.1-8.2 16.6.4 4 1.6 8.4 3.5 12.3l2.9 6.1-5.7 1c-7.2 1.2-13.1 4.2-15.8 8-2.8 3.9-4.6 11.9-3.6 16.7.8 4.3.7 4.4 4.1-5.1 1-2.8 3.7-7 6.2-9.7 4.3-4.6 5.4-5.2 17.1-8.4.8-.3 1-1.1.6-2.2-1.9-4.6-3.5-12.2-3.5-17 0-6.5 1.7-10.8 6.4-15.9 3.1-3.5 3.7-5.3 1.7-5.3-.3 0-2.9 1.3-5.7 2.9zM141.08 46.554c-1.9.7-4.8 1.8-6.3 2.4l-2.8 1.1 1.8 3.1c4.2 7.3 12.7 9.9 24.3 7.5 4.1-.9 7.8-2 8.2-2.4 1.3-1.3-5.2-9.4-9.2-11.4-4.1-2.1-11-2.2-16-.3zM112.78 49.754c-1.5 1.5-.7 11.8 1.2 14.9 2.8 4.6 11.5 8.6 20.1 9.2 7.7.5 7.9.8 5.4 6.8-1.1 2.7-1.5 6-1.2 10.9.3 6 .8 7.8 3.1 10.9 2.8 3.6 11.9 9.1 13.1 7.9.3-.3-1.2-2.1-3.3-4-8.1-6.8-11.4-19.8-7.6-29 .8-1.9 1.5-3.9 1.5-4.3 0-.4-2.3-1.1-5.2-1.4-10.5-1.4-18.5-6.4-22.3-13.9-1.4-2.8-2.5-5.9-2.5-6.9 0-1.8-1.1-2.4-2.3-1.1zM213.68 50.454c-7.6 2.8-12.6 10.8-12.6 20.3 0 3 .3 3.3 3 3.3 4.6 0 10.7-3.5 14-8.2 2.9-4 6.9-14.3 5.9-15.3-1.4-1.3-6.8-1.3-10.3-.1zM259.58 50.554c-5.9 3.2-8.6 6.8-10 13.4-.9 4 .3 5.1 5.9 5.1 7.8 0 15.3-5.5 20-14.8 1-1.9 1.5-3.7 1.1-4-.3-.4-3.6-.8-7.3-1-4.8-.2-7.6.2-9.7 1.3zM361.98 54.254c-2 4.6-1.6 11.5.9 17 2.3 5.2 10.8 14.2 12.4 13.2 1.9-1.2 4.8-8.9 4.8-13 0-5.7-3.7-12.2-9.6-16.6-2.7-2.1-5.4-3.8-6-3.8-.6 0-1.8 1.5-2.5 3.2zM307.58 61.754c-6 3.1-11.3 9.8-10.1 12.8.7 1.9 8.2 3.8 12 3.1 1.7-.3 4.9-1.5 7.1-2.7 4.1-2.1 11.5-8.7 11.5-10.1 0-.4-1.8-1.7-4-2.8-4.7-2.4-12.3-2.6-16.5-.3zM166.78 64.454c-5 1.8-7.6 4.2-9.8 9.1-1.8 4-2.4 11-1.3 15.2 1.4 5.1 10.4.8 14.1-6.7 1.3-2.7 2.5-7.5 2.9-11.8.8-8.1.7-8.1-5.9-5.8zM399.18 70.454c-1.9.7-4.9 2.9-6.5 5-2.9 3.6-3.1 4.3-3.1 12.4 0 4.8.3 10.1.7 11.9l.7 3.2-6.7-.6c-15-1.2-21.5 3.9-24.7 19.4-.9 4.5 1.1 4.3 3-.4 4.3-10.3 12.5-15.6 24.2-15.6h7.1l-.5-7.3c-.8-10.3.9-15.7 6.8-21.6 2.6-2.6 5.9-5 7.3-5.4 1.4-.3 2.3-1 2-1.5-.7-1.3-6.2-1-10.3.5zM97.58 78.254c-3.9 1.4-13.5 7.7-13.5 8.9 0 .5 1.9 2.1 4.2 3.6 3.4 2.3 5.2 2.8 10.2 2.8 6-.1 14-2.9 19.1-6.8 2-1.5 2-1.5 0-3.8-4.5-5-13.3-7.1-20-4.7zM354.58 84.054c-4.8.8-9.2 3-12.3 6.3l-2.3 2.4 3.1 2.6c6.7 5.7 16.2 5.7 25.7.1 4.8-2.8 4.9-3.1 2.5-6-3.4-4.2-10.1-6.4-16.7-5.4zM408.48 91.654c-5.3 6.9-3.8 20.4 3 28.9l2.4 3 2.7-2.5c3.3-2.9 6.4-9.4 6.5-13.1 0-4.4-3-11.5-6.6-15.8-2-2.2-3.9-4.1-4.4-4.1-.5 0-2.1 1.6-3.6 3.6zM122.48 90.954c-9.2 5.6-11.9 18.4-5.8 27.6 2.1 3.2 2.6 3.1 6.7-.5 3.7-3.2 5.7-8.8 5.7-16 0-4.5-1.9-13-2.9-13-.3 0-2 .9-3.7 1.9zM65.08 93.354c0 5.6 3.9 11.9 9 14.5 4 2.1 5.5 2.3 13.5 1.9 5-.3 9.9-.8 10.9-1.3 1.3-.5 1.7-.4 1.3.3-1.5 2.3-1.8 8.7-.7 13.6 2.2 10.5 9.6 17.1 18.3 16.5l4.2-.3-5.7-3.2c-9.4-5.4-13.8-12.9-13.8-23.8v-6.6l-4.7.8c-6.5 1-12 .6-17-1.2-4.3-1.6-10.5-7.6-12.5-12.1-1.6-3.4-2.8-3-2.8.9zM202.08 110.154c-7.1.9-18.4 4.3-27.2 8.2l-5.5 2.5 9.7 58.3c5.4 32.1 15.3 90.7 21.9 130.2 6.7 39.5 12.1 72 12.1 72.2 0 .2-2.4.5-5.2.7l-5.3.3-.3 8.7-.3 8.8h69.1v-7.9c0-8.6-.6-9.7-5.7-10.3l-3.3-.3 9.9-16c74.2-120.7 86.9-142 92.1-154.2 11.1-26.4 6.2-33.2-17.5-24.7-23 8.3-26.2 9.3-31.2 10-7.9 1-11.9-.2-17.1-4.9-6-5.6-18.5-22.4-26.3-35.6-8.3-13.9-12.9-20.3-20.3-27.9-14.3-14.7-30.4-20.6-49.6-18.1zm15.4 36.8c.3.4 4.9 26.2 10.2 57.2 5.2 31 11.3 66.5 13.4 78.9 2.1 12.4 6.2 36.3 9 53.2l5.2 30.7-4.6 7.6c-2.6 4.1-5.2 7.5-5.7 7.5-1.1 0-1.2-.4-4.8-22-1.7-9.6-4.6-26.7-6.5-38-19.9-115.3-29.6-172.7-29.6-174.2s.9-1.8 6.4-1.8c3.6 0 6.7.4 7 .9zm-19 2.8c.3 1 1.6 8.5 3 16.8 7.4 43.9 35.5 209.5 36.2 212.7l.6 2.8h-12.8l-19.4-113.8c-10.6-62.5-19.5-114.3-19.8-115-.2-.7 1.4-2 3.9-3.2 5.5-2.4 7.6-2.5 8.3-.3zm34.6 3.4c3.4 2.3 6.4 4.7 6.6 5.3.2.6 7.1 40.9 15.4 89.6 8.2 48.7 15.2 89.4 15.5 90.6.3 1.2-1.5 5.3-4.7 10.9-4.3 7.3-5.3 8.5-5.9 6.9-.5-1-8.1-44.9-16.9-97.4-8.9-52.5-16.7-98.8-17.4-102.8-1.6-8.7-1.3-8.9 7.4-3.1zm22.5 21.6c4.4 5.1 7.9 10.3 8.5 12.3 1.1 4.4 22 126.5 22 128.8 0 2.1-10.2 18.1-10.6 16.7-.2-.6-3.7-21-7.9-45.5-4.1-24.5-10.4-61.6-14-82.5-3.6-20.9-6.5-38.1-6.5-38.3 0-1 1.9.9 8.5 8.5zm27.8 29.2c2.6 1.7 4.7 3.5 4.7 3.9 0 .4 3.2 19.2 7 41.8l7 41.2-5.2 8.8c-5.1 8.6-5.3 8.7-6.1 5.8-.4-1.6-4.8-26.3-9.7-54.9-5-28.6-9.3-53.1-9.6-54.4-.5-2.3-.3-2.2 3.3 1 2.1 1.9 6 5 8.6 6.8zm65.6.6c1.2 1.2 1.2 2.1.2 5.7-1.4 4.5-5.4 12.7-9.4 19.2l-2.4 3.8-2.2-13.7c-1.2-7.6-1.8-14.2-1.4-14.6 1.3-1.3 8.6-2.8 11.3-2.3 1.4.3 3.1 1.2 3.9 1.9zm-21.4 5.7c.3 1.8 1.6 9.4 2.8 16.8l2.3 13.5-4.9 8.3c-2.7 4.6-5.1 8.1-5.3 7.9-.3-.3-2.1-9.9-4-21.3-1.9-11.5-3.7-21.6-3.9-22.4-.4-1.1 1.1-2.1 5.3-3.6 3.1-1.2 6-2.2 6.4-2.3.4 0 1 1.4 1.3 3.1zm-23.5 1.3l4.5.7 9 53.8-5 8c-2.7 4.4-5.2 8-5.5 8-.5 0-13.1-69.1-13-71.3 0-.5 1.2-.6 2.8-.3 1.5.3 4.7.8 7.2 1.1zM436.08 117.154c-6.5 2.6-10 9.2-10.7 20.1-.3 4.3-.7 7.8-.9 7.8-.2 0-2.6-.9-5.4-2-6.9-2.7-15.4-2.7-20 .1-4 2.5-5.3 3.9-8 9.1-3.2 6-2.3 6.5 2.8 1.6 2.6-2.5 6.3-5.4 8.2-6.4 4.7-2.4 15.3-2.4 19.8 0 1.8.9 3.6 1.5 4.1 1.2.4-.3 1.1-2.8 1.4-5.5 1.4-11.9 8.3-20.8 18.4-23.7 2.9-.9 5.1-2 4.8-2.5-.8-1.2-11.3-1.1-14.5.2zM385.48 118.354c-1.7.6-4.1 1.9-5.2 2.7l-2.2 1.5 2.1 3.3c3 4.6 8.6 7.2 15.4 7.2 6.9 0 14.5-1.8 14.5-3.5 0-1.9-4.2-7.6-7.2-9.8-3.3-2.5-12.8-3.2-17.4-1.4zM62.78 120.054c-4.2 1.3-9.2 5.5-12.8 10.7-3.1 4.4-3.1 4.7-1.4 6 3.3 2.3 14.3 1.7 20.2-1.3 4.8-2.4 12.3-9.3 12.3-11.3 0-1.2-10.4-5.1-13.3-5-1.2 0-3.5.5-5 .9zM84.28 129.854c-4.3 4.3-5.8 9.1-4.6 14.5 1.4 6.6 6.3 13.7 9.4 13.7 3 0 6-7.1 6-14.1 0-6.3-3.2-15.7-5.9-17.3-.5-.4-2.8 1.1-4.9 3.2zM444.58 138.254c-1.5 1.2-3.6 4-4.6 6.2-3.1 6.9-2.2 21.3 1.5 25.4 1 1 2 .7 5.3-1.7 5.3-3.9 7.8-10 7-17.5-.6-5.7-3.9-14.6-5.5-14.6-.5 0-2.2 1-3.7 2.2zM30.08 143.754c0 1 1 3.6 2.3 5.8 4.9 8.8 17.2 10.9 28.7 4.9 3-1.6 5.8-3 6.1-3.2.3-.1.9 2.1 1.2 5 .4 2.8 1.8 7.5 3.2 10.4 3.5 7.2 7.6 9.6 17.1 10.2 4.1.2 7.4.1 7.4-.4s-2.7-1.7-5.9-2.6c-11-3.3-18.4-11.1-19.7-21.1-.4-2.6-1.1-4.7-1.6-4.7s-2.6.9-4.7 1.9c-9.5 4.9-21.2 3.3-29.4-4-3.7-3.2-4.7-3.7-4.7-2.2zM408.58 160.454c-1.7 1.3-1.7 1.5.6 5.6 3.3 6 9.8 9.2 19.8 9.8l7.4.5-.6-3.8c-.8-4.8-5-10.3-9.3-12.1-4.3-1.8-15.4-1.8-17.9 0zM37.58 171.854c-6.2 2.9-11 9.3-13 17.5-.7 2.7-.6 2.7 4.1 2.7 6.1 0 12-2.7 16.6-7.4 3.9-4 8.6-12.1 7.6-13.1-.3-.3-3-.8-5.9-1.1-4-.4-6.5 0-9.4 1.4zM60.28 172.354c-1.9 2.3-4.2 8.5-4.2 11.4 0 4.9 4.5 12.9 9.1 16.2 2.3 1.7 4.6 3.1 5.1 3.1 1.5 0 3.8-6.6 3.8-10.8 0-4.9-3.9-12.7-8.8-17.5-3.2-3.1-4.1-3.5-5-2.4zM460.48 172.054c-4.7 1.9-11.1 11.6-12.9 19.8l-.7 3.2-3.8-3c-5.4-4.3-10.1-6-16.2-6-6.8.1-12.8 2.8-16.3 7.4-3.5 4.7-2.7 5.5 2.2 2.2 5.4-3.8 13.4-5.9 18.6-5.1 4.8.8 10.7 3.6 12.6 5.9 2.2 2.6 3.5 1.8 5.3-3.2 3.7-10.2 12.6-16.9 24.2-18.2l6.1-.7-3.7-1.6c-3.9-1.8-11.9-2.2-15.4-.7zM467.48 192.954c-7.9 3.6-12.4 12.4-12.4 24.4v6l4-.6c9.2-1.2 14.3-9 14.2-21.4-.1-9.9-.6-10.7-5.8-8.4zM42.28 201.654c-10.6 7.1-17.7 8-26.6 3.5-3.1-1.5-5.9-2.5-6.1-2-.8 1.3 5.2 7.5 8.9 9.3 6.8 3.2 14.6 1.2 23.8-5.9l5.6-4.5 2.5 5.2c2.8 6.1 6.8 10.5 11.4 12.4 4.4 1.9 12.6 1.7 17.1-.3l3.7-1.7-7.5-.6c-4.7-.4-9.2-1.4-12.2-2.9-5.5-2.6-11.4-9-12.3-13.2-.4-1.6-1.2-2.9-1.8-2.9-.7 0-3.6 1.6-6.5 3.6zM425.48 209.254c.4 2.4 1.5 5.6 2.4 7.3 1.9 3.2 9.8 8 16.8 10.1l4.4 1.3v-5.2c0-10.6-7.5-17.4-19.4-17.6l-4.9-.1.7 4.2zM45.98 225.154c-1.7 3.3-.6 12.1 2 15.7 3.6 5.1 8.7 8.5 12.9 8.6l3.7.1.3-5.5c.2-4.7-.2-6.2-2.7-10.3-2.9-4.4-10.9-10.7-13.8-10.7-.7 0-1.7 1-2.4 2.1zM27.58 226.054c-6.4 3.2-11.5 13-11.5 22.2 0 3.7.1 3.7 3.3 3.1 5.2-.9 9.4-3.3 12-6.6 3.8-5.1 6.7-11.3 7.4-16.2l.6-4.5h-3.9c-2.2 0-5.7.9-7.9 2zM468.58 231.754c-4.3 2.2-9.3 7.2-12.2 12l-2.5 4.3-3.8-4.9c-8.6-10.9-18.7-12.8-29.7-5.7-5.1 3.3-4.1 4.6 2 2.5 6.4-2.3 8.9-2.3 15.4-.4 3.5 1 6.8 3.1 10.4 6.5 2.9 2.8 5.6 5 5.9 5 .3 0 2.4-2.2 4.7-4.9 7.3-8.4 17.3-12 27.7-9.8 4.7 1 4.6-.7-.4-4.1-4-2.7-12.9-3-17.5-.5zM36.68 256.654c-4.8 5.5-11.3 9.6-17.3 10.8-2.9.7-6.9 0-11.5-1.9-1.3-.5-1.8-.2-1.8.9 0 2.7 8.8 7.6 13.6 7.6 5.8 0 12.7-4.8 18.1-12.8l4.2-6.2 2.7 3.9c7.1 10.8 22.1 13.5 31.9 5.7 4-3.2 2.9-4-2.9-2s-15.6 1.5-20.6-1.1c-1.9-1-5.3-3.7-7.5-6l-4.1-4.3-4.8 5.4zM472.38 252.154c-6.8 2-14.8 13.4-16.1 23.1l-.5 4.1 5.3-.6c10.4-1.2 17.1-9.2 18.6-22 .7-5.5.6-5.7-1.7-5.6-1.3 0-3.9.5-5.6 1zM430.58 256.354c-1.2 7.8 4.9 17.4 14.2 22.4 4.3 2.3 5.3 1.1 5.3-6.5 0-7.8-3.9-13.7-11.5-17.5-6.8-3.3-7.3-3.2-8 1.6zM46.58 278.354c-.4 1.9-.2 5.2.4 7.3 2 7.3 7.7 11.3 17.3 12.1l5.8.6v-3.7c0-7-4-11.9-13-15.9-9.4-4.3-9.8-4.3-10.5-.4zM32.38 281.554c-5.8 2.9-7.7 5.4-9.4 11.9-1.6 6.4-.4 17.6 1.9 17.6 5.6 0 13.2-9.3 15.2-18.3 1.2-5.7.4-13.7-1.4-13.7-.7 0-3.5 1.1-6.3 2.5zM416.38 283.054c-3.7 1.5-2.6 2.5 3 2.7 2.8.1 7.1.8 9.5 1.4 5.5 1.5 13.5 8.6 15.6 13.9 1.8 4.6 2.5 4.8 5.2 1.9 3.3-3.7 11.5-7.1 18.1-7.7 5.4-.4 7-.1 11.8 2.3 3.1 1.5 5.9 2.5 6.2 2.2 1-1-3.6-6.5-7.4-8.8-7.3-4.5-16.6-2.2-25.9 6.3-2.5 2.3-4.6 3.9-4.7 3.7-.2-.2-1.2-2.4-2.3-4.9-2.3-5.4-6.6-10.6-10.5-12.6-3.1-1.6-15-1.8-18.6-.4zM423.58 302.954c-3.5 6.9-1.2 16.2 6.5 25.1l3.8 4.4 2.1-3.4c4.8-8 4-15.1-2.7-22.2-6.5-7-7.8-7.5-9.7-3.9zM46.28 308.754c-1.7 5.8-6.6 12.7-10.5 15.2-1.9 1.2-6.9 2.7-11.1 3.3-4.2.7-7.6 1.6-7.6 1.9 0 1.3 6.3 2.9 11.5 2.9 7.3 0 12.3-3.8 16.4-12.2 1.6-3.5 3.2-7.5 3.6-8.9l.7-2.7 5.9 4.1c5.1 3.5 6.8 4.2 12.4 4.5 5.6.4 7 .1 10.9-2.2 4.1-2.4 9.4-8.1 8.4-9.2-.3-.2-3 1-6.1 2.7-9.7 5.2-19.2 5-27.7-.7-4.7-3.2-5.5-3-6.8 1.3zM459.98 311.354c-2 .8-5.1 2.4-6.9 3.7-3.3 2.3-11 13.2-11 15.5 0 1.8 2.4 2.5 8.4 2.5 9.1 0 16.2-6 20.1-17 .8-2.4 1.4-4.4 1.2-4.6-1.1-1.1-8.8-1.2-11.8-.1zM60.08 328.654c.1 4.6 3.6 11.2 7.2 13.4 2.8 1.8 4.6 2.1 11.5 1.8 4.5-.2 8.5-.6 8.8-1 1.4-1.4-.7-6.2-4.3-9.9-4-3.9-8.3-5.6-17.4-6.6l-5.8-.6v2.9zM399.58 327.054c.3.5 1.6 1 2.8 1 3.6.1 10.9 3.9 15 7.8 4.6 4.4 7.2 9.2 8.2 14.9.4 2.4.8 4.3 1 4.3.1 0 2.2-.9 4.6-1.9 10.6-4.7 23-3.2 29.7 3.5 1.9 1.9 3.7 3.3 3.9 3 1.2-1.2-1.2-7-4.1-10-5.9-6.3-15.5-6.7-26.5-1.1-2.8 1.4-5.2 2.5-5.5 2.5-.3 0-1-2.6-1.6-5.8-2.1-10.1-5.4-14.8-12.3-17.7-4.1-1.7-16.2-2.1-15.2-.5zM50.48 333.954c-6.5 4-10.1 11.3-9 18.8.7 5.5 4.5 14.3 6 14.3 2.2 0 7.5-6.4 9.1-10.9 2.5-7.1 1.6-17.8-1.7-22.4-1.2-1.6-1.5-1.6-4.4.2zM102.58 348.154c-7.8 8.1-19 10.9-28.9 7.4-2.2-.8-4.3-1.2-4.6-1-.4.3-1 2.7-1.3 5.4-1.4 11.8-8.2 20.8-17.6 23.2-2.8.7-5.1 1.6-5.1 2 0 1 3.9 1.9 8.5 1.9 9.5 0 14.9-6.5 16.8-20.5.7-5.1 1.6-8.3 2.2-8.1 14.4 6.3 26.5 3.5 32-7.5 1.5-2.8 2.5-5.5 2.3-6-.2-.5-2.1.9-4.3 3.2zM403.68 347.054c-4.7 5.7-4.4 17.8.8 26.4l2.3 3.8 3.6-3.2c6.2-5.4 7.2-14.8 2.5-23.2-1.2-2.1-3.2-4.5-4.4-5.3-2.1-1.4-2.4-1.2-4.8 1.5zM374.58 363.954c-.3.5 1.1 1.5 3.2 2.2 2 .6 5.8 3.3 8.4 5.9 5.5 5.5 8.1 12.5 7.7 20.5-.2 4 0 4.9 1.2 4.6.8-.2 4.7-.4 8.5-.4 11.2 0 19.4 4.3 23 12.4 2.5 5.4 3.9 4.9 3.3-1.2-.5-5.3-2.6-8.9-7.2-12.3-2.2-1.7-4.2-2.1-10.9-2.1-4.5 0-9.8.3-11.8.8l-3.5.7v-8.2c0-9.4-2-14.6-7.4-19.1-4.3-3.7-13.1-6-14.5-3.8zM427.48 367.554c-5.9 2.9-13 9.8-11.9 11.5 1 1.6 8.4 5 11 5 6.7 0 16.6-6.4 20.1-13.1 1.3-2.6 1.2-2.9-.8-4.3-3.5-2.5-12.5-2.1-18.4.9zM89.38 371.354c-2.4.5-4.3 1.3-4.3 1.6 0 .4 1.3 2.7 2.9 5.2 5 8 13.9 10.1 23.9 5.4 2.8-1.3 5.2-2.8 5.2-3.3 0-2-4.6-6.6-8.4-8.3-4.5-2-12.4-2.3-19.3-.6zM132.78 381.554c-2.5 5.3-8.8 11.6-13.7 13.8-3 1.3-6.5 2-11 1.9h-6.5l.4 8c.5 12.2-3.9 21.2-12.8 25.8l-3.6 1.8 2.6.7c4 1 10.4-1.2 13.2-4.5 3.9-4.6 5-9.2 4.5-19.6l-.4-9.4h7.8c9.5 0 14.6-2.2 18.2-7.8 2.1-3 4.5-10.2 4.6-13.5 0-1.9-1.8-.4-3.3 2.8zM77.68 383.354c-5.3 7-6 13.8-2 21.3 2.6 4.9 7.1 10.4 8.6 10.4.4 0 1.9-2.2 3.3-5 4.2-8.4 3-17.9-3.6-27.1-1.1-1.6-2.4-2.9-2.9-2.9s-2 1.5-3.4 3.3zM371.78 385.454c-5.1 5-6.9 14.5-4.8 23.9.5 2.1 1.2 4.1 1.4 4.4 1.2 1.1 8.9-4.3 11-7.7 3-4.8 3-13.9-.1-19.8-1.2-2.3-2.7-4.2-3.2-4.2s-2.5 1.5-4.3 3.4zM341.08 392.754c0 .4 1.5 2 3.4 3.5 5.3 4.2 8.6 11.9 8.6 19.8 0 3.7-.5 8.2-1.1 10-1.4 3.9-.7 4.5 6 5.4 5.8.8 14.2 5.5 17.6 10.1 1.5 1.9 3.3 5.4 4 7.7.7 2.4 1.6 4.2 2.1 4 .5-.1.9-3.4.9-7.3 0-6.8-.1-7.2-3.7-10.4-4.2-3.9-8.7-5.4-18.1-6.2-7.5-.6-7.2-.1-4.3-7.8 3.7-9.6.7-20.5-6.9-25.7-4.3-2.9-8.5-4.4-8.5-3.1zM135.78 404.154c-2 .5-6 2-8.8 3.4-4.8 2.5-5 2.7-3.6 4.8 5.8 8.9 21.4 9.1 29.5.4l2.3-2.5-2.8-2.6c-2.7-2.5-8.1-4.7-11.3-4.5-.8.1-3.2.5-5.3 1zM171.88 404.054c-.4.8-1.4 3.9-2.4 6.9-2.8 9.1-11 16.3-20 17.8-2 .3-3.8 1.2-4.1 1.8-.2.7.5 4.3 1.6 8 1.2 3.7 2.1 8.6 2.1 10.9 0 5.1-4.2 14-7.6 16.3-2.9 1.9-3.1 3.3-.4 3.3 2.9 0 7-2.3 10-5.5 2.1-2.2 2.5-3.8 2.8-10 .4-6.7.1-8.1-2.7-14.1-3.4-7.2-3.1-8.4 1.8-8.4 7.7 0 17.3-6.4 19.1-12.8 1.2-3.8 1-16.8-.2-14.2zM389.58 410.454c-2.2.7-6.4 2.5-9.4 4l-5.3 2.7 2.3 2.6c5.6 6 15 7.8 22.8 4.3 5.6-2.6 12.3-7.9 11.5-9.2-1.2-1.9-10.9-5.8-14.4-5.7-1.9 0-5.3.6-7.5 1.3zM300.78 411.654c-.3.4.5 2.1 1.8 3.8 4.2 5.6 5.8 11 5.3 18.6-.3 5.8-.9 7.6-3.6 11.5-1.8 2.5-3.2 4.9-3.2 5.3 0 .4 2.2 1.5 4.9 2.5 10.7 3.8 18.1 13.8 18.1 24.4 0 4.8 1.1 5.5 2.8 1.9 5.4-11.8-.8-22.8-15.4-27.6-6.4-2.1-6.5-2.3-5-4.4 5.7-7.8 7-11 7-17 0-3.6-.7-7.3-1.6-9.1-2.3-4.2-9.9-11-11.1-9.9zM334.48 412.154c-6.8 1.9-11.6 10.8-11.8 21.9l-.1 5.5 3.4-.3c8.5-.7 14.5-8.5 14.6-18.9 0-7.5-1.4-9.5-6.1-8.2zM213.88 421.454c.7 5.7-1.7 14.3-5.2 18.9-1.7 2.3-5.5 5.5-8.4 7-2.9 1.6-5.2 3.3-5.2 3.8 0 .6 1.3 2.9 2.9 5.3 6.6 9.6 7.6 19.5 2.7 28.3-2.8 5-1.5 5.8 3.5 2.2 8.6-6.1 7.8-19.3-2.1-31l-3.8-4.6 5.7-2.6c6.6-3 10.8-6.8 12.7-11.4 1.7-4 1.7-7.4.1-13.7-1.5-5.8-3.5-7.3-2.9-2.2zM118.08 422.254c-2.6 4.3-2.7 12.6-.1 17.6 2.5 4.7 10.6 12.2 13.4 12.2.4 0 1.5-1.7 2.4-3.7 1.9-4.6 1.2-11.5-1.6-17-2.6-5-8.9-12.3-10.7-12.3-.8 0-2.3 1.5-3.4 3.2zM258.78 424.754c3.7 9.1.4 22.5-7.2 29.2-3.3 2.9-4.5 5.1-2.7 5.1 1.5 0 10.5 9.6 12.4 13.3 2.5 4.9 3.3 12.2 1.9 17.2-.6 2.1-.8 4.1-.6 4.3.9.9 3.4-2 5.6-6.4 4.2-8.7-.1-18.8-11-25.8l-5.9-3.9 5.5-5.1c6-5.4 9.2-11.1 9.3-16.2 0-3.8-5.6-15.4-7.5-15.4-1.2 0-1.1.7.2 3.7zM181.38 426.954c-4 1.9-13.3 9.6-13.3 11.1 0 1.6 8.7 4.5 13.1 4.4 5.2-.2 8.1-1.4 12.2-5.3 2.5-2.2 5.7-7 5.7-8.4 0-.9-8.1-3.7-10.8-3.7-1.5 0-4.6.9-6.9 1.9zM285.58 430.254c-6.5 3.5-13.5 13.9-13.5 20 0 2.7.2 2.8 4.8 2.8 8.5 0 15.4-6.4 17.2-16 .5-2.9 1-5.9 1-6.6 0-1.7-6.6-1.9-9.5-.2zM232.58 435.754c-4.3 2.2-7.3 5.1-11.1 10.8l-3.4 5 2.7 1.2c6.1 2.7 15.6.9 19.8-3.7.9-1 2.7-4.5 4-7.7 2.2-5.3 2.3-5.9.7-6.5-3-1.2-9.6-.8-12.7.9zM336.58 442.754c-3.5.7-7.5 2.5-7.5 3.3 0 1.5 4.6 7.4 7.3 9.4 4.3 3.2 15.4 3 22.7-.5l5.5-2.6-4-4c-2.4-2.4-5.7-4.5-8-5.2-3.9-1.1-12.1-1.3-16-.4zM166.68 447.654c-2 5.3.3 15.5 4.7 20.3 2.6 2.8 11.3 7.1 14.5 7.1 2 0 2.2-.4 2.2-5.8 0-8.8-5.4-16.3-15.7-21.6-4-2-4.9-2-5.7 0zM221.08 464.354c0 9 6.3 15.8 16.8 18.3 8.8 2.1 10.2 1.9 10.2-1.4-.1-8.9-9.4-17.9-21.7-20.8l-5.3-1.2v5.1zM276.08 460.954c0 6.1 5.6 12.8 12.6 15.1 3.6 1.2 17.8 1 19.1-.3.3-.4-.5-2.8-1.9-5.4-3.5-6.8-11.1-10.7-22-11.2-7.4-.3-7.8-.2-7.8 1.8z"></path></g></symbol><symbol viewBox="0 0 3997.000000 634.000000" id="icon-anniversary-logo"><path d="M223.3 32.1c-3.6 5.5-4.3 13.1-1.5 18.5 2.3 4.4 5.8 7.9 12 11.9 2.3 1.5 4.2 2.9 4.2 3 0 .1-1.8 1.5-3.9 2.9-11.1 7.7-14 22.1-6.1 30.9 3.5 4 4.5 3.2 2.4-1.9-2-4.7-1.5-15.4.9-20 .9-1.7 3.8-5.2 6.4-7.9l4.8-4.7-2.5-1.7c-5.5-3.6-9.1-7.5-11.6-12.7-2.3-4.6-2.6-6.3-2.2-12.1.3-3.8.8-7.6 1.3-8.6 1.4-3.3-1.5-1.7-4.2 2.4zM284.6 36.5c-8.3 8.2-6.5 21.8 4.3 31.9l3.1 2.9-5.7 2.3c-9.8 4-14.3 10-14.3 19 0 4.9 1.8 12.4 3 12.4.4 0 .9-3.5 1.2-7.9.7-11.9 5.7-18.9 16.6-23.3l3.3-1.3-2.6-3.5c-8.6-11.4-10.3-21.4-5.2-30.4 3.2-5.7 3.1-5.6 1.2-5.6-.8 0-3 1.6-4.9 3.5zM242 42.5c0 5 3.5 10.9 8.4 14.2 5.2 3.4 16.8 7.5 18 6.3.5-.5.5-3.4.2-6.4-1.1-8.7-7.3-14.5-17.1-16.1-2.2-.3-5.2-.9-6.7-1.1-2.6-.5-2.8-.4-2.8 3.1zM161.9 44.7c-1.7 4.3-1.4 11.4.5 15.1 2.3 4.4 8.4 8.6 16.3 11.3l6.5 2.1-2.5 2.7c-7.1 7.6-9 18.6-4.4 26.3 2.4 4.1 7.5 8.8 9.6 8.8.5 0-.7-3.2-2.7-7.1-5.7-11-5-19.4 2.4-29.6 1.6-2.2 1.5-2.3-3.9-4.7-10.9-4.8-17.8-13.8-18.1-23.6-.1-4.7-2.1-5.4-3.7-1.3zM184.2 46.7c-2 .4-2.3.9-1.7 3.1 1.7 7.4 10.4 12.8 22 13.7 8.8.8 10.3-.1 8.5-4.7-3.8-9.3-9.3-12.9-19.7-12.7-3.7.1-7.9.4-9.1.6zM301 53.1c0 6.2 2.2 11.1 7.2 16.1 3.5 3.5 10.5 7.8 12.7 7.8 1.7 0 3.3-7.9 2.6-12.2-1.2-7.2-12.8-16.8-20.2-16.8-2.1 0-2.3.5-2.3 5.1zM343.4 55.9c-6.8 3.9-8.8 8.1-8.2 16.6.4 4 1.6 8.4 3.5 12.3l2.9 6.1-5.7 1c-7.2 1.2-13.1 4.2-15.8 8-2.8 3.9-4.6 11.9-3.6 16.7.8 4.3.7 4.4 4.1-5.1 1-2.8 3.7-7 6.2-9.7 4.3-4.6 5.4-5.2 17.1-8.4.8-.3 1-1.1.6-2.2-1.9-4.6-3.5-12.2-3.5-17 0-6.5 1.7-10.8 6.4-15.9 3.1-3.5 3.7-5.3 1.7-5.3-.3 0-2.9 1.3-5.7 2.9zM1204.8 127.2c-.4 79.2-.2 76.4-6.5 83.7-5.4 6.3-11.1 8.6-21.8 8.6-4.9 0-10.9-.6-13.3-1.3-5.1-1.5-11.4-7.5-13.8-12.9-2-4.7-4.3-17.2-4.4-23.6V177h-22v7.4c0 15.2 5.1 30.4 13 39 9.5 10.3 21.2 14.8 39 14.9 13.2 0 21.1-1.6 30.2-6.5 11.2-6 19.6-18.5 21.7-32.5.7-4.7 1.1-31.2 1.1-75.7V55h-22.9l-.3 72.2zM1385 145v90h20v-41.5c0-43.5.4-48.3 4.5-56.5 2.9-5.7 10.1-12.5 16.3-15.2 6.7-3 19.3-3.6 26.6-1.3 6.7 2.1 13.2 7.5 15.7 12.9 1.7 3.8 1.9 7.7 1.9 52.8V235h21.1l-.3-51.8c-.3-51.1-.3-51.8-2.6-57.4-6.4-16-19.8-23.8-40.7-23.8-15.8 0-26.6 4.1-36.7 14.2l-5.8 5.6V55h-20v90zM832.9 59c-20.5 3.2-36 15.2-46 35.4-7.7 15.7-10 26.3-10.6 48.5-1 33.1 3.8 52.7 17.3 71.8 17.5 24.6 54.2 31.6 81.3 15.6 12.4-7.4 23.5-22.5 29-39.3 8.9-27.5 7.2-70.2-3.8-94.4-4-8.9-10.8-18.3-17.3-24-5.7-5-16.7-10.8-23.8-12.4-6.7-1.6-19.7-2.2-26.1-1.2zm24.2 20.3c7.8 3.3 12.1 6.8 17.3 14.5 5.5 8.1 9.1 17.5 11 28.5 6.2 36.1-.6 73.1-16.1 87.8-8.3 7.9-12.6 9.4-26.3 9.4-10.6 0-11.9-.2-17.3-2.8-16.3-8.1-25.6-27-27.6-56.5-1.9-27.8 2.9-53.4 12.7-67.2 7.8-11.1 17.4-16 31.7-16 7.1 0 10.2.5 14.6 2.3zM992 58.6c-8.9 1.5-14.2 3-19.5 5.5C946.7 76.4 932 106.8 932 148c0 36.1 9.5 62.2 28.4 77.8 13.4 11.1 33.6 15.6 52.1 11.7 11.6-2.4 22.1-8.3 30.2-16.9 16.4-17.2 22.8-37.8 22.8-72.6-.1-25.8-2.8-38.8-11.8-56.5-7.5-14.6-22.4-27.1-37-30.9-6-1.6-20.4-2.7-24.7-2zm23.5 21.4c11.9 5.7 21.8 20.9 25.6 39.2 2.6 12.7 3.5 32.8 2 45.7-3.3 27.9-12.1 45-26.9 51.9-5.1 2.4-6.8 2.7-17.2 2.7-11 0-11.8-.1-17.5-3.2-18.5-9.7-27.5-32-27.5-67.8 0-28.3 6.2-49.5 17.8-61.1 8.1-8.1 14.8-10.5 28.7-10.1 8.1.3 11 .8 15 2.7zM653.7 64.2c-.3 1.3-4.5 21.2-9.2 44.3-4.8 23.1-8.9 43-9.2 44.2-.5 2.3-.4 2.3 9.8 2.3h10.4l4.2-4.4c8.7-9 19.2-12.9 34.3-12.9 7.5 0 10.7.4 15.3 2.2 10.8 4.2 18.6 12 22.8 22.8 3 7.9 3.1 23.1 0 31.6-5.8 16.3-19.5 25.7-37.6 25.7-22 0-36.5-9.9-41.2-28.1l-1.7-6.9h-20.9l.7 5.5c1.4 11.9 7.7 23.7 17.3 32.5 6 5.5 18.6 12 27.3 14.1 8.1 2 29 1.7 36.9-.5 21-5.7 37-21.5 41.6-40.7 1.7-7.5 2-24.5.4-32.1-1.8-9-8.6-21.5-15.4-28.3-11-11.1-24.8-16.5-42.2-16.5-14.7 0-25.2 3.2-34.6 10.4l-4.9 3.7.7-3.3c.4-1.8 2.9-13.4 5.6-25.7 2.7-12.4 4.9-22.6 4.9-22.8 0-.2 17.3-.3 38.5-.3H746V62h-91.8l-.5 2.2zM135 66.5c-1.9.7-4.8 1.8-6.3 2.4l-2.8 1.1 1.8 3.1c4.2 7.3 12.7 9.9 24.3 7.5 4.1-.9 7.8-2 8.2-2.4 1.3-1.3-5.2-9.4-9.2-11.4-4.1-2.1-11-2.2-16-.3zM106.7 69.7c-1.5 1.5-.7 11.8 1.2 14.9 2.8 4.6 11.5 8.6 20.1 9.2 7.7.5 7.9.8 5.4 6.8-1.1 2.7-1.5 6-1.2 10.9.3 6 .8 7.8 3.1 10.9 2.8 3.6 11.9 9.1 13.1 7.9.3-.3-1.2-2.1-3.3-4-8.1-6.8-11.4-19.8-7.6-29 .8-1.9 1.5-3.9 1.5-4.3 0-.4-2.3-1.1-5.2-1.4-10.5-1.4-18.5-6.4-22.3-13.9-1.4-2.8-2.5-5.9-2.5-6.9 0-1.8-1.1-2.4-2.3-1.1zM207.6 70.4C200 73.2 195 81.2 195 90.7c0 3 .3 3.3 3 3.3 4.6 0 10.7-3.5 14-8.2 2.9-4 6.9-14.3 5.9-15.3-1.4-1.3-6.8-1.3-10.3-.1zM253.5 70.5c-5.9 3.2-8.6 6.8-10 13.4-.9 4 .3 5.1 5.9 5.1 7.8 0 15.3-5.5 20-14.8 1-1.9 1.5-3.7 1.1-4-.3-.4-3.6-.8-7.3-1-4.8-.2-7.6.2-9.7 1.3zM355.9 74.2c-2 4.6-1.6 11.5.9 17 2.3 5.2 10.8 14.2 12.4 13.2 1.9-1.2 4.8-8.9 4.8-13 0-5.7-3.7-12.2-9.6-16.6-2.7-2.1-5.4-3.8-6-3.8-.6 0-1.8 1.5-2.5 3.2zM301.5 81.7c-6 3.1-11.3 9.8-10.1 12.8.7 1.9 8.2 3.8 12 3.1 1.7-.3 4.9-1.5 7.1-2.7 4.1-2.1 11.5-8.7 11.5-10.1 0-.4-1.8-1.7-4-2.8-4.7-2.4-12.3-2.6-16.5-.3zM160.7 84.4c-5 1.8-7.6 4.2-9.8 9.1-1.8 4-2.4 11-1.3 15.2 1.4 5.1 10.4.8 14.1-6.7 1.3-2.7 2.5-7.5 2.9-11.8.8-8.1.7-8.1-5.9-5.8zM393.1 90.4c-1.9.7-4.9 2.9-6.5 5-2.9 3.6-3.1 4.3-3.1 12.4 0 4.8.3 10.1.7 11.9l.7 3.2-6.7-.6c-15-1.2-21.5 3.9-24.7 19.4-.9 4.5 1.1 4.3 3-.4 4.3-10.3 12.5-15.6 24.2-15.6h7.1l-.5-7.3c-.8-10.3.9-15.7 6.8-21.6 2.6-2.6 5.9-5 7.3-5.4 1.4-.3 2.3-1 2-1.5-.7-1.3-6.2-1-10.3.5zM91.5 98.2c-3.9 1.4-13.5 7.7-13.5 8.9 0 .5 1.9 2.1 4.2 3.6 3.4 2.3 5.2 2.8 10.2 2.8 6-.1 14-2.9 19.1-6.8 2-1.5 2-1.5 0-3.8-4.5-5-13.3-7.1-20-4.7zM1645.2 102.1c-23.3 2.7-43.5 21.3-50.4 46.5-3.1 11.5-3.1 31.8 0 42.7 3.8 13.3 12.4 27.5 20.5 33.9 5.8 4.5 15.8 9.6 22.7 11.4 7.9 2.1 25.1 2.3 33 .5 13.3-3.1 26.6-12.4 32.7-22.8 2.5-4.4 7.3-16.3 7.3-18.3 0-.6-4.3-1-9.8-1h-9.8l-2.4 5.7c-3.1 7.4-9.6 14.4-16.3 17.4-4.5 2.1-6.7 2.4-17.2 2.4-11 0-12.5-.2-17.8-2.7-11.3-5.3-19.7-17.1-23.1-32.5-.9-4-1.6-7.9-1.6-8.7 0-1.4 5.5-1.6 50.5-1.6h50.5v-4.3c0-7.7-2.8-23.2-5.6-30.6-5.5-14.8-15.7-26.9-27.8-32.9-9-4.5-22.8-6.5-35.4-5.1zm21.6 17.4c12.9 3.9 22 16.6 24.6 34.7l.7 4.8h-39c-35.2 0-39.1-.2-39.1-1.6 0-.9.7-4.3 1.6-7.7 3.9-15.2 13.5-26.4 25.7-30.3 5.8-1.8 19.3-1.7 25.5.1zM1293.3 103.4c-21.9 4.2-35.4 17.3-37.8 36.9l-.7 5.7h19.9l.6-5c.9-7.1 5.1-14.4 10.5-18 5.9-3.9 13-5.3 24.3-4.8 8.1.3 10.2.8 14.8 3.3 7.3 4 10.4 8.9 10.9 17 .5 7.4-1.2 11.3-6 14.3-4.3 2.6-8.3 3.6-26.7 6.8-27.4 4.6-38.7 8.9-46.6 17.6-5.8 6.5-7.9 12.9-7.9 24.4-.1 8.2.2 9.6 3.2 15.6 5.7 11.7 15.7 17.9 31.9 19.8 19.5 2.4 34.6-2.4 47.9-15.2l4.1-3.9 1.7 4.5c3.7 9.7 9.6 13.5 20.8 13.6 3.7 0 7.8-.4 9.3-1 2.5-.9 2.6-1.2 2.3-8.2l-.3-7.1-4.9-.1c-4.1-.1-5.2-.5-7-2.9-2-2.8-2.1-4.1-2.6-44-.6-44.7-.5-44-6.6-53.8-4.3-6.9-13.4-12.7-23.4-14.8-8.8-1.9-23.7-2.2-31.7-.7zm43.5 77.6c-.5 10.8-.9 13.3-3.2 18.5-5.8 12.9-18.3 21.1-33.8 22.2-22 1.5-34.6-11.4-28.4-29 3.5-9.8 10.1-13.1 37.1-18.7 8.3-1.8 17.9-4.4 21.5-5.9 5.5-2.3 6.6-2.5 6.9-1.1.2.8.1 7.1-.1 14zM348.5 104c-4.8.8-9.2 3-12.3 6.3l-2.3 2.4 3.1 2.6c6.7 5.7 16.2 5.7 25.7.1 4.8-2.8 4.9-3.1 2.5-6-3.4-4.2-10.1-6.4-16.7-5.4zM1567.5 104.3c-10.2 2.6-19.5 9.1-26.8 18.7l-2.7 3.5V105h-20v130h20v-37.3c0-22.6.4-39.7 1.1-43.3 3.6-19.5 21.6-33.2 41-31l5.9.7v-9.5c0-5.6-.4-9.7-1.1-10.1-2.1-1.3-12.5-1.4-17.4-.2zM402.4 111.6c-5.3 6.9-3.8 20.4 3 28.9l2.4 3 2.7-2.5c3.3-2.9 6.4-9.4 6.5-13.1 0-4.4-3-11.5-6.6-15.8-2-2.2-3.9-4.1-4.4-4.1-.5 0-2.1 1.6-3.6 3.6zM116.4 110.9c-9.2 5.6-11.9 18.4-5.8 27.6 2.1 3.2 2.6 3.1 6.7-.5 3.7-3.2 5.7-8.8 5.7-16 0-4.5-1.9-13-2.9-13-.3 0-2 .9-3.7 1.9zM59 113.3c0 5.6 3.9 11.9 9 14.5 4 2.1 5.5 2.3 13.5 1.9 5-.3 9.9-.8 10.9-1.3 1.3-.5 1.7-.4 1.3.3-1.5 2.3-1.8 8.7-.7 13.6 2.2 10.5 9.6 17.1 18.3 16.5l4.2-.3-5.7-3.2c-9.4-5.4-13.8-12.9-13.8-23.8v-6.6l-4.7.8c-6.5 1-12 .6-17-1.2-4.3-1.6-10.5-7.6-12.5-12.1-1.6-3.4-2.8-3-2.8.9zM196 130.1c-7.1.9-18.4 4.3-27.2 8.2l-5.5 2.5 9.7 58.3c5.4 32.1 15.3 90.7 21.9 130.2 6.7 39.5 12.1 72 12.1 72.2 0 .2-2.4.5-5.2.7l-5.3.3-.3 8.7-.3 8.8H265v-7.9c0-8.6-.6-9.7-5.7-10.3l-3.3-.3 9.9-16c74.2-120.7 86.9-142 92.1-154.2 11.1-26.4 6.2-33.2-17.5-24.7-23 8.3-26.2 9.3-31.2 10-7.9 1-11.9-.2-17.1-4.9-6-5.6-18.5-22.4-26.3-35.6-8.3-13.9-12.9-20.3-20.3-27.9-14.3-14.7-30.4-20.6-49.6-18.1zm15.4 36.8c.3.4 4.9 26.2 10.2 57.2 5.2 31 11.3 66.5 13.4 78.9 2.1 12.4 6.2 36.3 9 53.2l5.2 30.7-4.6 7.6c-2.6 4.1-5.2 7.5-5.7 7.5-1.1 0-1.2-.4-4.8-22-1.7-9.6-4.6-26.7-6.5-38C207.7 226.7 198 169.3 198 167.8s.9-1.8 6.4-1.8c3.6 0 6.7.4 7 .9zm-19 2.8c.3 1 1.6 8.5 3 16.8 7.4 43.9 35.5 209.5 36.2 212.7l.6 2.8h-12.8L200 288.2c-10.6-62.5-19.5-114.3-19.8-115-.2-.7 1.4-2 3.9-3.2 5.5-2.4 7.6-2.5 8.3-.3zm34.6 3.4c3.4 2.3 6.4 4.7 6.6 5.3.2.6 7.1 40.9 15.4 89.6 8.2 48.7 15.2 89.4 15.5 90.6.3 1.2-1.5 5.3-4.7 10.9-4.3 7.3-5.3 8.5-5.9 6.9-.5-1-8.1-44.9-16.9-97.4-8.9-52.5-16.7-98.8-17.4-102.8-1.6-8.7-1.3-8.9 7.4-3.1zm22.5 21.6c4.4 5.1 7.9 10.3 8.5 12.3 1.1 4.4 22 126.5 22 128.8 0 2.1-10.2 18.1-10.6 16.7-.2-.6-3.7-21-7.9-45.5-4.1-24.5-10.4-61.6-14-82.5-3.6-20.9-6.5-38.1-6.5-38.3 0-1 1.9.9 8.5 8.5zm27.8 29.2c2.6 1.7 4.7 3.5 4.7 3.9 0 .4 3.2 19.2 7 41.8l7 41.2-5.2 8.8c-5.1 8.6-5.3 8.7-6.1 5.8-.4-1.6-4.8-26.3-9.7-54.9-5-28.6-9.3-53.1-9.6-54.4-.5-2.3-.3-2.2 3.3 1 2.1 1.9 6 5 8.6 6.8zm65.6.6c1.2 1.2 1.2 2.1.2 5.7-1.4 4.5-5.4 12.7-9.4 19.2l-2.4 3.8-2.2-13.7c-1.2-7.6-1.8-14.2-1.4-14.6 1.3-1.3 8.6-2.8 11.3-2.3 1.4.3 3.1 1.2 3.9 1.9zm-21.4 5.7c.3 1.8 1.6 9.4 2.8 16.8l2.3 13.5-4.9 8.3c-2.7 4.6-5.1 8.1-5.3 7.9-.3-.3-2.1-9.9-4-21.3-1.9-11.5-3.7-21.6-3.9-22.4-.4-1.1 1.1-2.1 5.3-3.6 3.1-1.2 6-2.2 6.4-2.3.4 0 1 1.4 1.3 3.1zm-23.5 1.3l4.5.7 4.5 26.9 4.5 26.9-5 8c-2.7 4.4-5.2 8-5.5 8-.5 0-13.1-69.1-13-71.3 0-.5 1.2-.6 2.8-.3 1.5.3 4.7.8 7.2 1.1zM430 137.1c-6.5 2.6-10 9.2-10.7 20.1-.3 4.3-.7 7.8-.9 7.8-.2 0-2.6-.9-5.4-2-6.9-2.7-15.4-2.7-20 .1-4 2.5-5.3 3.9-8 9.1-3.2 6-2.3 6.5 2.8 1.6 2.6-2.5 6.3-5.4 8.2-6.4 4.7-2.4 15.3-2.4 19.8 0 1.8.9 3.6 1.5 4.1 1.2.4-.3 1.1-2.8 1.4-5.5 1.4-11.9 8.3-20.8 18.4-23.7 2.9-.9 5.1-2 4.8-2.5-.8-1.2-11.3-1.1-14.5.2zM379.4 138.3c-1.7.6-4.1 1.9-5.2 2.7l-2.2 1.5 2.1 3.3c3 4.6 8.6 7.2 15.4 7.2 6.9 0 14.5-1.8 14.5-3.5 0-1.9-4.2-7.6-7.2-9.8-3.3-2.5-12.8-3.2-17.4-1.4zM56.7 140c-4.2 1.3-9.2 5.5-12.8 10.7-3.1 4.4-3.1 4.7-1.4 6 3.3 2.3 14.3 1.7 20.2-1.3 4.8-2.4 12.3-9.3 12.3-11.3 0-1.2-10.4-5.1-13.3-5-1.2 0-3.5.5-5 .9zM78.2 149.8c-4.3 4.3-5.8 9.1-4.6 14.5C75 170.9 79.9 178 83 178c3 0 6-7.1 6-14.1 0-6.3-3.2-15.7-5.9-17.3-.5-.4-2.8 1.1-4.9 3.2zM438.5 158.2c-1.5 1.2-3.6 4-4.6 6.2-3.1 6.9-2.2 21.3 1.5 25.4 1 1 2 .7 5.3-1.7 5.3-3.9 7.8-10 7-17.5-.6-5.7-3.9-14.6-5.5-14.6-.5 0-2.2 1-3.7 2.2zM24 163.7c0 1 1 3.6 2.3 5.8 4.9 8.8 17.2 10.9 28.7 4.9 3-1.6 5.8-3 6.1-3.2.3-.1.9 2.1 1.2 5 .4 2.8 1.8 7.5 3.2 10.4 3.5 7.2 7.6 9.6 17.1 10.2 4.1.2 7.4.1 7.4-.4s-2.7-1.7-5.9-2.6c-11-3.3-18.4-11.1-19.7-21.1-.4-2.6-1.1-4.7-1.6-4.7s-2.6.9-4.7 1.9c-9.5 4.9-21.2 3.3-29.4-4-3.7-3.2-4.7-3.7-4.7-2.2zM402.5 180.4c-1.7 1.3-1.7 1.5.6 5.6 3.3 6 9.8 9.2 19.8 9.8l7.4.5-.6-3.8c-.8-4.8-5-10.3-9.3-12.1-4.3-1.8-15.4-1.8-17.9 0zM31.5 191.8c-6.2 2.9-11 9.3-13 17.5-.7 2.7-.6 2.7 4.1 2.7 6.1 0 12-2.7 16.6-7.4 3.9-4 8.6-12.1 7.6-13.1-.3-.3-3-.8-5.9-1.1-4-.4-6.5 0-9.4 1.4zM54.2 192.3c-1.9 2.3-4.2 8.5-4.2 11.4 0 4.9 4.5 12.9 9.1 16.2 2.3 1.7 4.6 3.1 5.1 3.1 1.5 0 3.8-6.6 3.8-10.8 0-4.9-3.9-12.7-8.8-17.5-3.2-3.1-4.1-3.5-5-2.4zM454.4 192c-4.7 1.9-11.1 11.6-12.9 19.8l-.7 3.2-3.8-3c-5.4-4.3-10.1-6-16.2-6-6.8.1-12.8 2.8-16.3 7.4-3.5 4.7-2.7 5.5 2.2 2.2 5.4-3.8 13.4-5.9 18.6-5.1 4.8.8 10.7 3.6 12.6 5.9 2.2 2.6 3.5 1.8 5.3-3.2 3.7-10.2 12.6-16.9 24.2-18.2l6.1-.7-3.7-1.6c-3.9-1.8-11.9-2.2-15.4-.7zM461.4 212.9c-7.9 3.6-12.4 12.4-12.4 24.4v6l4-.6c9.2-1.2 14.3-9 14.2-21.4-.1-9.9-.6-10.7-5.8-8.4zM36.2 221.6c-10.6 7.1-17.7 8-26.6 3.5-3.1-1.5-5.9-2.5-6.1-2-.8 1.3 5.2 7.5 8.9 9.3 6.8 3.2 14.6 1.2 23.8-5.9l5.6-4.5 2.5 5.2c2.8 6.1 6.8 10.5 11.4 12.4 4.4 1.9 12.6 1.7 17.1-.3l3.7-1.7-7.5-.6c-4.7-.4-9.2-1.4-12.2-2.9-5.5-2.6-11.4-9-12.3-13.2-.4-1.6-1.2-2.9-1.8-2.9-.7 0-3.6 1.6-6.5 3.6zM419.4 229.2c.4 2.4 1.5 5.6 2.4 7.3 1.9 3.2 9.8 8 16.8 10.1l4.4 1.3v-5.2c0-10.6-7.5-17.4-19.4-17.6l-4.9-.1.7 4.2zM39.9 245.1c-1.7 3.3-.6 12.1 2 15.7 3.6 5.1 8.7 8.5 12.9 8.6l3.7.1.3-5.5c.2-4.7-.2-6.2-2.7-10.3-2.9-4.4-10.9-10.7-13.8-10.7-.7 0-1.7 1-2.4 2.1zM21.5 246c-6.4 3.2-11.5 13-11.5 22.2 0 3.7.1 3.7 3.3 3.1 5.2-.9 9.4-3.3 12-6.6 3.8-5.1 6.7-11.3 7.4-16.2l.6-4.5h-3.9c-2.2 0-5.7.9-7.9 2zM462.5 251.7c-4.3 2.2-9.3 7.2-12.2 12l-2.5 4.3-3.8-4.9c-8.6-10.9-18.7-12.8-29.7-5.7-5.1 3.3-4.1 4.6 2 2.5 6.4-2.3 8.9-2.3 15.4-.4 3.5 1 6.8 3.1 10.4 6.5 2.9 2.8 5.6 5 5.9 5 .3 0 2.4-2.2 4.7-4.9 7.3-8.4 17.3-12 27.7-9.8 4.7 1 4.6-.7-.4-4.1-4-2.7-12.9-3-17.5-.5zM30.6 276.6c-4.8 5.5-11.3 9.6-17.3 10.8-2.9.7-6.9 0-11.5-1.9-1.3-.5-1.8-.2-1.8.9 0 2.7 8.8 7.6 13.6 7.6 5.8 0 12.7-4.8 18.1-12.8l4.2-6.2 2.7 3.9c7.1 10.8 22.1 13.5 31.9 5.7 4-3.2 2.9-4-2.9-2S52 284.1 47 281.5c-1.9-1-5.3-3.7-7.5-6l-4.1-4.3-4.8 5.4zM466.3 272.1c-6.8 2-14.8 13.4-16.1 23.1l-.5 4.1 5.3-.6c10.4-1.2 17.1-9.2 18.6-22 .7-5.5.6-5.7-1.7-5.6-1.3 0-3.9.5-5.6 1zM424.5 276.3c-1.2 7.8 4.9 17.4 14.2 22.4 4.3 2.3 5.3 1.1 5.3-6.5 0-7.8-3.9-13.7-11.5-17.5-6.8-3.3-7.3-3.2-8 1.6zM40.5 298.3c-.4 1.9-.2 5.2.4 7.3 2 7.3 7.7 11.3 17.3 12.1l5.8.6v-3.7c0-7-4-11.9-13-15.9-9.4-4.3-9.8-4.3-10.5-.4zM26.3 301.5c-5.8 2.9-7.7 5.4-9.4 11.9-1.6 6.4-.4 17.6 1.9 17.6 5.6 0 13.2-9.3 15.2-18.3 1.2-5.7.4-13.7-1.4-13.7-.7 0-3.5 1.1-6.3 2.5zM410.3 303c-3.7 1.5-2.6 2.5 3 2.7 2.8.1 7.1.8 9.5 1.4 5.5 1.5 13.5 8.6 15.6 13.9 1.8 4.6 2.5 4.8 5.2 1.9 3.3-3.7 11.5-7.1 18.1-7.7 5.4-.4 7-.1 11.8 2.3 3.1 1.5 5.9 2.5 6.2 2.2 1-1-3.6-6.5-7.4-8.8-7.3-4.5-16.6-2.2-25.9 6.3-2.5 2.3-4.6 3.9-4.7 3.7-.2-.2-1.2-2.4-2.3-4.9-2.3-5.4-6.6-10.6-10.5-12.6-3.1-1.6-15-1.8-18.6-.4zM2047.4 304c-19.6 2.2-36.1 11.3-43.7 24.2-4.4 7.6-6 14.9-5.5 26.2.3 8.7.8 10.9 3.4 16.1 7.4 15 21 22.8 51.9 30 32.1 7.5 40.2 10.4 48.1 17.6 6.5 6 8.8 11.5 8.7 21-.1 23.1-21.1 36.3-52.3 32.8-15.4-1.7-25.1-6-33.3-14.8-5.8-6.2-9.1-13-11.4-23.4l-1.6-7.7h-22l.7 6.2c1.7 14.9 10.3 32 20.4 40.8 5.7 4.9 20.5 12.4 28.7 14.5 15 3.8 33.4 4.2 48.7 1 20.4-4.3 35.7-16.2 41.9-32.4 2.7-7.1 3.6-20.4 2-29.7-3.4-19.2-18.9-32.8-45.1-39.8-5.2-1.4-16.1-3.9-24.2-5.6-8.1-1.7-17.2-3.9-20.2-5-11.5-3.9-20.1-11-22.6-18.5-1.6-4.8-.8-15 1.4-19.3 7-13.5 29.2-20.3 51-15.7 18.7 4 28.5 14.3 33 34.7l.6 2.8h10.5c12.2 0 11.6.8 8.4-11.6-6-23.1-21-37.9-43.4-42.7-8.9-1.9-25-2.7-34.1-1.7zM642 397.1v90l48.3-.3c47.4-.4 48.3-.4 54.7-2.7 14.1-5 25.7-14.9 31.1-26.6 5.6-12.1 5.8-29.4.5-41-4.7-10.2-15.8-19.6-28-23.5l-3.9-1.2 7.3-3.9c9-4.7 14.3-9.7 17.8-16.9 3.7-7.7 4.4-21.8 1.4-31.7-5-16.5-17.2-26.7-36.5-30.7-6.2-1.3-15.5-1.6-50.2-1.6H642v90.1zm89.7-68.6c6.7 2 14.6 9 16.9 15.1 5.6 14.8-1.4 32-15.4 37.6-5.4 2.2-7.1 2.3-36.9 2.6l-31.3.3V327h30.8c24.6 0 31.9.3 35.9 1.5zm-1.4 76c17.8 3.8 27.1 14.7 27.1 32 0 12.1-5.7 21.4-16.1 26.2-8 3.7-14.5 4.3-46.5 4.3H665v-64h29.3c21.5 0 31 .4 36 1.5zM1273 319.5V332h20v-25h-20v12.5zM1571 397v90h20.9l.3-45.3.3-45.2 3.3-6.7c3.7-7.5 8.8-12.4 16.8-16 4-1.9 6.7-2.3 14.9-2.3 9 0 10.6.3 15.8 2.8 3.1 1.6 6.9 4.4 8.3 6.2 5.2 6.9 5.4 9 5.4 59.7V487h20.1l-.3-52.8-.3-52.7-2.6-5.6c-3.6-7.7-8.9-13.3-16-16.8-8.5-4.2-15.5-5.4-28.1-4.8-9.6.4-11.5.8-18.1 3.9-4.3 2.1-9.8 5.8-13.5 9.3l-6.2 5.7V307h-21v90zM3040 397v90h20.9l.3-45.3.3-45.2 3.3-6.7c3.7-7.5 8.8-12.4 16.8-16 4-1.9 6.7-2.3 14.9-2.3 11.4 0 16.6 1.8 22.4 7.6 6.7 6.7 6.6 5.3 6.9 59.1l.3 48.8h19.9v-49.8c0-41.7-.3-50.7-1.5-55.7-3.1-11.6-10.7-20-22.3-24.7-5-2-7.5-2.3-19.7-2.3h-14l-7.8 3.7c-4.9 2.4-10 5.8-13.7 9.4l-6 5.7V307h-21v90zM2166 336.5V357h-19v16h18.9l.3 49.2c.3 48.2.3 49.4 2.4 53.3 2.8 5.1 4.8 6.9 10.9 9.7 4.3 2 6.6 2.3 16.5 2.3 6.3 0 12.3-.3 13.3-.7 1.4-.6 1.7-2.1 1.7-9v-8.3h-9.6c-9.2 0-9.6-.1-12-2.8l-2.4-2.8V373h25v-16h-25v-41h-21v20.5zM2500 336.5V357h-19v15.9l9.3.3 9.2.3.5 49.5c.5 54.2.3 52.2 6.7 58.2 5.1 4.8 10.6 6.3 23.3 6.3 6.3 0 12.3-.4 13.3-.7 1.4-.6 1.7-2.1 1.7-9.2v-8.5l-8.8.6c-8.8.6-8.9.6-12.3-2.5l-3.4-3V373.5l12.8-.3 12.7-.3v-15.8l-12.7-.3-12.8-.3-.2-20-.2-20-10-.3-10.1-.3v20.6zM3438 336.5V357h-19v15.9l9.3.3 9.2.3.5 49.5c.5 49.4.5 49.5 2.8 53.5 4.9 8.5 14.7 12.1 30.5 11.2 5.4-.4 10.2-.9 10.7-1.2.6-.3 1-4.4 1-9v-8.4l-8.3.6c-10.4.7-14.1-.8-15.7-6.5-.7-2.5-1-17.9-.8-46.7l.3-43 12.3-.3 12.2-.3v-15.8l-12.2-.3-12.3-.3-.3-20.3-.2-20.2h-20v20.5zM417.5 322.9c-3.5 6.9-1.2 16.2 6.5 25.1l3.8 4.4 2.1-3.4c4.8-8 4-15.1-2.7-22.2-6.5-7-7.8-7.5-9.7-3.9zM40.2 328.7c-1.7 5.8-6.6 12.7-10.5 15.2-1.9 1.2-6.9 2.7-11.1 3.3-4.2.7-7.6 1.6-7.6 1.9 0 1.3 6.3 2.9 11.5 2.9 7.3 0 12.3-3.8 16.4-12.2 1.6-3.5 3.2-7.5 3.6-8.9l.7-2.7 5.9 4.1c5.1 3.5 6.8 4.2 12.4 4.5 5.6.4 7 .1 10.9-2.2 4.1-2.4 9.4-8.1 8.4-9.2-.3-.2-3 1-6.1 2.7-9.7 5.2-19.2 5-27.7-.7-4.7-3.2-5.5-3-6.8 1.3zM453.9 331.3c-2 .8-5.1 2.4-6.9 3.7-3.3 2.3-11 13.2-11 15.5 0 1.8 2.4 2.5 8.4 2.5 9.1 0 16.2-6 20.1-17 .8-2.4 1.4-4.4 1.2-4.6-1.1-1.1-8.8-1.2-11.8-.1zM54 348.6c.1 4.6 3.6 11.2 7.2 13.4 2.8 1.8 4.6 2.1 11.5 1.8 4.5-.2 8.5-.6 8.8-1 1.4-1.4-.7-6.2-4.3-9.9-4-3.9-8.3-5.6-17.4-6.6l-5.8-.6v2.9zM393.5 347c.3.5 1.6 1 2.8 1 3.6.1 10.9 3.9 15 7.8 4.6 4.4 7.2 9.2 8.2 14.9.4 2.4.8 4.3 1 4.3.1 0 2.2-.9 4.6-1.9 10.6-4.7 23-3.2 29.7 3.5 1.9 1.9 3.7 3.3 3.9 3 1.2-1.2-1.2-7-4.1-10-5.9-6.3-15.5-6.7-26.5-1.1-2.8 1.4-5.2 2.5-5.5 2.5-.3 0-1-2.6-1.6-5.8-2.1-10.1-5.4-14.8-12.3-17.7-4.1-1.7-16.2-2.1-15.2-.5zM44.4 353.9c-6.5 4-10.1 11.3-9 18.8.7 5.5 4.5 14.3 6 14.3 2.2 0 7.5-6.4 9.1-10.9 2.5-7.1 1.6-17.8-1.7-22.4-1.2-1.6-1.5-1.6-4.4.2zM840.5 355.1c-14.9 2.3-27.1 9.1-33.4 18.6-3.6 5.3-7.1 15.8-7.1 20.9v3.5l9.7-.3 9.8-.3.7-4.8c1.5-10.7 7.9-18.2 18.2-21.2 6.5-1.9 19.9-1.9 26.4 0 9.5 2.8 16.1 11.1 16.2 20.1 0 11.9-5.7 15.7-29.5 19.4-16.5 2.6-31.1 6.2-37.9 9.3-14.6 6.7-21.8 20-20.2 37.1 1.8 19.5 15.2 30.4 39.4 32.2 16.1 1.1 30.4-3.6 41.8-14l6.1-5.5 1.2 3.9c2.7 9 10.1 14 20.8 14 11.3 0 11.3 0 11.3-8.6V472h-4.1c-5.3 0-7.4-1.3-8.8-5.1-.7-2.1-1.1-15.6-1.1-39.4 0-20.2-.4-38.6-1-41.5-2.9-15.2-12.5-25.5-27.1-29.4-7.4-1.9-23.8-2.7-31.4-1.5zm40.5 76.4c0 11.3-.3 14.3-2.2 19.2-3 8.1-9.9 15.1-19.1 19.4-6.8 3.2-7.8 3.4-18.2 3.4-9.6 0-11.6-.3-15.8-2.4-6.9-3.4-10.1-8.5-10.5-17-.3-5.4.1-7.4 2-11.1 4.6-8.9 9.8-11.3 38.8-17.5 6.9-1.5 15-3.7 18-5 3-1.2 5.8-2.3 6.3-2.4.4 0 .7 6 .7 13.4zM1089.5 355.9c-9.4 2.7-16.4 7-24.6 15.1-13.1 13-19.9 30.4-19.9 51 0 10.2 2.8 24.3 6.4 32.4 3.3 7.5 10.4 17.5 15.7 21.9 5.2 4.5 15.7 10 23.4 12.3 7.4 2.2 25.5 2.5 33.5.5 18.2-4.4 32.7-17.7 38-34.9 1.1-3.5 2-6.6 2-6.8 0-.2-4.4-.4-9.9-.4h-9.9l-2.2 5.5c-4.8 11.7-13.9 18.5-27.4 20.4-18.1 2.6-34.3-5.6-42.3-21.2-2.5-5.1-6.3-18.3-6.3-22.4V427h101.2l-.7-8.3c-1.2-14.2-3.3-22.6-8.5-33.3-7.7-16-19.2-25.8-34.6-29.8-8.4-2.2-25.9-2-33.9.3zm33.6 17.3c6.8 3.1 13.1 9.5 16.5 16.6 2.6 5.5 5.8 19.7 4.8 21.3-.3.5-17.1.9-39 .9H1067v-2.8c0-7.3 5.8-20.7 11.7-27.3 8.2-9.1 15.7-12.1 29.3-11.6 7.7.2 10.6.8 15.1 2.9zM1348.8 355.5c-9.1 1.8-14.8 4.5-20.3 9.6-6.8 6.2-9.6 12.5-10.3 22.4-.6 11.1 1.3 17.7 7.4 24.4 7.5 8.4 15.2 11.5 42.9 17.7 15.4 3.4 21.9 5.8 26.6 10.1 9 8.1 6.1 24.6-5.3 30.2-9.5 4.6-25.2 5.1-37 1.4-9.5-3.1-16.8-12-19.2-23.6l-.6-2.7h-21.1l.7 4.7c2.8 20.1 14.8 33.2 35.5 38.9 9.2 2.6 34 2.6 42.4 0 13.5-4.1 22.5-10.9 27.2-20.5 2.6-5.2 2.8-6.5 2.8-17.6 0-11.4-.1-12.3-2.9-17.3-6.7-12-15.3-16.5-44-22.9-28.3-6.2-33.8-9.3-35.2-19.6-.8-5.5 2.2-12.6 6.6-15.7 7.1-5.1 23.1-6.2 34.2-2.5 6.6 2.3 12.3 8.7 14.4 16.5l1.7 6h10.4c7.7 0 10.3-.3 10.3-1.3 0-3.1-3.9-14.9-6.3-19-3.3-5.7-11.2-12.8-17.4-15.7-9.9-4.7-29.7-6.2-43.5-3.5zM1479.1 355.6c-27.8 7.5-46.7 36-45.5 68.9.7 21.7 9.5 41.3 23.5 52.8 5.6 4.5 16.8 10 23.9 11.8 7 1.7 24.8 1.7 32 0 21.4-5.2 35.9-21.2 38.5-42.4l.7-5.7h-20.1l-1.1 5.7c-3.2 15.2-12.4 23.8-28 26.2-13.1 2.1-25.2-1.8-34.7-11.1-14.9-14.7-18.3-48.1-7.2-70 3.2-6.2 11.2-14.1 17.3-17.1 9.6-4.7 24.5-5.3 34.1-1.3 8.3 3.5 15.2 11.6 17.6 20.8l1.3 4.8H1552.1l-.7-3.8c-.4-2-1.7-6.3-2.9-9.4-6.2-15.4-18.5-26-35-30.3-7.6-1.9-27-1.9-34.4.1zM1742.1 355.6c-19.9 5.3-36.8 23.2-42.8 45.4-2.5 9.1-2.5 32.9 0 42 5 18.5 16.9 34 31.7 41.2 10.5 5.1 16.6 6.3 30 6.2 9.3-.1 13-.6 19.2-2.7 17.4-5.6 28.8-17.5 34.1-35.5l1.6-5.2H1796.2l-3 6.3c-5.6 12.1-13.3 17.8-26.4 19.6-23.4 3.3-40.9-9.2-47.2-33.5-.9-3.4-1.6-7.6-1.6-9.3V427h100v-7.3c-.1-30.5-17.5-57.1-41.8-63.8-8.2-2.3-26.1-2.5-34.1-.3zm32.6 17.3c5.8 2.6 13 9.6 16.2 15.9 2.7 5.2 5.1 14.5 5.1 19.4v3.8l-38.7-.2-38.8-.3.3-3c.5-4.6 4.1-15.6 6.5-19.5 5.1-8.6 11.7-14.2 20.1-17.2 7.3-2.6 22.1-2 29.3 1.1zM1868.8 355c-22.3 4-32.8 15.5-32.8 35.8 0 10.3 2.4 16.6 8.8 23 6.8 6.8 13.3 9.2 45.2 16.7 17.6 4.1 23.7 7.3 26.6 14.2 1.7 3.9 1.8 11.1.3 15-1.7 4.6-7.8 10.1-13.3 12-6.9 2.4-25 2.4-32.2 0-9.8-3.4-17.3-11.5-19.5-21.3l-1.2-5.4h-21l.7 5.1c2.6 19.8 14.8 33 35.6 38.6 10.2 2.7 34.2 2.5 43.5-.4 18.3-5.8 28.1-17.2 29.2-34.2 1-14.4-3.9-25.9-14-32.6-6.9-4.6-13.3-6.6-35-11.5-28-6.2-34.3-10.4-33.5-22.2.8-11.6 8.8-17.1 24.8-17.2 18.1-.1 26.5 5.2 30.6 19.1l1.5 5.3h20.9l-.6-2.8c-2.7-11.9-5.5-18.1-11.1-24.3-8-8.8-19.1-12.9-36.8-13.4-6.6-.2-14.1 0-16.7.5zM2272.5 355c-12.2 1.9-25.1 8.2-30.9 15.1-4.5 5.2-8.5 14.8-9.2 21.7l-.7 6.2h19.2l.6-3.8c1.9-10.8 5.9-16.8 14.1-20.8 7.5-3.7 21.8-4.6 30.8-2 10.9 3.2 17.5 12.7 16.3 23.4-1 9.1-8 13-29.7 16.2-13.8 2.1-30.4 6.2-36.7 9-8 3.6-15.4 10.6-18.4 17.3-2 4.3-2.3 6.9-2.4 15.7 0 13.2 2.1 18.6 10.1 25.9 15 13.7 44.7 14.6 63.9 2.1 3.6-2.3 7.8-5.8 9.5-7.6 1.6-1.9 3.1-3.4 3.3-3.4.2 0 .9 1.8 1.6 4 1.5 5 6.5 10.9 10.8 12.6 3.3 1.4 15 1.9 19.1.8 2-.6 2.2-1.2 2.2-8V472h-3.9c-10.1 0-10.1.2-10.1-42.7 0-19.7-.5-38.7-1-42.3-2.6-16.1-12.7-26.9-29-30.8-6.6-1.6-22.6-2.2-29.5-1.2zm40.3 80c-.3 11.1-.7 13.1-3.1 18.1-6.7 13.8-22.3 21.8-39.8 20.6-14.6-1-22-6.8-22.7-18.1-.6-9.1 1-13.7 6.4-18.5 5.3-4.7 11.5-6.9 29.9-10.6 13.4-2.7 26-6.6 27.9-8.5 1.6-1.6 1.9 2.1 1.4 17zM2400.2 355.1c-22.5 3.4-37.5 17.5-39.8 37.4l-.7 5.5h20l.6-4.9c1.7-14.5 11.2-22 28.8-22.9 12.1-.6 19.2 1.3 25.1 6.6 5 4.5 6.8 8.5 6.8 15.4 0 11.4-5.2 14.7-29.8 18.9-31.1 5.4-39.9 8.5-48.6 17.1-3.7 3.7-5.8 6.9-6.9 10.3-5 15.5-1.9 31.5 7.5 40 5.5 5 13.2 8.6 21.7 10.1 19.7 3.5 36.3-.9 49.8-13.1l6.1-5.5 1.2 3.7c3.1 9.7 9.9 14.3 20.9 14.3 3.8 0 8.1-.4 9.5-1 2.5-.9 2.6-1.4 2.6-8v-7h-5c-5.6 0-8.4-2.1-9.4-7.2-.3-1.7-.6-19.2-.6-38.9 0-38.9-.4-43-5.3-52.2-4.5-8.6-12.2-14.3-23-17.1-7.5-2-23.5-2.7-31.5-1.5zm41.5 77.4c-.6 15-2.8 21.7-9.8 29.1-7.7 8.1-18.1 12.3-30.5 12.4-19.3.1-29.9-11.7-25.3-28.3 2.6-9.4 10.9-14.1 33.5-18.7 15.1-3.1 24.8-5.9 29.4-8.5 3.3-1.8 3.4-1.3 2.7 14zM2595.5 355.5c-9.6 1.8-15.6 4.6-21.4 10-7.4 6.9-9.6 12.7-9.6 25 0 11.8 1.9 16.9 9 23.4 7.7 7 15.9 10.2 39 15.2 23.7 5 31.2 9.2 33.5 18.7 4.1 17.3-12.7 28.7-37.4 25.4-16.8-2.2-25.8-10.1-29-25.5l-.6-2.7h-21l.6 4.7c2.6 19.7 14.9 33.2 35.5 38.9 9.2 2.6 34 2.6 42.4 0 13.5-4.1 22.5-10.9 27.2-20.5 2.6-5.2 2.8-6.5 2.8-17.6 0-11.1-.2-12.4-2.7-17.1-6.2-11.8-15.6-16.7-44.2-23-24.3-5.4-30.1-7.9-33.4-14.4-1.8-3.5-2.2-5.5-1.8-9 .8-5.5 4.7-11.3 9.1-13.5 8.3-3.9 21.9-4.3 31.8-.9 6.5 2.2 12.2 8.7 14.4 16.3l1.8 6.1h10.3c7.7 0 10.2-.3 10.2-1.3 0-2.7-3.1-13-5.1-16.9-3.2-6.4-11.5-14.5-17.7-17.4-10.6-5-29-6.7-43.7-3.9zM2726.2 355.5c-16.2 3.9-30.5 15.6-38.5 31.6-6 11.8-7.9 20.8-7.9 35.9.1 34.7 20.1 61.2 50.3 66.6 33.7 6.1 63.5-12.9 72.5-46.1 3.8-14.3 2.7-36.7-2.6-50.8-6.7-17.8-22.8-32.5-40.6-37.1-7.5-1.9-25.5-2-33.2-.1zm28.9 17.1c18.1 5.7 28.8 24.2 28.9 50 0 32.2-18.7 52.9-45.8 50.7-17.2-1.5-30.8-14.2-35.9-33.6-2-7.7-2.2-26.1-.4-33.7 3.5-14.1 12.3-26.5 22.5-31.5 8.9-4.3 20.6-5 30.7-1.9zM2948.1 355.6c-19 5.1-34.8 20.6-41.6 40.8-11.8 35.1 1.8 73.7 31.1 88.1 13 6.4 31.2 8 46.3 4 18.3-4.8 31.7-18.9 35.7-37.4 2.3-10.8 2.8-10.1-8.5-10.1h-9.9l-.7 3.2c-3.4 17.2-12.7 26.6-28.6 28.8-22.5 3.2-40-9.2-46.5-33.1-3.8-13.9-1.9-35 4.3-47.3 3.5-6.9 11.6-15.1 17.9-18.1 10.2-4.8 25.1-5 34.8-.4 8.1 3.8 15.1 12.7 17.1 21.6l.7 3.3h10.4c6.7 0 10.4-.4 10.4-1.1 0-.6-1.1-4.4-2.5-8.6-6-17.7-18.2-29.2-36-33.8-7.6-1.9-27-1.9-34.4.1zM3211.3 355.5c-21.3 5.8-38.4 24.6-43.7 48.2-2.3 10.3-2.1 27.6.4 38.1 5.8 24.4 22.5 41.9 45 47.3 7.2 1.7 25 1.7 32 0 18.7-4.6 32.8-18.1 38.3-36.9l1.6-5.2h-10.5c-7.6 0-10.4.3-10.4 1.2 0 2.5-4.8 11.5-7.9 15.1-9 10.2-30.7 13.2-45.5 6.2-6.6-3.1-14.9-11.7-18.1-18.7-2.9-6.4-5.5-16-5.5-20.5V427h100v-6.8c-.1-14-4.5-29.6-11.5-41.2-7.1-11.6-20.5-21.2-33.3-23.9-7.3-1.5-24.6-1.3-30.9.4zm32.4 17.4c5.8 2.6 13 9.6 16.2 15.9 2.4 4.7 5.1 15.2 5.1 20v3.2l-38.7-.2-38.8-.3.3-3c.6-6.5 4.4-16.7 8.5-22.6 4.7-6.9 11.5-12.1 18.6-14.4 7-2.2 22.1-1.5 28.8 1.4zM3337.3 355c-7.3 1.3-15.4 4.6-20.2 8.1-4.6 3.3-9.6 10.4-11.1 15.9-1.4 4.8-1.3 19 .2 23.1 3.1 9.2 11.7 16.9 23 20.8 3.1 1.1 11.9 3.4 19.5 5.1 31.8 7.2 37.2 10.4 38.1 22.8.5 7.1-1.8 12.4-7.4 17-5.2 4.3-11.2 5.7-23.9 5.6-13.7-.1-20.7-2.5-27.1-9.1-4.1-4.2-8.4-13.1-8.4-17.3 0-1.9-.7-2-10.5-2H3299v2.6c0 3.9 2.9 14.2 5.2 18.8 3.2 6.3 11.2 14 18.1 17.4 8.8 4.5 16.5 6.2 29.7 6.9 30.4 1.5 51-10.2 55-31.3 3.1-16.1-2.1-30.7-13.4-37.9-7.4-4.6-13.9-6.8-34.4-11.4-20.1-4.5-26.6-6.8-30.8-11.2-2.6-2.7-2.9-3.7-2.9-9.8 0-5.9.4-7.2 2.9-10.5 4.6-6.1 10.1-8 22.6-8 8.7 0 11.4.4 15.5 2.3 8.1 3.6 12.5 9.1 14.3 17.8l.8 3.8 10.6.3 10.6.3-.8-4.3c-3.2-17-13.4-29-28.8-33.9-7.7-2.4-27.3-3.4-35.9-1.9zM3544 355c-15 3.6-30.6 16.1-38.4 30.9-11.9 22.8-11.1 54.6 2.1 76.4 7.4 12.4 20 21.9 34.8 26.3 8.6 2.6 27.6 2.4 36.7-.3 12.1-3.6 23.8-12.3 29.5-22.1 2.5-4.3 7.3-16.2 7.3-18.2 0-.6-4.3-1-9.8-1h-9.8l-2.4 5.7c-4.7 11.4-13.7 18.1-27.1 20.2-17.7 2.8-33.6-5-42.2-20.7-2.8-5.1-6.7-18.5-6.7-22.9V427h101.2l-.7-8.8c-2.7-33.9-18-56.2-43.2-62.7-6.2-1.6-25.3-1.9-31.3-.5zm31.2 18.2c6.8 3.1 12.8 9.2 16.3 16.2 2.7 5.5 5.9 19 5.1 21.3-.4 1-7.8 1.3-39.1 1.3-44.2 0-39.9 1.2-36.9-10.4 3.6-14 13-25.5 24.1-29.5 8.5-3 22.6-2.5 30.5 1.1zM1237.7 356c-9.7 1.7-19.5 8-26.8 17.2l-3.9 5V357h-21v130h21v-39.3c0-41.3.3-44.5 4.8-53.3 2.9-5.8 12.2-13.9 18.5-16.2 6.9-2.6 15.5-3.6 20-2.4l3.7 1v-20.5l-3.7-.7c-4.5-.7-6.2-.6-12.6.4zM2876.7 356c-2.7.5-7.3 2.1-10.3 3.5-5.3 2.6-15.4 11.6-18.7 16.5-1.5 2.4-1.6 2.1-1.6-8.3l-.1-10.7h-21v130h20.9l.3-41.8.3-41.7 3.3-6.7c4-8.2 12-15.8 19.5-18.6 6.9-2.6 15.5-3.6 20-2.4l3.7 1v-20.5l-3.7-.7c-4.5-.7-6.2-.6-12.6.4zM3687 356.3c-10 2.3-20 9.2-27.3 18.7l-2.7 3.5V357h-20v130h20v-37.9c0-20.8.4-40.1 1-42.9 2.1-11.2 9-20.8 18.7-26 7.4-3.9 17.5-5.9 23.1-4.5 2.3.6 4.4.8 4.7.5.9-.9.6-19-.4-19.6-2-1.3-12-1.4-17.1-.3zM916.3 358.2c.5 1.1 18.1 45 43.2 107.2l7.2 17.9-3.3 8.5c-4.3 11-7.5 15.7-12.4 18.2-4.6 2.4-13.5 2.6-19.2.6l-3.8-1.4V527.9l3.9 1.2c6.3 1.9 24.7.8 29.6-1.8 5.5-2.9 11.7-9.8 15.6-17.4 2.7-5.4 33-81.3 60.6-151.7.4-.9-2.1-1.2-10.6-1.2-6.1 0-11.1.2-11.1.4s-4.1 11.6-9.1 25.2c-17.1 46.8-23.6 64.9-25.9 71.9-1.2 3.8-2.5 7.3-2.9 7.7-.4.5-2-3.1-3.5-8-1.6-4.8-10.2-28.2-19.2-52S939 358.5 939 358c0-.6-4.7-1-11.6-1-8.9 0-11.5.3-11.1 1.2zM1273 422v65h20V357h-20v65zM96.5 368.1c-7.8 8.1-19 10.9-28.9 7.4-2.2-.8-4.3-1.2-4.6-1-.4.3-1 2.7-1.3 5.4-1.4 11.8-8.2 20.8-17.6 23.2-2.8.7-5.1 1.6-5.1 2 0 1 3.9 1.9 8.5 1.9 9.5 0 14.9-6.5 16.8-20.5.7-5.1 1.6-8.3 2.2-8.1 14.4 6.3 26.5 3.5 32-7.5 1.5-2.8 2.5-5.5 2.3-6-.2-.5-2.1.9-4.3 3.2zM397.6 367c-4.7 5.7-4.4 17.8.8 26.4l2.3 3.8 3.6-3.2c6.2-5.4 7.2-14.8 2.5-23.2-1.2-2.1-3.2-4.5-4.4-5.3-2.1-1.4-2.4-1.2-4.8 1.5zM368.5 383.9c-.3.5 1.1 1.5 3.2 2.2 2 .6 5.8 3.3 8.4 5.9 5.5 5.5 8.1 12.5 7.7 20.5-.2 4 0 4.9 1.2 4.6.8-.2 4.7-.4 8.5-.4 11.2 0 19.4 4.3 23 12.4 2.5 5.4 3.9 4.9 3.3-1.2-.5-5.3-2.6-8.9-7.2-12.3-2.2-1.7-4.2-2.1-10.9-2.1-4.5 0-9.8.3-11.8.8l-3.5.7v-8.2c0-9.4-2-14.6-7.4-19.1-4.3-3.7-13.1-6-14.5-3.8zM421.4 387.5c-5.9 2.9-13 9.8-11.9 11.5 1 1.6 8.4 5 11 5 6.7 0 16.6-6.4 20.1-13.1 1.3-2.6 1.2-2.9-.8-4.3-3.5-2.5-12.5-2.1-18.4.9zM83.3 391.3c-2.4.5-4.3 1.3-4.3 1.6 0 .4 1.3 2.7 2.9 5.2 5 8 13.9 10.1 23.9 5.4 2.8-1.3 5.2-2.8 5.2-3.3 0-2-4.6-6.6-8.4-8.3-4.5-2-12.4-2.3-19.3-.6zM126.7 401.5c-2.5 5.3-8.8 11.6-13.7 13.8-3 1.3-6.5 2-11 1.9h-6.5l.4 8c.5 12.2-3.9 21.2-12.8 25.8l-3.6 1.8 2.6.7c4 1 10.4-1.2 13.2-4.5 3.9-4.6 5-9.2 4.5-19.6l-.4-9.4h7.8c9.5 0 14.6-2.2 18.2-7.8 2.1-3 4.5-10.2 4.6-13.5 0-1.9-1.8-.4-3.3 2.8zM71.6 403.3c-5.3 7-6 13.8-2 21.3 2.6 4.9 7.1 10.4 8.6 10.4.4 0 1.9-2.2 3.3-5 4.2-8.4 3-17.9-3.6-27.1-1.1-1.6-2.4-2.9-2.9-2.9s-2 1.5-3.4 3.3zM365.7 405.4c-5.1 5-6.9 14.5-4.8 23.9.5 2.1 1.2 4.1 1.4 4.4 1.2 1.1 8.9-4.3 11-7.7 3-4.8 3-13.9-.1-19.8-1.2-2.3-2.7-4.2-3.2-4.2s-2.5 1.5-4.3 3.4zM335 412.7c0 .4 1.5 2 3.4 3.5 5.3 4.2 8.6 11.9 8.6 19.8 0 3.7-.5 8.2-1.1 10-1.4 3.9-.7 4.5 6 5.4 5.8.8 14.2 5.5 17.6 10.1 1.5 1.9 3.3 5.4 4 7.7.7 2.4 1.6 4.2 2.1 4 .5-.1.9-3.4.9-7.3 0-6.8-.1-7.2-3.7-10.4-4.2-3.9-8.7-5.4-18.1-6.2-7.5-.6-7.2-.1-4.3-7.8 3.7-9.6.7-20.5-6.9-25.7-4.3-2.9-8.5-4.4-8.5-3.1zM129.7 424.1c-2 .5-6 2-8.8 3.4-4.8 2.5-5 2.7-3.6 4.8 5.8 8.9 21.4 9.1 29.5.4l2.3-2.5-2.8-2.6c-2.7-2.5-8.1-4.7-11.3-4.5-.8.1-3.2.5-5.3 1zM165.8 424c-.4.8-1.4 3.9-2.4 6.9-2.8 9.1-11 16.3-20 17.8-2 .3-3.8 1.2-4.1 1.8-.2.7.5 4.3 1.6 8 1.2 3.7 2.1 8.6 2.1 10.9 0 5.1-4.2 14-7.6 16.3-2.9 1.9-3.1 3.3-.4 3.3 2.9 0 7-2.3 10-5.5 2.1-2.2 2.5-3.8 2.8-10 .4-6.7.1-8.1-2.7-14.1-3.4-7.2-3.1-8.4 1.8-8.4 7.7 0 17.3-6.4 19.1-12.8 1.2-3.8 1-16.8-.2-14.2zM383.5 430.4c-2.2.7-6.4 2.5-9.4 4l-5.3 2.7 2.3 2.6c5.6 6 15 7.8 22.8 4.3 5.6-2.6 12.3-7.9 11.5-9.2-1.2-1.9-10.9-5.8-14.4-5.7-1.9 0-5.3.6-7.5 1.3zM294.7 431.6c-.3.4.5 2.1 1.8 3.8 4.2 5.6 5.8 11 5.3 18.6-.3 5.8-.9 7.6-3.6 11.5-1.8 2.5-3.2 4.9-3.2 5.3 0 .4 2.2 1.5 4.9 2.5 10.7 3.8 18.1 13.8 18.1 24.4 0 4.8 1.1 5.5 2.8 1.9 5.4-11.8-.8-22.8-15.4-27.6-6.4-2.1-6.5-2.3-5-4.4 5.7-7.8 7-11 7-17 0-3.6-.7-7.3-1.6-9.1-2.3-4.2-9.9-11-11.1-9.9zM328.4 432.1c-6.8 1.9-11.6 10.8-11.8 21.9l-.1 5.5 3.4-.3c8.5-.7 14.5-8.5 14.6-18.9 0-7.5-1.4-9.5-6.1-8.2zM207.8 441.4c.7 5.7-1.7 14.3-5.2 18.9-1.7 2.3-5.5 5.5-8.4 7-2.9 1.6-5.2 3.3-5.2 3.8 0 .6 1.3 2.9 2.9 5.3 6.6 9.6 7.6 19.5 2.7 28.3-2.8 5-1.5 5.8 3.5 2.2 8.6-6.1 7.8-19.3-2.1-31l-3.8-4.6 5.7-2.6c6.6-3 10.8-6.8 12.7-11.4 1.7-4 1.7-7.4.1-13.7-1.5-5.8-3.5-7.3-2.9-2.2zM112 442.2c-2.6 4.3-2.7 12.6-.1 17.6 2.5 4.7 10.6 12.2 13.4 12.2.4 0 1.5-1.7 2.4-3.7 1.9-4.6 1.2-11.5-1.6-17-2.6-5-8.9-12.3-10.7-12.3-.8 0-2.3 1.5-3.4 3.2zM252.7 444.7c3.7 9.1.4 22.5-7.2 29.2-3.3 2.9-4.5 5.1-2.7 5.1 1.5 0 10.5 9.6 12.4 13.3 2.5 4.9 3.3 12.2 1.9 17.2-.6 2.1-.8 4.1-.6 4.3.9.9 3.4-2 5.6-6.4 4.2-8.7-.1-18.8-11-25.8l-5.9-3.9 5.5-5.1c6-5.4 9.2-11.1 9.3-16.2 0-3.8-5.6-15.4-7.5-15.4-1.2 0-1.1.7.2 3.7zM175.3 446.9c-4 1.9-13.3 9.6-13.3 11.1 0 1.6 8.7 4.5 13.1 4.4 5.2-.2 8.1-1.4 12.2-5.3 2.5-2.2 5.7-7 5.7-8.4 0-.9-8.1-3.7-10.8-3.7-1.5 0-4.6.9-6.9 1.9zM279.5 450.2c-6.5 3.5-13.5 13.9-13.5 20 0 2.7.2 2.8 4.8 2.8 8.5 0 15.4-6.4 17.2-16 .5-2.9 1-5.9 1-6.6 0-1.7-6.6-1.9-9.5-.2zM226.5 455.7c-4.3 2.2-7.3 5.1-11.1 10.8l-3.4 5 2.7 1.2c6.1 2.7 15.6.9 19.8-3.7.9-1 2.7-4.5 4-7.7 2.2-5.3 2.3-5.9.7-6.5-3-1.2-9.6-.8-12.7.9zM330.5 462.7c-3.5.7-7.5 2.5-7.5 3.3 0 1.5 4.6 7.4 7.3 9.4 4.3 3.2 15.4 3 22.7-.5l5.5-2.6-4-4c-2.4-2.4-5.7-4.5-8-5.2-3.9-1.1-12.1-1.3-16-.4zM160.6 467.6c-2 5.3.3 15.5 4.7 20.3 2.6 2.8 11.3 7.1 14.5 7.1 2 0 2.2-.4 2.2-5.8 0-8.8-5.4-16.3-15.7-21.6-4-2-4.9-2-5.7 0zM215 484.3c0 9 6.3 15.8 16.8 18.3 8.8 2.1 10.2 1.9 10.2-1.4-.1-8.9-9.4-17.9-21.7-20.8l-5.3-1.2v5.1zM270 480.9c0 6.1 5.6 12.8 12.6 15.1 3.6 1.2 17.8 1 19.1-.3.3-.4-.5-2.8-1.9-5.4-3.5-6.8-11.1-10.7-22-11.2-7.4-.3-7.8-.2-7.8 1.8z"></path></symbol><symbol viewBox="0 0 1220 327" id="icon-apollon-logo"><path d="M772.755 279.62s-.033.037-.033.07c0 0 0-.033-.037-.033.037-.037.07-.037.07-.037M0 264.533h54.352l17.375-56.2h95.393l17.743 56.2h55.832L147.523.177H92.064L0 264.533M107.963 91.128c4.432-14.046 11.09-40.668 11.09-40.668h.741s6.285 26.622 10.722 40.668l23.661 76.164H84.298l23.665-76.164zM256.59 326.646h50.283v-83.558h.74c10.722 16.268 28.098 26.99 54.719 26.99 48.807 0 82.082-38.82 82.082-100.197 0-59.157-32.167-100.193-82.449-100.193-25.882 0-43.63 12.198-55.833 28.838h-1.108V74.86H256.59v251.785zm95.02-98.344c-29.946 0-45.846-22.558-45.846-56.941 0-34.015 12.571-61.005 43.998-61.005 31.058 0 43.629 25.142 43.629 61.005 0 35.864-16.267 56.94-41.781 56.94m208.896 41.777c58.789 0 99.089-43.63 99.089-100.197 0-56.568-40.3-100.193-99.089-100.193-58.784 0-99.084 43.625-99.084 100.193s40.3 100.197 99.084 100.197m0-38.452c-31.054 0-48.062-24.77-48.062-61.745 0-36.972 17.008-62.113 48.062-62.113 30.691 0 48.066 25.14 48.066 62.113 0 36.976-17.375 61.745-48.066 61.745m120.161 32.907h50.283V.177h-50.283v264.356zm76.9 0h50.283V.177h-50.283v264.356zm170.444 5.545c58.789 0 99.089-43.63 99.089-100.197 0-56.568-40.3-100.193-99.089-100.193-58.784 0-99.085 43.625-99.085 100.193s40.301 100.197 99.085 100.197m0-38.452c-31.054 0-48.062-24.77-48.062-61.745 0-36.972 17.008-62.113 48.062-62.113 30.686 0 48.066 25.14 48.066 62.113 0 36.976-17.38 61.745-48.066 61.745M1096.61 74.86h-49.18v189.672h50.28V156.942c0-25.881 16.27-43.63 38.46-43.63 21.07 0 32.9 14.42 32.9 34.756v116.465h50.29V140.675c0-41.41-26.26-70.987-65.45-70.987-25.88 0-43.26 10.718-56.2 31.054h-1.1V74.86zM256.594 44.933h16.779c5.657 0 9.996-1.569 13.325-4.335 4.712-3.952 7.161-10.368 7.161-17.659C293.859 9.675 286.135 0 274.128 0h-17.534v44.933zm9.107-7.85V7.784h7.291c7.738 0 11.635 6.225 11.635 15.155 0 8.925-3.334 14.144-11.887 14.144h-7.039zm47.708 8.79c9.996 0 16.84-7.407 16.84-17.026s-6.844-17.03-16.84-17.03c-9.996 0-16.84 7.411-16.84 17.03 0 9.62 6.844 17.026 16.84 17.026m0-6.527c-5.28 0-8.176-4.213-8.176-10.499 0-6.29 2.896-10.564 8.176-10.564 5.219 0 8.175 4.274 8.175 10.564 0 6.286-2.956 10.5-8.175 10.5m33.88 6.526c8.045 0 13.571-3.887 13.571-10.363 0-7.543-5.968-9.05-11.374-10.183-4.59-.945-8.864-1.196-8.864-3.962 0-2.328 2.197-3.585 5.531-3.585 3.65 0 5.852 1.257 6.229 4.717h7.724c-.628-6.476-5.34-10.68-13.827-10.68-7.352 0-13.13 3.328-13.13 10.303 0 7.04 5.652 8.613 11.435 9.744 4.399.88 8.487 1.197 8.487 4.274 0 2.268-2.137 3.711-5.908 3.711-3.841 0-6.481-1.634-7.044-5.345h-7.915c.503 6.853 5.717 11.37 15.085 11.37m30.481 0c8.045 0 13.572-3.888 13.572-10.364 0-7.543-5.964-9.05-11.37-10.183-4.59-.945-8.869-1.196-8.869-3.962 0-2.328 2.202-3.585 5.536-3.585 3.645 0 5.848 1.257 6.225 4.717h7.724c-.629-6.476-5.336-10.68-13.823-10.68-7.357 0-13.134 3.328-13.134 10.303 0 7.04 5.652 8.613 11.434 9.744 4.405.88 8.492 1.197 8.492 4.274 0 2.268-2.141 3.711-5.912 3.711-3.837 0-6.481-1.634-7.045-5.345h-7.91c.503 6.853 5.713 11.37 15.08 11.37m17.413-.94h8.539V12.695h-8.539v32.237zm0-37.275h8.539V0h-8.539v7.66zm29.224 38.214c8.297 0 13.386-4.832 14.578-10.554h-8.418c-.94 2.453-2.891 3.967-6.225 3.967-4.842 0-7.607-3.083-8.236-8.055h23.381c0-11.5-5.526-19.415-15.899-19.415-9.428 0-15.9 7.412-15.9 16.966 0 9.62 6.03 17.091 16.719 17.091m-.693-27.464c3.901 0 6.602 2.831 6.853 6.923h-14.335c.754-4.218 2.956-6.923 7.482-6.923m27.967-5.713h-8.227v32.237h8.539V29.224c0-6.788 4.023-9.74 9.619-9.176h.186v-7.477c-.503-.187-1.066-.252-2.011-.252-3.771 0-5.969 1.886-7.92 5.531h-.186v-5.154z" fill-rule="nonzero"></path></symbol><symbol viewBox="0 0 15 15" id="icon-arrow-down"><path d="M12 3l-4.5 8.5L3 3"></path></symbol><symbol viewBox="0 0 5.971 12.162" id="icon-arrow-jumpmark"><g data-name="Gruppe 228" fill="none" stroke="currentColor"><path data-name="Linie 183" d="M3.083 0v11"></path><path data-name="Pfad 65" d="M.406 7.725l2.58 3.58 2.58-3.58"></path></g></symbol><symbol viewBox="0 0 15 15" id="icon-arrow-left"><path d="M10.5 12l-6-4.5 6-4.5"></path></symbol><symbol viewBox="0 0 15 15" id="icon-arrow-right"><path d="M4.5 3l6 4.5-6 4.5"></path></symbol><symbol viewBox="0 0 10 10" id="icon-arrow-rotate-left"><path d="M10 5a5.002 5.002 0 0 1-8.94 3.08c-.12-.16-.09-.38.06-.5s.38-.09.5.06c1.45 1.87 4.15 2.22 6.02.76 1.87-1.45 2.22-4.15.76-6.02a4.286 4.286 0 0 0-6.02-.77c-.44.34-.81.76-1.09 1.24h1.92c.2 0 .36.16.36.36s-.16.36-.36.36H.36c-.2 0-.36-.16-.36-.36V.36C0 .16.16 0 .36 0s.36.16.36.36v2.09A4.98 4.98 0 0 1 7.56.7 4.96 4.96 0 0 1 10 5z"></path></symbol><symbol viewBox="0 0 15 15" id="icon-arrow-up"><path d="M3 12l4.5-8.5L12 12"></path></symbol><symbol viewBox="0 0 15 15" id="icon-arrow"><path d="M7 12l4.5-4.5L7 3M11 7.5H2"></path></symbol><symbol viewBox="0 0 40 40" id="icon-blog"><g fill-rule="nonzero"><path d="M22 19c-1.1 0-1.8 1-1.8 2.3 0 1.4.7 2.3 1.8 2.3s1.8-1 1.8-2.3c.1-1.3-.7-2.3-1.8-2.3zM31 19c-1.1 0-1.9.9-1.9 2.3s.7 2.4 1.9 2.4c.6 0 1.2-.3 1.6-.8V20c-.3-.6-.9-.9-1.6-1z"></path><path d="M33.3 6.2C29.5 2.4 24.9.5 19.5.5S9.5 2.4 5.7 6.2C1.9 10 0 14.6 0 20s1.9 10 5.7 13.8c3.8 3.8 8.4 5.7 13.8 5.7s10-1.9 13.8-5.7C37.1 30 39 25.4 39 20s-1.9-10-5.7-13.8zM8.2 25.5c-.7 0-1.3-.3-1.8-.8 0 .4-.3.6-.7.6h-.4c-.4 0-.6-.4-.6-.7V14.4c0-.4.4-.7.8-.6H6c.4 0 .7.4.6.8V18c.5-.4 1.1-.6 1.6-.6 2.3 0 3.6 1.7 3.6 4.1 0 2.3-1.3 4-3.6 4zm9.1-.9v.1c0 .4-.4.7-.8.6h-.6c-1.1-.1-2-1-2-2.2v-8.8c0-.4.3-.7.7-.7h.5c.4 0 .7.3.7.7v8.6c0 .2.2.4.5.4h.4c.4 0 .7.3.7.7v.6h-.1zm4.7.9h-.2c-2.1-.2-3.7-2-3.5-4.1v-.7c.2-2 2-3.5 4.1-3.3 2.1.2 3.5 2 3.3 4.1v.2c.1 2-1.6 3.7-3.7 3.8zm12.5-.4c-.1 2-1.8 3.4-3.8 3.3-1.7 0-3.1-1.1-3.2-2.1v-.1c0-.3.3-.6.6-.6h.6c.4 0 .7.2.8.6.3.4.8.7 1.3.6h.4c1-.1 1.7-1 1.6-2-.5.4-1.1.7-1.7.7-2.3 0-3.6-1.7-3.6-4.1 0-2.4 1.5-4.1 3.5-4.1.7 0 1.3.3 1.8.8 0-.4.3-.6.7-.6h.5c.4 0 .6.4.6.7v6.6c-.1.1-.1.2-.1.3z"></path><path d="M8 19c-.6 0-1.2.3-1.5.8v3c.3.6.9.9 1.5 1 1.1 0 1.9-1 1.9-2.4S9.2 19 8 19z"></path></g></symbol><symbol viewBox="0 0 21.03 21.07" id="icon-bso-favicon"><path d="M2.86 7.7v10.21h-.84v.99h16.97v-.99h-.84V7.7H2.86zm14.3 10.21h-2.57V8.69h2.57v9.22zm-6.15-9.22h2.58v9.22h-2.58V8.69zm-1 9.22H7.42V8.69h2.59v9.22zM3.86 8.7h2.56v9.22H3.86V8.7zM10.51 2.98l9.31 4.56.45-.9-9.76-4.76L.76 6.64l.45.9 9.3-4.56z"></path><path d="M10.59 1.1l4.22 2.04.44-.89L10.6 0 5.79 2.24l.42.9 4.38-2.04zM0 20.07h21.03v.99H0z"></path></symbol><symbol viewBox="0 0 15 15" id="icon-calendar"><path d="M2 3.5h11M2.5 6.5h10M2 12.5h11M2.5 13V4M4.5 2v3M10.5 2v3M12.5 13V4"></path></symbol><symbol viewBox="0 0 18 18" id="icon-captions-off"><path d="M1 1c-.6 0-1 .4-1 1v11c0 .6.4 1 1 1h4.6l2.7 2.7c.2.2.4.3.7.3.3 0 .5-.1.7-.3l2.7-2.7H17c.6 0 1-.4 1-1V2c0-.6-.4-1-1-1H1zm4.52 10.15c1.99 0 3.01-1.32 3.28-2.41l-1.29-.39c-.19.66-.78 1.45-1.99 1.45-1.14 0-2.2-.83-2.2-2.34 0-1.61 1.12-2.37 2.18-2.37 1.23 0 1.78.75 1.95 1.43l1.3-.41C8.47 4.96 7.46 3.76 5.5 3.76c-1.9 0-3.61 1.44-3.61 3.7 0 2.26 1.65 3.69 3.63 3.69zm7.57 0c1.99 0 3.01-1.32 3.28-2.41l-1.29-.39c-.19.66-.78 1.45-1.99 1.45-1.14 0-2.2-.83-2.2-2.34 0-1.61 1.12-2.37 2.18-2.37 1.23 0 1.78.75 1.95 1.43l1.3-.41c-.28-1.15-1.29-2.35-3.25-2.35-1.9 0-3.61 1.44-3.61 3.7 0 2.26 1.65 3.69 3.63 3.69z" fill-rule="evenodd" fill-opacity=".5"></path></symbol><symbol viewBox="0 0 18 18" id="icon-captions-on"><path d="M1 1c-.6 0-1 .4-1 1v11c0 .6.4 1 1 1h4.6l2.7 2.7c.2.2.4.3.7.3.3 0 .5-.1.7-.3l2.7-2.7H17c.6 0 1-.4 1-1V2c0-.6-.4-1-1-1H1zm4.52 10.15c1.99 0 3.01-1.32 3.28-2.41l-1.29-.39c-.19.66-.78 1.45-1.99 1.45-1.14 0-2.2-.83-2.2-2.34 0-1.61 1.12-2.37 2.18-2.37 1.23 0 1.78.75 1.95 1.43l1.3-.41C8.47 4.96 7.46 3.76 5.5 3.76c-1.9 0-3.61 1.44-3.61 3.7 0 2.26 1.65 3.69 3.63 3.69zm7.57 0c1.99 0 3.01-1.32 3.28-2.41l-1.29-.39c-.19.66-.78 1.45-1.99 1.45-1.14 0-2.2-.83-2.2-2.34 0-1.61 1.12-2.37 2.18-2.37 1.23 0 1.78.75 1.95 1.43l1.3-.41c-.28-1.15-1.29-2.35-3.25-2.35-1.9 0-3.61 1.44-3.61 3.7 0 2.26 1.65 3.69 3.63 3.69z" fill-rule="evenodd"></path></symbol><symbol viewBox="0 0 24 24" id="icon-check"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></symbol><symbol viewBox="0 0 15 15" id="icon-close"><path d="M3 3l9 9M3 12l9-9"></path></symbol><symbol viewBox="0 0 24 24" id="icon-copylink"><g transform="translate(-3.734 -2.179) scale(1.38245)"><circle cx="11.381" cy="10.256" r="8.68"></circle><clipPath id="copylink-a"><circle cx="11.381" cy="10.256" r="8.68"></circle></clipPath><g clip-path="url(#copylink-a)"><path d="M11.98 8.588a2.268 2.268 0 0 1 .625 3.648l-2.265 2.267a2.267 2.267 0 0 1-1.603.664A2.277 2.277 0 0 1 6.471 12.9c0-.6.239-1.177.664-1.602l.885-.885m6.723-.313l.885-.885a2.267 2.267 0 0 0 .664-1.603 2.277 2.277 0 0 0-2.267-2.266c-.6 0-1.177.239-1.602.664l-2.267 2.266a2.268 2.268 0 0 0 .626 3.648" fill="none" stroke="#fff" stroke-width=".7554299999999999"></path></g></g></symbol><symbol viewBox="0 0 15 15" id="icon-enter-fullscreen"><path d="M7 3.5h4.5V8M3.5 11.5l8-8M8 11.5H3.5V7"></path></symbol><symbol viewBox="0 0 15 15" id="icon-exit-fullscreen"><path d="M7 3.5h4.5V8M3.5 11.5l8-8M8 11.5H3.5V7"></path></symbol><symbol viewBox="0 0 40 40" id="icon-facebook"><path d="M33.787 6.311C29.979 2.502 25.382.598 20 .598c-5.383 0-9.978 1.904-13.787 5.713C2.404 10.119.5 14.716.5 20.098c0 5.383 1.904 9.979 5.713 13.787 3.105 3.105 6.743 4.922 10.894 5.496V25.85h-4.705v-5.449h4.705v-4.019c0-4.664 2.848-7.203 7.008-7.203 1.993 0 3.706.148 4.205.215v4.874l-2.885.001c-2.262 0-2.7 1.075-2.7 2.652V20.4h5.396l-.703 5.449h-4.693v13.553c4.217-.548 7.908-2.374 11.053-5.518 3.809-3.809 5.713-8.404 5.713-13.787-.001-5.381-1.905-9.978-5.714-13.786z" fill-rule="nonzero"></path></symbol><symbol viewBox="0 0 24 24" id="icon-file-upload"><path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5"></path></symbol><symbol viewBox="0 0 40 40" id="icon-file"><path d="M33.3 6.2C29.5 2.4 24.9.5 19.5.5S9.5 2.4 5.7 6.2C1.9 10 0 14.6 0 20s1.9 10 5.7 13.8c3.8 3.8 8.4 5.7 13.8 5.7s10-1.9 13.8-5.7C37.1 30 39 25.4 39 20s-1.9-10-5.7-13.8zm-6.6 10.7l-8.9 8.9c-.6.6-1.3.9-2.2.9-.9 0-1.6-.3-2.2-.9-.6-.6-.9-1.3-.9-2.2 0-.9.3-1.6.9-2.3l7.4-7.4 1.5 1.5-7.4 7.4c-.2.2-.3.5-.3.8 0 .3.1.5.3.7.2.2.4.3.7.3.3 0 .5-.1.8-.3l8.9-8.8c.6-.6.9-1.4.9-2.3 0-.9-.3-1.6-.9-2.2-.6-.6-1.3-.9-2.2-.9-.9 0-1.6.3-2.3.9l-9.3 9.3c-1 1-1.5 2.3-1.5 3.7 0 1.4.5 2.7 1.5 3.7s2.2 1.5 3.7 1.5c1.4 0 2.7-.5 3.7-1.5l6.4-6.3 1.5 1.5-6.3 6.4c-1.4 1.4-3.1 2.1-5.1 2.1-2 0-3.7-.7-5.1-2.1-1.4-1.4-2.1-3.1-2.1-5.1 0-2 .7-3.7 2.1-5.1l9.3-9.3c1-1 2.3-1.5 3.7-1.5 1.4 0 2.7.5 3.7 1.5s1.5 2.2 1.5 3.7-.8 2.4-1.8 3.4z" fill-rule="nonzero"></path></symbol><symbol viewBox="0 0 15 15" id="icon-filter"><path d="M2 3.5h11M9.5 5V2M5.5 9V6M9.5 13v-3M2 11.5h11M2 7.5h11"></path></symbol><symbol viewBox="0 0 16 15" id="icon-fontsize"><path d="M3.136 6.288H4.2L6.4 12H5.328l-.536-1.512h-2.28L1.976 12H.944l2.192-5.712zm-.352 3.44h1.744l-.856-2.456h-.024l-.864 2.456zm7.404-1.268l1.452-3.996h.024l1.428 3.996h-2.904zm.852-5.028L7.704 12h1.164l.96-2.58h3.624l.936 2.58h1.26L12.3 3.432h-1.26z"></path></symbol><symbol viewBox="0 0 512 512" id="icon-image"><path d="M160 32h192l21.3 64H512v384H0V96h138.7L160 32zm213.3 96h-23l-7.3-21.9L328.9 64H183.1l-14 42.1-7.4 21.9H32v320h448V128H373.3zM256 176a112 112 0 1 1 0 224 112 112 0 1 1 0-224zm80 112a80 80 0 1 0-160 0 80 80 0 1 0 160 0z"></path></symbol><symbol viewBox="0 0 40 40" id="icon-instagram"><path d="M28.229 12.594v2.469a.824.824 0 0 1-.824.823h-2.468a.822.822 0 0 1-.823-.823v-2.469c0-.454.368-.823.823-.823h2.468a.825.825 0 0 1 .824.823zM20 24.114a4.115 4.115 0 1 0 0-8.23 4.115 4.115 0 0 0 0 8.23zm6.366-5.76h1.862v9.052a.823.823 0 0 1-.824.822h-14.81a.823.823 0 0 1-.824-.822v-9.052h1.863A6.567 6.567 0 0 0 13.417 20a6.582 6.582 0 0 0 6.582 6.582A6.582 6.582 0 0 0 26.581 20a6.515 6.515 0 0 0-.215-1.646zM39.5 20c0 5.383-1.904 9.979-5.713 13.787C29.979 37.596 25.382 39.5 20 39.5c-5.383 0-9.979-1.904-13.787-5.713C2.404 29.979.5 25.383.5 20c0-5.382 1.904-9.979 5.713-13.787C10.022 2.404 14.617.5 20 .5c5.382 0 9.978 1.904 13.787 5.713C37.596 10.021 39.5 14.618 39.5 20zm-8.803-8.228a2.468 2.468 0 0 0-2.468-2.468H11.771a2.468 2.468 0 0 0-2.468 2.468v16.456a2.468 2.468 0 0 0 2.468 2.469h16.458a2.468 2.468 0 0 0 2.468-2.469V11.772z" fill-rule="nonzero"></path></symbol><symbol viewBox="0 0 565.2 509.2" id="icon-layoutplan-balcony"><g class="hover-elements" fill="none"><path class="elevator" d="M472.1 94.4h26.8v26.8h-26.8zM472.1 379.3h26.8v26.8h-26.8z"></path><path class="wardrobe" d="M385 388h36v25h-36zM385 86h36v25h-36z"></path><path class="bathroom-men" d="M240 12h30v30h-30zM319 468h30v30h-30z"></path><path class="bathroom-women" d="M334 12h30v30h-30zM269 468h30v30h-30z"></path></g><text transform="translate(161.002 259.2)" data-lang-en="gallery" fill="#a0a0a0" font-family="Neue Haas Grotesk W05" font-size="12">GALERIE</text><g fill="none" stroke="#000"><path d="M429.4 354.9c0-6-2.2-14.3-16.2-14.3-46.7 0-84.6-41.5-85-92.9.4-51.4 38.3-92.9 85-92.9 14 0 16.2-8.5 16.2-11.9M153.9 355.6h29.6M153.9 352h29.6M153.9 348.3h29.6M154 344.7h29.5M154 341.1h29.5M192 366.3v29.1M195.6 366.3v29.1M199.3 366.3v29.1M202.9 366.4v28.9M206.5 366.4v28.9M210.1 366.4v28.9M213.8 366.4v28.9M217.4 366.4v28.9M221 366.4v28.9M224.7 366.4v28.9M153.9 153.6h29.6M153.9 157.2h29.6M153.9 160.8h29.6M154 164.5h29.5M154 168.1h29.5M192 142.8v-29M195.6 142.8v-29M199.3 142.8v-29M202.9 142.8v-28.9M206.5 142.8v-28.9M210.1 142.8v-28.9M213.8 142.8v-28.9M217.4 142.8v-28.9M221 142.8v-28.9M224.7 142.8v-28.9M268.8 92.3h7.7v7.7h-7.7zM310.5 92.3h7.7v7.7h-7.7z"></path><path d="M502.6 375.6h-34.2v30.5h-5.3v-41.4c11.3-5.5 21.7-12.6 30.9-21.1 1.2-1.1 2.2-2.5 3-4l67.6-12v181.2H.5V.5h564.2v160.9h-67.6c-.8-2-2-3.8-3.6-5.3-9-8.5-19.3-15.6-30.3-21.3V95.2h5.3v29.7h34.2V50.2h-157v-4h36.9v-39h-67.9v39H332v4h-72.5v-4h19.1v-39h-48v39h15.3v4h-15.3v63.6h-76.7v84.1H190v3.8h-36.1v105.6H190v3.8h-36.1v84.1h76.7V459h52.9v3.8h-19.7v40.3h40.8v-40.3h-6.4V459h27.3v3.8h-17v40.3H359v-40.3h-18.9V459h162.5v-83.4z"></path><path d="M183.5 337.8h47v28.5h-47zM183.5 142.8h47v28.5h-47zM235.5 201.8v-3.9h-31v3.9h27.2v105.6h-27.2v3.8h31v-3.8zM314.1 342.8c-10.1-9.4-18.7-20.4-25.3-32.6l-11.1 5.3c6.3 14.1 14.8 27.1 25.1 38.7l11.3-11.4zM315 156.6l-12.8-12.8c-10.3 11.6-18.7 24.8-25 39l12.8 6.1c6.6-12 15-22.9 25-32.3zM362 384.9h80.4v21.2h5.3V371c-13.9 4.7-28.5 7.1-43.2 7.1-28.5.1-56.3-9-79.2-26L313 364.4c12.9 11.8 28.1 21 44.6 26.9v14.8h4.5l-.1-21.2zM362 95.2h-4.5V106c-16.8 6-32.1 15.3-45.2 27.4l13.8 13.8c34.8-26.3 80.4-33.4 121.6-18.9V95.2h-5.3v18.9H362V95.2zM273.8 251.7c.1-17 3.5-33.9 10-49.7l-11.8-5.6c-11.4 34.3-11.3 71.3.3 105.5l10.3-4.9c-5.7-14.4-8.7-29.8-8.8-45.3zM268.8 395h7.7v7.7h-7.7zM310.5 395h7.7v7.7h-7.7zM491.8 154.6c-1 2.6-2.9 4.7-5.3 6-3.7 2-8.3 1.8-11.8-.6-39.3-26.6-91.7-22.9-126.7 9.1M346.8 328.7c35.4 31.8 87.8 35.9 127.8 9.9 3.5-2.3 8.1-2.5 11.8-.5 2.8 1.5 4.9 4.1 5.7 7.1M338.2 179.1c-17.1 20-26.5 45.4-26.5 71.6.1 24.9 9.1 49 25.3 67.9"></path></g><g fill="#a0a0a0"><path d="M254.5 18.3c.8 0 1.4-.6 1.4-1.4s-.6-1.4-1.4-1.4c-.8 0-1.4.6-1.4 1.4 0 .7.7 1.4 1.4 1.4zM254.5 19.5c-3.5 0-3.7 3.9-3.7 10.3 0 .3.3.6.6.6h1.1v7.9c0 .3.3.6.6.6s.6-.3.6-.6v-8.5c0-.3-.3-.6-.6-.6H252c0-6.8.6-8.5 2.5-8.5s2.5 1.8 2.5 8.5h-1c-.3 0-.6.3-.6.6v8.5c0 .3.3.6.6.6s.6-.3.6-.6v-7.9h1.1c.3 0 .6-.3.6-.6 0-6.4-.3-10.3-3.8-10.3zM348.6 18.3c.8 0 1.4-.6 1.4-1.4s-.6-1.4-1.4-1.4-1.4.6-1.4 1.4c0 .7.6 1.4 1.4 1.4zM353.5 31.6c-.9-6.5-1.7-12.1-4.9-12.1s-3.9 5.5-4.8 11.9l-.2 1.4c0 .2 0 .3.1.5.1.1.3.2.5.2h2.5v4.8c0 .3.3.6.6.6s.6-.3.6-.6v-5.4c0-.3-.3-.6-.6-.6h-2.4l.1-.8c.8-5.3 1.5-10.8 3.6-10.8s2.9 5.6 3.7 11.1l.1.5H350c-.2 0-.3.1-.4.2-.1.1-.2.3-.2.4v5.4c0 .3.3.6.6.6s.6-.3.6-.6v-4.8h2.5c.2 0 .3-.1.5-.2.1-.1.2-.3.1-.5l-.2-1.2zM333.3 475.5c.8 0 1.4-.6 1.4-1.4s-.6-1.4-1.4-1.4-1.4.6-1.4 1.4.6 1.4 1.4 1.4zM333.3 476.7c-3.5 0-3.7 3.9-3.7 10.3 0 .3.3.6.6.6h1.1v7.9c0 .3.3.6.6.6s.6-.3.6-.6V487c0-.3-.3-.6-.6-.6h-1.1c0-6.8.6-8.5 2.5-8.5s2.5 1.8 2.5 8.5h-1.1c-.3 0-.6.3-.6.6v8.5c0 .3.3.6.6.6s.6-.3.6-.6v-7.9h1.1c.3 0 .6-.3.6-.6 0-6.4-.2-10.3-3.7-10.3zM283.7 475.5c.8 0 1.4-.6 1.4-1.4s-.6-1.4-1.4-1.4-1.4.6-1.4 1.4.7 1.4 1.4 1.4zM288.6 488.8c-.9-6.5-1.7-12.1-4.9-12.1s-3.9 5.5-4.8 11.9l-.2 1.5c0 .2 0 .3.1.5.1.1.3.2.5.2h2.5v4.8c0 .3.3.6.6.6s.6-.3.6-.6v-5.4c0-.3-.3-.6-.6-.6H280l.1-.8c.8-5.3 1.5-10.8 3.6-10.8s2.9 5.6 3.7 11l.1.5h-2.4c-.2 0-.3.1-.4.2s-.2.3-.2.4v5.4c0 .3.3.6.6.6s.6-.3.6-.6v-4.8h2.5c.2 0 .3-.1.5-.2.1-.1.2-.3.1-.5l-.2-1.2zM415 99.1c-2.5 0-8.8-3.2-12.2-3.4.1-1.6 2.7-1.8 2.7-4.1 0-1.4-1.1-2.6-2.6-2.7h-.1c-1.4.1-2.6 1.3-2.6 2.7 0 .2.2.4.4.3.2 0 .3-.2.3-.3-.1-1 .7-1.9 1.7-2s1.9.7 2 1.7v.3c0 2.3-2.6 1.9-2.7 4.1-3.4.3-9.3 3.3-11.9 3.3-2.1 0-3.8 1.7-3.8 3.8 0 2.1 1.7 3.8 3.8 3.8 7 0 7-.5 12.4-.5s5.4.5 12.4.5c2.1 0 3.8-1.7 3.8-3.8.1-2.1-1.6-3.8-3.6-3.7zm0 6.1c-7 0-6.9-.5-12.4-.5-6.8 0-5.5.5-12.4.5-1.3-.1-2.4-1.2-2.3-2.6.1-1.2 1-2.2 2.3-2.3 3.3 0 8.8-3.2 12.1-3.2s9.2 3.2 12.7 3.2c1.3.1 2.4 1.2 2.3 2.6-.1 1.3-1.1 2.3-2.3 2.3zM416.3 401.2c-2.5 0-8.8-3.2-12.2-3.4.1-1.6 2.7-1.9 2.7-4.1 0-1.4-1.1-2.6-2.6-2.7h-.1c-1.4.1-2.6 1.3-2.6 2.7 0 .2.2.4.4.4s.4-.2.4-.4c-.1-1 .7-1.9 1.7-2s1.9.7 2 1.7v.3c0 2.3-2.6 1.9-2.7 4.1-3.4.3-9.3 3.3-11.9 3.3-2.1.1-3.7 1.9-3.6 4 .1 1.9 1.6 3.5 3.6 3.6 7 0 7-.5 12.4-.5s5.4.5 12.3.5c2.1-.1 3.7-1.9 3.6-4 .1-1.9-1.5-3.4-3.4-3.5zm0 6.2c-7 0-6.9-.5-12.3-.5-6.8 0-5.5.5-12.4.5-1.3.1-2.5-.9-2.6-2.3-.1-1.3.9-2.5 2.3-2.6h.3c3.3 0 8.8-3.2 12.1-3.2s9.2 3.2 12.7 3.2c1.3-.1 2.5.9 2.6 2.3.1 1.3-.9 2.5-2.3 2.6h-.4zM483.3 108.9l-3.7-3c0 5.7.5 7.7.5 9.1 0 .4-.4.8-.8.8s-.8-.4-.8-.8c0-1.4.5-3.4.5-9.1l-3.7 3c-.1.1-.4-.1-.2-.3 2.6-2.1 4.1-5.3 4.2-8.6 0-.1 0-.1.1-.1s.1 0 .1.1c.1 3.4 1.6 6.5 4.2 8.6 0 .1-.3.4-.4.3zM487.9 106.7l3.7 3c0-5.7-.5-7.7-.5-9.1 0-.4.3-.8.7-.9.4 0 .8.3.9.7v.2c0 1.4-.5 3.4-.5 9.1l3.7-3.1c.2-.1.4.1.2.3-2.6 2.1-4.1 5.3-4.2 8.7 0 .1-.1.1-.1.1s-.1 0-.1-.1c-.1-3.3-1.6-6.5-4.2-8.6-.1-.2.2-.4.4-.3zM486.1 99.4c0-.3-.2-.5-.5-.5s-.5.2-.5.5v15.8c0 .3.2.5.5.5s.5-.2.5-.5V99.4zM483.3 393.7l-3.7-3c0 5.7.5 7.7.5 9.1 0 .4-.3.8-.7.9-.4 0-.8-.3-.9-.7v-.2c0-1.4.5-3.4.5-9.1l-3.7 3c-.1.1-.4-.1-.2-.3 2.6-2.1 4.1-5.3 4.2-8.6 0-.1.2-.1.2 0 .1 3.4 1.6 6.5 4.2 8.6 0 .2-.3.5-.4.3zM487.9 391.6l3.7 3c0-5.7-.5-7.7-.5-9.1 0-.4.3-.8.7-.9.4 0 .8.3.9.7v.2c0 1.4-.5 3.4-.5 9.1l3.7-3.1c.1-.1.4.1.2.3-2.6 2.1-4.1 5.3-4.2 8.6 0 .1-.1.1-.1.1s-.1 0-.1-.1c-.1-3.3-1.6-6.5-4.2-8.6-.1-.1.2-.4.4-.2zM486.1 384.3c0-.3-.2-.5-.5-.5s-.5.2-.5.5v15.8c0 .3.2.5.5.5s.5-.2.5-.5v-15.8z"></path></g><g fill="none" stroke="#a0a0a0"><path d="M472.1 94.4h26.8v26.8h-26.8zM472.1 379.3h26.8v26.8h-26.8z"></path></g></symbol><symbol viewBox="0 0 537.3 509.2" id="icon-layoutplan-first-gallery"><g class="hover-elements" fill="none"><path class="elevator" d="M468 96h26.8v26.8H468zM468 380h26.8v26.8H468z"></path><path class="wardrobe" d="M384 388h36v25h-36zM384 86h36v25h-36z"></path><path class="bathroom-men" d="M240 10h30v30h-30zM270 464h30v30h-30z"></path><path class="bathroom-women" d="M338 10h30v30h-30zM319 464h30v30h-30z"></path><path class="bathroom-accessible" d="M286 10h30v30h-30z"></path><path class="snacks" d="M303 80h30v30h-30zM303 390h30v30h-30z"></path><path class="drinks" d="M279 80h25v30h-25zM279 390h25v30h-25z"></path></g><g fill="#a0a0a0" font-family="Neue Haas Grotesk W05" font-size="12"><text transform="translate(28.501 44.1)"><tspan x="0" y="0">IONISCHER SAAL</tspan><tspan x="40.6" y="14.4">NORD</tspan></text><text transform="translate(37.242 255.365)">KÖNIGSSAAL</text><text transform="translate(30.801 460.1)"><tspan x="0" y="0">IONISCHER SAAL</tspan><tspan x="46.6" y="14.4">SÜD</tspan></text><text transform="translate(326.538 255.366)">MITTELLOGE</text></g><g fill="none" stroke="#000"><path d="M182 341.4h50.3v28.5H182zM182 131.6h50.3v28.5H182z"></path><circle cx="167.1" cy="468.4" r="5.6"></circle><circle cx="167.1" cy="439.2" r="5.6"></circle><path d="M152.3 359.2H182M152.3 355.5H182M152.3 351.9H182M152.4 348.3h29.5M152.4 344.6h29.5M152.3 156.5H182M152.3 152.9H182M152.3 149.2H182M152.4 145.6h29.5M152.4 142h29.5M58.4 177.5h35.3M58.5 173.9h35.2M58.5 170.2h35.1M58.5 166.6h35.1M58.5 163h35.1M58.5 159.4h35.1M58.5 155.7h35.1M58.5 152.1h35.1M58.5 148.5h35.1M58.5 144.8h35.1M58.5 141.2h35.1M58.5 137.6h35.1M58.5 133.9h35.1M58.5 130.3h35.1M58.5 126.7h35.1M58.5 123.1h35.1M58.5 119.4h35.1M58.5 115.8h35.1M58.5 112.2h35.1M58.5 108.5h35.1M58.5 104.9h35.1M58.5 101.3h35.1M58.5 97.7h35.1M58.5 94h35.1M58.5 90.4h35.1M58.5 86.8h35.1M58.5 83.1h35.1M193.4 369.9v29M197 369.9v29M200.7 369.9v29M204.3 370v28.9M207.9 370v28.9M211.6 370v28.9M215.2 370v28.9M218.8 370v28.9M222.5 370v28.9M226.1 370v28.9M193.4 103.4v28.2M197 103.4v28.2M200.7 103.4v28.2M204.3 103.5v28.1M207.9 103.5v28M211.6 103.5v28M215.2 103.5v28M218.8 103.5v28M222.5 103.5v28M226.1 103.5v28"></path><circle cx="167.1" cy="63.4" r="5.6"></circle><circle cx="167.1" cy="34.2" r="5.6"></circle><path d="M228.5 70.3h3.8v4.3h-3.8zM125.8 181.7v7.7h18.8v54.5h7.7v-54.5h11v-3.8h-11v-82.2h80V89.1h-3.8v6.7H125.8v7.6h18.8v78.3zM177.9 313h35.2v3.8h-35.2z"></path><path d="M177.9 185.6h35.2v3.8h-35.2zM234.8 189.4v-3.8h-7.2v3.8h3.3v29.8h3.9zM230.9 283.2V313h-3.3v3.8h7.2v-33.6zM232.3 406.6v-7.7h-80v-82.1h11V313h-11v-54.5h-7.7V313h-18.8v7.7h18.8v78.2h-18.8v7.7h102.7v11h3.8zM228.5 432.1h3.8v4.3h-3.8zM93.7 181.7V79.5h3.9v16.3h13.7v7.6H97.6v78.3h13.7v7.7H40.8v-7.7h13.7v-78.3H40.8v-7.6h13.7V79.5h3.9V181.7zM58.4 324.9h35.3M58.5 328.5h35.2M58.5 332.1h35.1M58.5 335.8h35.1M58.5 339.4h35.1M58.5 343h35.1M58.5 346.7h35.1M58.5 350.3h35.1M58.5 353.9h35.1M58.5 357.5h35.1M58.5 361.2h35.1M58.5 364.8h35.1M58.5 368.4h35.1M58.5 372.1h35.1M58.5 375.7h35.1M58.5 379.3h35.1M58.5 383h35.1M58.5 386.6h35.1M58.5 390.2h35.1M58.5 393.9h35.1M58.5 397.5h35.1M58.5 401.1h35.1M58.5 404.7h35.1M58.5 408.4h35.1M58.5 412h35.1M58.5 415.6h35.1M58.5 419.2h35.1M93.7 320.7v102.2h3.9v-16.3h13.7v-7.7H97.6v-78.2h13.7V313H40.8v7.7h13.7v78.2H40.8v7.7h13.7v16.3h3.9V320.7z"></path><path d="M297.4 42.7v3.8h33.8v-3.8h-4.4V8.2h52.7v34.5h-33.8v3.8h183.4v49.2h-8.2v3.5h11.8v33.6h-11.8v5.7c8.1 1.6 14.2 9.1 14.2 18.1 0 4.3-1.4 8.5-4.1 11.9l5.8 1.2V.5H.5v508.2h536.3V331.5l-6.3 1.3c2.9 3.4 4.4 7.7 4.4 12.2.1 7.4-4.3 14.2-11.2 17.1v6.5h9.5V399h-9.5v7.8h5.4v23.8h-44.3v24.6H340.5v3.8h18.7v40.3h-50V459H326v-3.8h-27v3.8h6.3v40.3H265V459h19.5v-3.8h-52.2v-4.3h-3.8V501H19.7v-94.4h6.6v-7.7h-6.6v-78.3h6.6V313h-6.6V189.4h6.6v-7.7h-6.6v-78.3h6.6v-7.7h-6.6V8.2h208.8v47.6h3.8v-9.3h11.4v-3.8h-11.4V8.2h44v34.5h-18.1v3.8h24.6v-3.8h-2.7V8.2h42.8v34.5h-25.5z"></path><path d="M460.4 95.8v39.8c11.5 5.8 24 13.3 33.2 22.1 1 1 1.9 2.2 2.6 3.4l4.6 1c-.5-1.8-.8-3.6-.8-5.4 0-5.4 2.3-10.6 6.4-14.2v-9.6h-3V99.3h10.2v-3.5h-15.1v30.3h-33.9V95.8h-4.2zM361.3 385.5V406.7h-4.5v-14.8c-54.5-19.2-94-75.8-94-142.6s39.5-123.3 94-142.6V95.8h4.5v18.9h80.4V95.8h5.3V129c-13.9-4.9-28.5-7.4-43.2-7.4-71.9 0-130.2 58.4-130.7 130.7.5 69.9 58.9 126.5 130.7 126.5 14.7 0 29.3-2.4 43.2-7.1v35.1h-5.3v-21.2l-80.4-.1zM509.3 368.7v-7.4c-5.9-3.3-9.5-9.5-9.5-16.3 0-2 .3-3.9.9-5.8l-4.5 1c-.6 1.5-1.6 2.9-2.8 4-9.2 8.4-20.5 15.6-31.9 21.2v41.4h2.8v-30.5h34.3v30.4H513v-7.8h-3.7 3.3-10.9v-30.2h7.6z"></path><path d="M490.7 155.3c-.9 2.6-2.8 4.7-5.2 6-3.8 2.1-8.4 2-12.1-.3-16.7-11.5-36.6-17.7-56.9-17.7-27.7 0-53.8 11.3-73.4 31.7-19.7 20.7-30.8 48.2-30.8 76.8.1 27.8 11.2 54.5 30.8 74.2 34.6 35 89 40.8 130.1 13.7 3.5-2.3 8-2.5 11.7-.5 2.8 1.5 4.8 4.1 5.6 7.1M499.4 162.1c-1.6 7.7 31.6 14.8 33.2 7.1M499.4 339.2c-1.6-7.7 31.6-14.8 33.2-7.1"></path></g><g fill="#a0a0a0"><path d="M300.6 396.1c.1-.1.2-.3.1-.5s-.3-.3-.4-.3h-15.1c-.2 0-.4.1-.4.3-.1.2 0 .4.1.5l7.4 8v9.2h-4.4c-.3 0-.5.2-.5.5s.2.5.5.5h9.8c.3 0 .5-.2.5-.5s-.2-.5-.5-.5h-4.4v-9.2l7.3-8zm-1.5.2l-6.5 7-6.5-7h13z"></path><g class="snacks" fill="none" stroke="#a0a0a0"><path d="M309.2 405c-.5.9-2 4.5-1.7 5.3.2.4.9.5 1.3.4 1.1-.3 3.7-1.5 3.9-2-.4-.2-2.7-2.4-3.5-3.7z"></path><path d="M313.6 409c.4-.1 2.6-1.1 2.5-1.4-.5-1-2-6.8-2-6.8-1.2 0-5.3 2.5-5.4 2.9-.3 1.1 4.2 5.7 4.9 5.3zm14-4.1c.5.9 2 4.5 1.7 5.3-.2.4-.9.5-1.3.4-1.1-.3-3.7-1.5-3.9-2 .4-.3 2.8-2.4 3.5-3.7z"></path><path d="M323.2 408.9c-.3-.2-2.5-1.1-2.4-1.4.5-1 2-6.8 2-6.8 1.2 0 5.3 2.5 5.4 2.9.3 1.1-4.2 5.7-5 5.3z"></path><path d="M320.4 408.3c.5-.1 2.4-7.6 2.4-7.7.2-1.1.2-1.8-.1-1.8-3.1-.4-5.6-.3-8.6.1-.3 0-.2.8-.1 1.9 0 .2 1.9 7.7 2.4 7.7l4-.2z"></path></g><path d="M300.3 87.3c.1-.1.2-.3.1-.5s-.3-.3-.4-.3h-15.1c-.2 0-.4.1-.4.3-.1.2 0 .4.1.5l7.4 8v9.2h-4.4c-.3 0-.5.2-.5.5s.2.5.5.5h9.8c.2 0 .4-.2.4-.4 0-.3-.2-.5-.5-.5h-4.4v-9.2l7.4-8.1zm-1.4.2l-6.5 7-6.5-7h13z"></path><g class="snacks" fill="none" stroke="#a0a0a0"><path d="M309.2 95c-.5.9-2 4.5-1.7 5.3.2.4.9.5 1.3.4 1.1-.3 3.7-1.5 3.9-2-.4-.2-2.7-2.4-3.5-3.7z"></path><path d="M313.6 99c.4-.1 2.6-1.1 2.5-1.4-.5-1-2-6.8-2-6.8-1.2 0-5.3 2.5-5.4 2.9-.3 1.1 4.2 5.7 4.9 5.3zm14-4.1c.5.9 2 4.5 1.7 5.3-.2.4-.9.5-1.3.4-1.1-.3-3.7-1.5-3.9-2 .4-.3 2.8-2.4 3.5-3.7z"></path><path d="M323.2 98.9c-.3-.2-2.5-1.1-2.4-1.4.5-1 2-6.8 2-6.8 1.2 0 5.3 2.5 5.4 2.9.3 1.1-4.2 5.7-5 5.3z"></path><path d="M320.4 98.3c.5-.1 2.4-7.6 2.4-7.7.2-1.1.2-1.8-.1-1.8-3.1-.4-5.6-.3-8.6.1-.3 0-.2.8-.1 1.9 0 .2 1.9 7.7 2.4 7.7l4-.2z"></path></g><path d="M285.4 470.3c.8 0 1.4-.6 1.4-1.4s-.6-1.4-1.4-1.4-1.4.6-1.4 1.4.6 1.4 1.4 1.4zM285.4 471.5c-3.5 0-3.7 3.9-3.7 10.3 0 .3.3.6.6.6h1.1v7.9c0 .3.3.6.6.6s.6-.3.6-.6v-8.5c0-.3-.3-.6-.6-.6h-1.1c0-6.8.6-8.5 2.5-8.5s2.5 1.8 2.5 8.5h-1.1c-.3 0-.6.3-.6.6v8.5c0 .3.3.6.6.6s.6-.3.6-.6v-7.9h1.1c.3 0 .6-.3.6-.6 0-6.4-.2-10.3-3.7-10.3zM334.4 470.3c.8 0 1.4-.6 1.4-1.4s-.6-1.4-1.4-1.4-1.4.6-1.4 1.4.6 1.4 1.4 1.4zM339.3 483.6c-.9-6.5-1.7-12.1-4.9-12.1s-3.9 5.5-4.9 11.9l-.2 1.5c0 .2 0 .3.1.5.1.1.3.2.5.2h2.5v4.8c0 .3.3.6.6.6s.6-.3.6-.6V485c0-.3-.3-.6-.6-.6h-2.4l.1-.8c.8-5.3 1.5-10.8 3.7-10.8s2.9 5.6 3.7 11l.1.5h-2.4c-.2 0-.3.1-.4.2s-.2.3-.2.4v5.4c0 .3.3.6.6.6s.6-.3.6-.6v-4.8h2.5c.2 0 .3-.1.5-.2.1-.1.2-.3.1-.5l-.2-1.2zM254.4 16.2c.8 0 1.4-.6 1.4-1.4s-.6-1.4-1.4-1.4c-.8 0-1.4.6-1.4 1.4s.6 1.4 1.4 1.4zM254.4 17.5c-3.5 0-3.7 3.9-3.7 10.3 0 .3.3.6.6.6h1.1v7.9c0 .3.3.6.6.6s.6-.3.6-.6v-8.5c0-.3-.3-.6-.6-.6h-1.1c0-6.8.6-8.5 2.5-8.5s2.5 1.8 2.5 8.5h-1.1c-.3 0-.6.3-.6.6v8.5c0 .3.3.6.6.6s.6-.3.6-.6v-7.9h1.1c.3 0 .6-.3.6-.6 0-6.4-.2-10.3-3.7-10.3zM352.6 16.2c.8 0 1.4-.6 1.4-1.4 0-.8-.6-1.4-1.4-1.4s-1.4.6-1.4 1.4.7 1.4 1.4 1.4zM357.5 29.5c-.9-6.5-1.7-12.1-4.9-12.1s-3.9 5.5-4.8 11.9l-.2 1.5c0 .2 0 .3.1.5.1.1.3.2.5.2h2.5v4.8c0 .3.3.6.6.6s.6-.3.6-.6v-5.4c0-.3-.3-.6-.6-.6h-2.4l.1-.8c.8-5.3 1.5-10.8 3.6-10.8s2.9 5.6 3.7 11l.1.5H354c-.2 0-.3.1-.4.2s-.2.3-.2.4v5.4c0 .3.3.6.6.6s.6-.3.6-.6v-4.7h2.5c.2 0 .3-.1.5-.2.1-.1.2-.3.1-.5l-.2-1.3z"></path><circle cx="300.1" cy="20.4" r="1.4"></circle><path d="M308.1 34.2l-1.6-3.8c-.1-.2-.3-.3-.5-.3h-5.3v-6.8c0-.3-.2-.5-.5-.5s-.5.2-.5.5v3c-1.1.1-2.2.6-3 1.4-1.9 1.9-1.9 4.9-.1 6.9.9.9 2.2 1.5 3.5 1.5 2.7 0 4.9-2.2 4.9-4.8h.7l1.5 3.5c.1.2.3.3.5.3h.2c.3-.1.4-.4.3-.6 0-.2-.1-.2-.1-.3zm-4.1-3.1c0 1-.4 2-1.1 2.7-1.5 1.4-3.9 1.4-5.4 0-1.5-1.5-1.5-3.9 0-5.4.6-.6 1.4-1 2.3-1.1v3.3c0 .3.2.5.5.5h3.7zM414.8 402.4c-2.5 0-8.8-3.2-12.2-3.4.1-1.6 2.7-1.9 2.7-4.1 0-1.4-1.1-2.6-2.6-2.7h-.1c-1.4.1-2.6 1.3-2.6 2.7 0 .2.2.4.4.3.2 0 .3-.2.3-.3 0-1 .8-1.9 1.9-1.9 1 0 1.9.8 1.9 1.9 0 2.3-2.6 1.9-2.7 4.1-3.4.3-9.3 3.3-11.9 3.3-2.1 0-3.8 1.7-3.8 3.8 0 2.1 1.7 3.8 3.8 3.8 7 0 7-.5 12.4-.5s5.4.5 12.4.5c2.1 0 3.8-1.7 3.8-3.8 0-2.1-1.6-3.7-3.7-3.7zm0 6.2c-7 0-6.9-.5-12.4-.5-6.8 0-5.5.5-12.4.5-1.3.1-2.5-.9-2.6-2.3-.1-1.3.9-2.5 2.3-2.6h.3c3.3 0 8.8-3.2 12.1-3.2s9.2 3.2 12.7 3.2c1.3-.1 2.5.9 2.6 2.3.1 1.3-.9 2.5-2.3 2.6h-.3zM414.7 100.8c-2.5 0-8.8-3.2-12.2-3.4.1-1.6 2.7-1.8 2.7-4.1 0-1.4-1.1-2.6-2.5-2.7h-.1c-1.4.1-2.6 1.2-2.6 2.7 0 .2.2.4.4.4s.4-.2.4-.4c-.1-1 .7-1.9 1.7-2s1.9.7 2 1.7v.3c0 2.3-2.6 1.9-2.7 4.1-3.4.3-9.3 3.3-11.9 3.3-2.1.1-3.7 1.9-3.6 4 .1 1.9 1.6 3.5 3.6 3.6 7 0 7-.5 12.4-.5s5.4.5 12.3.5c2.1 0 3.8-1.7 3.8-3.8.1-2.1-1.6-3.7-3.7-3.7zm0 6.2c-7 0-6.9-.5-12.3-.5-6.8 0-5.5.5-12.4.5-1.3.1-2.5-.9-2.6-2.3-.1-1.3.9-2.5 2.3-2.6h.3c3.3 0 8.8-3.2 12.1-3.2s9.2 3.2 12.7 3.2c1.3-.1 2.5.9 2.6 2.3.1 1.3-.9 2.5-2.3 2.6h-.4zM479.3 110.3l-3.7-3c0 5.7.5 7.7.5 9.1 0 .4-.3.8-.7.9-.4 0-.8-.3-.9-.7v-.2c0-1.4.5-3.4.5-9.1l-3.7 3c-.1.1-.4-.1-.2-.3 2.6-2.1 4.1-5.3 4.2-8.6 0-.1.1-.1.1-.1s.1 0 .1.1c.1 3.3 1.6 6.5 4.2 8.6 0 .1-.2.4-.4.3zM483.9 108.1l3.7 3c0-5.7-.5-7.7-.5-9.1 0-.4.3-.8.7-.9.4 0 .8.3.9.7v.2c0 1.4-.5 3.4-.5 9.1l3.7-3.1c.2-.1.4.1.2.3-2.6 2.1-4.1 5.3-4.2 8.7 0 .1-.2.1-.2 0-.1-3.3-1.6-6.5-4.2-8.6 0-.2.2-.4.4-.3zM482.1 100.8c0-.3-.2-.5-.5-.5s-.5.2-.5.5v15.8c0 .3.2.5.5.5s.5-.2.5-.5v-15.8zM479.4 394.4l-3.7-3c0 5.7.5 7.7.5 9.1 0 .4-.4.8-.8.8s-.8-.4-.8-.8c0-1.4.5-3.4.5-9.1l-3.7 3c-.1.1-.4-.1-.2-.3 2.6-2.1 4.1-5.3 4.2-8.6 0-.1 0-.1.1-.1s.1 0 .1.1c.1 3.4 1.6 6.5 4.2 8.6 0 .1-.3.4-.4.3zM484 392.2l3.7 3c0-5.7-.5-7.7-.5-9.1 0-.4.3-.8.7-.9.4 0 .8.3.9.7v.2c0 1.4-.5 3.4-.5 9.1l3.7-3.1c.2-.1.4.1.2.3-2.6 2.1-4.1 5.3-4.2 8.6 0 .1-.1.1-.1.1s-.1 0-.1-.1c-.1-3.3-1.6-6.5-4.2-8.6-.1-.1.2-.3.4-.2zM482.2 384.9c0-.3-.2-.5-.5-.5s-.5.2-.5.5v15.8c0 .3.2.5.5.5s.5-.2.5-.5v-15.8z"></path></g><g fill="none" stroke="#a0a0a0"><path d="M468.2 95.8H495v26.8h-26.8zM468.2 379.9H495v26.8h-26.8z"></path></g></symbol><symbol viewBox="0 0 565.2 509.2" id="icon-layoutplan-gallery"><g class="hover-elements" fill="none"><path class="elevator" d="M472 96h26.8v26.8H472zM472 380h26.8v26.8H472z"></path><path class="wardrobe" d="M385 388h36v25h-36zM385 86h36v25h-36z"></path><path class="bathroom-men" d="M248 12h30v30h-30zM328 469h31v30h-31z"></path><path class="bathroom-women" d="M342 12h30v30h-30zM279 469h30v30h-30z"></path></g><g fill="none" stroke="#000"><path d="M153.9 355.6h29.6M153.9 352h29.6M153.9 348.3h29.6M192 366.3v29.1M195.6 366.3v29.1M199.2 366.3v29.1M202.9 366.4v28.9M206.5 366.4v28.9M210.1 366.4v28.9M213.8 366.4v28.9M217.4 366.4v28.9M221 366.4v28.9M224.7 366.4v28.9M153.9 153.6h29.6M153.9 157.2h29.6M153.9 160.8h29.6M192 142.8v-29M195.6 142.8v-29M199.2 142.8v-29M202.9 142.8v-28.9M206.5 142.8v-28.9M210.1 142.8v-28.9M213.8 142.8v-28.9M217.4 142.8v-28.9M221 142.8v-28.9M224.7 142.8v-28.9M273.8 252.7v-1-1 2zM288.9 310.1l-11.2 5.3c6.3 14.1 14.8 27.1 25.1 38.7l11.4-11.3c-10.2-9.5-18.7-20.5-25.3-32.7zM277.3 182.9l12.9 6.1c6.6-12 15-22.9 24.9-32.3l-12.8-12.8c-10.3 11.6-18.8 24.7-25 39zM362 114.1V95.2h-4.5V106c-16.8 6-32.1 15.3-45.2 27.4l13.8 13.8c34.8-26.3 80.4-33.4 121.6-18.9V95.2h-5.3v18.9H362zM273.8 251.7v1-2 1c.1-17 3.5-33.9 10-49.7l-11.8-5.6c-11.4 34.3-11.3 71.3.4 105.5l10.3-4.9c-5.8-14.4-8.8-29.8-8.9-45.3zM362 384.9v21.2h-4.5v-14.8c-16.5-5.9-31.6-15-44.5-26.9l12.3-12.3c22.9 17 50.7 26.1 79.2 26 14.7 0 29.3-2.4 43.2-7.1v35.1h-5.3v-21.2H362zM491.5 154.8c-1 2.6-2.8 4.7-5.3 6-3.7 2-8.3 1.8-11.8-.6-41.5-28.2-97.2-22.2-131.9 14-20 20.6-31.1 48.2-31.2 76.8.3 58.2 47.8 105.2 106 104.9 20.2-.1 39.9-6 56.9-17 3.5-2.3 8.1-2.5 11.8-.5 2.8 1.5 4.9 4.1 5.7 7.1"></path></g><g fill="none" stroke="#a0a0a0"><path d="M447.7 398.3"></path></g><g fill="#a0a0a0"><path d="M415.2 99.7c-2.5 0-8.8-3.2-12.2-3.4.1-1.6 2.7-1.9 2.7-4.1 0-1.4-1.1-2.6-2.6-2.7h-.1c-1.4.1-2.6 1.3-2.6 2.7 0 .2.2.4.4.3.2 0 .3-.2.3-.3 0-1 .8-1.9 1.9-1.9 1 0 1.9.8 1.9 1.9 0 2.3-2.6 1.9-2.7 4.1-3.4.3-9.3 3.3-11.9 3.3-2.1.1-3.7 1.9-3.6 4 .1 1.9 1.6 3.5 3.6 3.6 7 0 7-.5 12.4-.5s5.4.5 12.4.5c2.1-.1 3.7-1.9 3.6-4 0-1.8-1.5-3.4-3.5-3.5zm0 6.2c-7 0-6.9-.5-12.4-.5-6.8 0-5.5.5-12.4.5-1.3-.1-2.4-1.2-2.3-2.6.1-1.2 1-2.2 2.3-2.3 3.3 0 8.8-3.2 12.1-3.2s9.2 3.2 12.7 3.2c1.3.1 2.4 1.2 2.3 2.6-.1 1.3-1 2.2-2.3 2.3zM417 401.3c-2.5 0-8.8-3.2-12.2-3.4.1-1.6 2.7-1.9 2.7-4.1 0-1.4-1.1-2.6-2.6-2.7h-.1c-1.4.1-2.6 1.3-2.6 2.7 0 .2.2.4.4.3.2 0 .3-.2.3-.3 0-1 .8-1.9 1.9-1.9 1 0 1.9.8 1.9 1.9 0 2.3-2.6 1.9-2.7 4.1-3.4.3-9.3 3.3-11.9 3.3-2.1 0-3.8 1.7-3.8 3.8 0 2.1 1.7 3.8 3.8 3.8 7 0 7-.5 12.4-.5s5.4.5 12.4.5c2.1 0 3.8-1.7 3.8-3.8.1-2-1.6-3.7-3.7-3.7zm0 6.2c-7 0-6.9-.5-12.4-.5-6.8 0-5.5.5-12.4.5-1.3 0-2.4-1.1-2.4-2.4 0-1.3 1.1-2.4 2.4-2.4 3.3 0 8.8-3.2 12.1-3.2s9.2 3.2 12.7 3.2c1.3 0 2.4 1.1 2.4 2.4 0 1.3-1 2.4-2.4 2.4zM262.4 18.6c.8 0 1.4-.6 1.4-1.4s-.6-1.4-1.4-1.4c-.8 0-1.4.6-1.4 1.4 0 .8.7 1.4 1.4 1.4zM262.4 19.9c-3.5 0-3.7 3.9-3.7 10.3 0 .3.3.6.6.6h1.1v7.9c0 .3.3.6.6.6s.6-.3.6-.6v-8.5c0-.3-.3-.6-.6-.6h-1.1c0-6.8.6-8.5 2.5-8.5s2.5 1.8 2.5 8.5h-1.1c-.3 0-.6.3-.6.6v8.5c0 .3.3.6.6.6s.6-.3.6-.6v-7.9h1.1c.3 0 .6-.3.6-.6 0-6.4-.2-10.3-3.7-10.3zM356.9 18.6c.8 0 1.4-.6 1.4-1.4s-.6-1.4-1.4-1.4c-.8 0-1.4.6-1.4 1.4.1.8.7 1.4 1.4 1.4zM361.9 31.9c-.9-6.5-1.7-12.1-4.9-12.1s-3.9 5.5-4.8 11.9l-.2 1.4c0 .3.2.6.5.7h2.6v4.8c0 .3.3.6.6.6s.6-.3.6-.6v-5.4c0-.3-.3-.6-.6-.6h-2.4l.1-.8c.8-5.3 1.5-10.8 3.7-10.8s2.9 5.6 3.7 11.1l.1.5h-2.4c-.2 0-.3.1-.4.2-.1.1-.2.3-.2.4v5.4c0 .3.3.6.6.6s.6-.3.6-.6v-4.8h2.5c.2 0 .3-.1.5-.2.1-.1.2-.3.1-.5l-.3-1.2zM343.4 475.2c.8 0 1.4-.6 1.4-1.4 0-.8-.6-1.4-1.4-1.4-.8 0-1.4.6-1.4 1.4 0 .7.6 1.4 1.4 1.4zM343.4 476.4c-3.5 0-3.7 3.9-3.7 10.3 0 .3.3.6.6.6h1.1v7.9c0 .3.3.6.6.6s.6-.3.6-.6v-8.5c0-.3-.3-.6-.6-.6h-1.1c0-6.8.6-8.5 2.5-8.5s2.5 1.8 2.5 8.5h-1.1c-.3 0-.6.3-.6.6v8.5c0 .3.3.6.6.6s.6-.3.6-.6v-7.9h1.1c.3 0 .6-.3.6-.6 0-6.4-.3-10.3-3.7-10.3zM293.8 475.2c.8 0 1.4-.6 1.4-1.4s-.6-1.4-1.4-1.4-1.4.6-1.4 1.4c0 .7.6 1.4 1.4 1.4zM298.7 488.5c-.9-6.5-1.7-12.1-4.9-12.1s-3.9 5.5-4.8 11.9l-.2 1.4c0 .2 0 .3.1.5.1.1.3.2.5.2h2.5v4.8c0 .3.3.6.6.6s.6-.3.6-.6v-5.4c0-.3-.3-.6-.6-.6H290l.1-.8c.8-5.3 1.5-10.8 3.6-10.8s2.9 5.6 3.7 11l.1.5h-2.4c-.3 0-.6.2-.6.6v5.4c0 .3.3.6.6.6s.6-.3.6-.6v-4.8h2.5c.3 0 .6-.3.6-.6v-.1l-.1-1.1zM483.3 109.5l-3.7-3c0 5.7.5 7.7.5 9.1 0 .4-.3.8-.7.9-.4 0-.8-.3-.9-.7v-.2c0-1.4.5-3.4.5-9.1l-3.7 3c-.1.1-.4-.1-.2-.3 2.6-2.1 4.1-5.3 4.2-8.6 0-.1.2-.1.2 0 .1 3.4 1.6 6.5 4.2 8.6 0 .2-.3.4-.4.3zM487.9 107.3l3.7 3c0-5.7-.5-7.7-.5-9.1 0-.4.3-.8.7-.9.4 0 .8.3.9.7v.2c0 1.4-.5 3.4-.5 9.1l3.7-3.1c.2-.1.4.1.2.3-2.6 2.1-4.1 5.3-4.2 8.7 0 .1-.1.1-.1.1s-.1 0-.1-.1c-.1-3.3-1.6-6.5-4.2-8.6 0-.2.2-.4.4-.3zM486.1 100.1c0-.3-.2-.5-.5-.5s-.5.2-.5.5v15.8c0 .3.2.5.5.5s.5-.2.5-.5v-15.8zM483 393.9l-3.7-3c0 5.7.5 7.7.5 9.1 0 .4-.3.8-.7.9-.4 0-.8-.3-.9-.7v-.2c0-1.4.5-3.4.5-9.1l-3.7 3c-.1.1-.4-.1-.2-.3 2.6-2.1 4.1-5.3 4.2-8.6 0-.1.1-.1.1-.1s.1 0 .1.1c.1 3.3 1.6 6.5 4.2 8.6 0 .1-.3.4-.4.3zM487.6 391.7l3.7 3c0-5.7-.5-7.7-.5-9.1 0-.4.3-.8.7-.9.4 0 .8.3.9.7v.2c0 1.4-.5 3.4-.5 9.1l3.7-3.1c.1-.1.4.1.2.3-2.6 2.1-4.1 5.3-4.2 8.7 0 .1-.2.1-.2 0-.1-3.3-1.6-6.5-4.2-8.6-.1-.2.2-.4.4-.3zM485.8 384.4c0-.3-.2-.5-.5-.5s-.5.2-.5.5v15.8c0 .3.2.5.5.5s.5-.2.5-.5v-15.8z"></path></g><g fill="none" stroke="#a0a0a0"><path d="M472.1 95h26.8v26.8h-26.8zM471.8 379.4h26.8v26.8h-26.8z"></path></g><path d="M505.4.5H.5v508.2h564.2V327.4l-67.6 12-.2.5c-.6 1.2-1.4 2.2-2.4 3.2-.6.5-3.1 2.7-3.7 3.2-8.4 7.2-17.7 13.3-27.6 18.2V406h5.3v-30.3h33.9V459H345.8v3.8H359v40.3h-31.3v-40.3h3.4V459h-33v3.8h25.7v40.3h-60.1v-40.3h19.7V459h-52.8v-63.7h-76.7v-50.7h29.6v21.6h47v-28.5h-76.7v-24.9h85.8V196.5h-85.8v-25.1h76.7v-28.5h-47.1v21.6h-29.7v-50.7h76.7V50.2H254v-4h-15.2v-39h48v39h-19.1v4h72.4v-4h-17.3v-39h67.9v39h-36.9v4h148.7v75.3h-34.2V95.2H463v39.6c10.4 5.1 20 11.7 28.4 19.6 1.2 1.2 4.7 4.8 5.2 6.2l.3.8h67.6V.5h-59.1z" fill="none" stroke="#000"></path></symbol><symbol viewBox="0 0 521.6 508.4" id="icon-layoutplan-ground-floor"><g class="hover-elements" fill="none"><path class="elevator" d="M482 75h26.8v26.8H482zM482 355h26.8v26.8H482z"></path><path class="warm-snacks" d="M296 374h36v25h-36zM296 65h36v25h-36z"></path><path class="bathroom-men" d="M165 30h30v30h-30z"></path><path class="bathroom-women" d="M78 30h30v30H78z"></path></g><g fill="#a0a0a0" font-family="Neue Haas Grotesk W05" font-size="12"><text transform="rotate(-90 211.856 191.046)">ZUR TIEFGARAGE</text><text transform="translate(97.07 423.32)">CAPRICCIO-SAAL</text><text transform="translate(97.07 437.72)">(EINFÜHRUNGEN)</text><text transform="matrix(.97 0 0 1 205 247.38)">KÄFER</text><text transform="matrix(.97 0 0 1 189.868 261.78)">RESTAURANT</text><text transform="translate(180 503.84)">EINGANG MAXIMILIANSTRASSE</text></g><g fill="none" stroke="#000"><path d="M194.1 335.3h25.6m-25.6-3.6h25.6m-25.6-3.6h25.6m-25.5-3.7h25.5m-25.5-3.6h25.5M194.1 339h25.6m-25.6 3.7h25.6m-25.6 3.8h25.6M95 329.9h24m-24-3.6h24m-24-3.7h24M95.1 319H119m-23.9-3.6H119m-24-3.7h24m-23.9-3.6H119m-23.9-3.6H119m-24 29h24m-24 3.7h24M95 341h24m-24 18.4h24m-24-3.6h24m-24-3.7h24m-23.9-3.6H119m-23.9-3.6H119M95 363h24m-24 3.7h24m-24 3.8h24m123.2 3.5v-24.1m-3.6 24.1v-24.1M235 374v-24.1m-3.7 24v-24m-3.6 24v-24m18.2 24.1v-24.1m3.7 24.1v-24.1m3.8 24.1v-24.1m-59.3-226.8h25.6m-25.6 3.6h25.6m-25.6 3.6h25.6m-25.5 3.7h25.5m-25.5 3.6h25.5m-25.6-18.2h25.6m-25.6-3.7h25.6m-25.6-3.8h25.6M94.9 147.5h34.5m-34.5 3.6h34.5m-34.5 3.7h34.5M95 158.4h34.3M95 162h34.3m-34.4-18.1h34.5m-34.5-3.8h34.5m-34.5-3.8h34.5m112.1-51.1V108m-3.6-22.8V108m-3.6-22.8V108m-3.7-22.7V108M227 85.3V108m18.2-22.8V108m3.7-22.8V108m3.8-22.8V108m40 320.5h21.6v7.7h-21.6v-7.7zm-27.9-20h-7.7V442h7.7v-5.8h13.4v-7.7h-13.4v-20zM292.7 477h21.6v7.7h-21.6V477zM167.2 195.9h11.5V220h-11.5v-24.1zm0 41.9h11.5v24.1h-11.5v-24.1z"></path><path d="M264.8 462.2v-5.8h-7.7v5.8H54.5v-74.7h202.6v6.5h7.7v-76.9h-45.1v32.7h37.4v24.1h-63v-94.2h-27.3v3.6H119v90.5H95v-90.5H54.5v-46.9H29.1v185.2H.5v63h277.7V477h-13.4v-14.8z"></path><path d="M.5.5V394h3.9V210.4h24.7V222h25.4v-47.5H64v-15.2h-9.5V85.2H64v-7.7h-9.5V15.2h77.9v62.3H78.5v7.7H88v74.1h-9.5v15.2H95v-42.4h34.5v42.4h14.9v-15.2h-8V85.2h8v-7.7h-4.2V15.2H221v62.3h-62.1v7.7h8v74.1h-8v15.2h8v3.6h27.4V85.2h62.6V108h-37v32.7h45.4V32.5h248.3v72.9H478V75.3h-96.2v12.9c-54.5 19.2-94 75.8-94 142.6s39.5 123.4 94 142.6v9h96.5v-30.9h34.9v77.1H328.8v7.7h10.6V477h-10.6v7.7h192.3V.5H.5z"></path></g><g fill="#a0a0a0"><circle cx="93.4" cy="36.2" r="1.4"></circle><circle cx="180.5" cy="36.2" r="1.4"></circle><circle cx="301.2" cy="392.1" r=".9"></circle><path d="M301.2 391.2h26.3v1.8h-26.3v-1.8z"></path><circle cx="314.3" cy="379.5" r="1.5"></circle><circle cx="327.5" cy="392.1" r=".9"></circle><circle cx="301.2" cy="83.1" r=".9"></circle><circle cx="314.3" cy="70.4" r="1.5"></circle><circle cx="327.5" cy="83.1" r=".9"></circle><path d="M493 370.7l-3.7-3c0 5.7.5 7.7.5 9.1 0 .4-.3.8-.7.9-.4 0-.8-.3-.9-.7v-.2c0-1.4.5-3.4.5-9.1l-3.7 3c-.2.1-.4-.1-.2-.3 2.6-2.1 4.1-5.3 4.2-8.6 0-.1.2-.1.2 0 .1 3.3 1.6 6.5 4.2 8.6.1.2-.2.5-.4.3zM497.6 368.6l3.7 3c0-5.7-.5-7.7-.5-9.1 0-.4.3-.8.7-.9.4 0 .8.3.9.7v.2c0 1.4-.5 3.4-.5 9.1l3.7-3.1c.1-.1.4.1.2.3-2.6 2.1-4.1 5.3-4.2 8.7 0 .1-.2.1-.2 0-.1-3.4-1.6-6.5-4.2-8.6 0-.2.3-.5.4-.3zM495.9 361.3c0-.3-.2-.5-.5-.5s-.5.2-.5.5v15.8c0 .3.2.5.5.5s.5-.2.5-.5v-15.8zM493 90.2l-3.7-3c0 5.7.5 7.7.5 9.1 0 .4-.3.8-.7.9-.4 0-.8-.3-.9-.7v-.2c0-1.4.5-3.4.5-9.1l-3.7 3c-.2.1-.4-.1-.2-.3 2.6-2.1 4.1-5.3 4.2-8.6 0-.1.2-.1.2 0 .1 3.3 1.6 6.5 4.2 8.6.1.2-.2.4-.4.3zM497.6 88l3.7 3c0-5.7-.5-7.7-.5-9.1 0-.4.3-.8.7-.9.4 0 .8.3.9.7v.2c0 1.4-.5 3.4-.5 9.1l3.7-3.1c.1-.1.4.1.2.3-2.6 2.1-4.1 5.3-4.2 8.7 0 .1-.2.1-.2 0-.1-3.4-1.6-6.5-4.2-8.6 0-.1.3-.4.4-.3zM495.9 80.8c0-.3-.2-.5-.5-.5s-.5.2-.5.5v15.8c0 .3.2.5.5.5s.5-.2.5-.5V80.8zM430.6 506.6l-1.7-4c-.1-.2-.3-.3-.5-.3h-4.5c-.7 0-1.2-.5-1.2-1.2V495c0-.3-.2-.6-.6-.6-.3 0-.5.3-.5.6v2.2c0 .6-.4 1-.9 1.2-2.4.7-4 3-3.7 5.4.4 2.6 2.5 4.6 5.1 4.6 2.9 0 5.1-2.3 5.1-5.2h.8l1.6 3.7c.1.2.3.3.5.3h.2c.3 0 .5-.3.3-.6zm-5.8-3.4c.8 0 1.4.8 1.1 1.6-.2.5-.5.9-.9 1.3-1.6 1.5-4.2 1.5-5.8 0-1.6-1.6-1.6-4.2 0-5.8l.3-.3c.8-.6 2 0 2 1v1.6c0 .3.2.5.5.5l2.8.1z"></path><circle cx="422" cy="491.9" r="1.5"></circle></g><g fill="none" stroke="#a0a0a0"><path d="M94.8 57.6v-5.4h3.1c-.9-6.5-1.6-12.8-4.5-12.8s-3.5 6.3-4.5 12.8h3v5.4M181.9 57.6v-8.5h1.7c0-6.7-.4-9.7-3.1-9.7s-3.1 3-3.1 9.7h1.7v8.5M325.6 391.2c0-5.8-5-10.5-11.2-10.5s-11.2 4.7-11.2 10.5M325.6 82.2c0-5.8-5-10.5-11.2-10.5s-11.2 4.7-11.2 10.5M301.2 82.2h26.3V84h-26.3v-1.8zM482.2 355.7H509v26.8h-26.8v-26.8zM482.2 75.1H509v26.8h-26.8V75.1z"></path></g></symbol><symbol viewBox="0 0 579.8 530.2" id="icon-layoutplan-pit"><g class="hover-elements" fill="none"><path class="elevator" d="M508 179h26.8v26.8H508zM508 414h26.8v26.8H508z"></path><path class="wardrobe" d="M190 125h36v25h-36z"></path><path class="snacks" d="M463 20h30v30h-30zM235 450h30v30h-30z"></path><path class="drinks" d="M436 20h25v30h-25zM210 450h25v30h-25zM194 202h25v30h-25z"></path><path class="info" d="M256 274h25v25h-25z"></path></g><g font-family="Neue Haas Grotesk W05" font-size="12" fill="#a0a0a0"><text transform="translate(150.85 312.88)">FOYER</text><text transform="translate(132.104 480.66)">ABEND-</text><text transform="translate(136.004 495.06)">KASSE</text><text transform="translate(196.54 492.97)">RHEINGOLD-</text><text transform="translate(227.04 507.37)">BAR</text><text transform="translate(250.272 317.3)"><tspan x="0" y="0">HAUS-</tspan><tspan x="-9.6" y="14.4">GÖTTER-</tspan><tspan x="2.9" y="28.8">SAAL</tspan></text><text transform="translate(431.71 65.25)">FREUNDE-</text><text transform="translate(444.01 79.65)">FOYER</text><text transform="translate(326.845 173.17)">OPERN-</text><text transform="translate(334.345 187.57)">SHOP</text><text transform="translate(411.198 252.31)">PARKETT</text><text transform="translate(422.498 266.71)">LINKS</text><text transform="translate(411.198 365.44)">PARKETT</text><text transform="translate(416.298 379.84)">RECHTS</text><text transform="translate(323.065 442.73)">LUDWIG</text><text transform="translate(333.765 457.13)">BECK</text><text transform="translate(322.165 471.53)">CD-SHOP</text><text transform="rotate(90 -93.729 170.432)">HAUPTEINGANG</text><text transform="translate(516.5 85.25)">AUSGANG</text><text transform="translate(529.71 100.25)">NORD</text></g><g fill="none" stroke="#000"><path d="M151.3 265.5c0 1.6 1.3 2.9 2.9 2.9h32.1c1.6 0 2.9-1.3 2.9-2.8M151.3 354.2c0-1.6 1.3-2.9 2.9-2.9h32.1c1.6 0 2.9 1.3 2.9 2.9M.5 430.1c0 8.7 7.1 15.7 15.7 15.7M.5 190.9c0-8.6 7-15.7 15.6-15.7M4.3 190.9c0-6.6 5.3-11.9 11.9-11.9M8 190.9c0-4.5 3.6-8.1 8.1-8.1M11.8 190.9c0-2.4 2-4.4 4.4-4.4M15.6 190.9c0-.4.3-.7.6-.7M.5 190.9v239.2M4.3 190.9v239.2M8 190.9v239.2M11.8 190.9v239.2M15.6 190.9v239.2M19.3 191.5v238.2M23.1 191.5v238.1M26.8 191.5v238.1M30.6 191.5v238.1M34.4 191.5v238.1M38.1 191.5v238.1M41.9 191.5v238.1"></path><path d="M51.8 173.6H16.2v17.9h29.4v238.1H16.2v17.9h35.6v65.4h-.9v16.8h13.7v-16.8h-.9v-65.4M4.3 430.1c0 6.6 5.3 11.9 11.9 11.9M8 430.1c0 4.5 3.7 8.1 8.1 8.1M11.8 430.1c0 2.4 2 4.4 4.4 4.4M15.6 430.1c0 .4.3.7.7.7M107.7 182.2h-40v-7.5M67.7 178.5h40"></path><path d="M107.7 174.7h-44v-70.4M51.8 173.6v-69.3M63.7 150.3h44M63.7 146.5h44M63.7 142.7h44M63.7 139h44M63.7 115.6h44M63.7 111.9h44M63.7 108.1h44M63.7 481.9h44M63.7 478.1h44M63.7 474.4h44M63.7 470.6h44M63.7 451.4h44M63.7 447.7h44M67.8 443.8h39.9M64.6 521.5h43.1M64.6 517.7h43.1M64.6 514h43.1M63.7 510.2h44M63.8 506.4h43.9M63.8 502.7h43.8M368.1 485.2v31M371.9 485.2v31M375.6 485.2v31M379.4 485.2v31M383.1 485.2v31M386.9 485.2v31M390.7 485.2v31M394.4 485.2v31M398.2 485.2v31M401.9 485.2v31M405.7 485.2v31M409.5 485.2v31M264.4 409.6v24.5M268.1 409.6v24.5M271.9 409.6v24.5M275.7 409.6v24.5M279.4 409.6V434M283.2 409.6V434M287 409.6V434M290.7 409.6V434M294.5 409.6V434M298.2 409.6V434M264.4 185.5v23.9M268.1 185.5v23.9M271.9 185.5v23.9M275.7 185.5v23.9M279.4 185.5v23.9M283.2 185.5v23.9M287 185.5v23.9M290.7 185.5v23.9M294.5 185.5v23.9M298.2 185.5v23.9M236.7 403.2h24.1M236.7 399.4h24.1M236.7 395.6h24.1M236.7 391.9h24.1M236.7 388.1h24.1M236.7 231h24.1M236.7 227.3h24.1M236.7 223.5h24.1M236.7 219.8h24.1M236.7 216h24.1M154.2 264.6h32.1M154.2 260.8h32.1M154.2 257.1h32.1M154.2 253.3h32.1M154.3 249.6h31.9M154.3 245.8h31.9M154.3 242h31.9M154.3 238.3h31.9M154.3 234.5h31.9M154.3 230.8h31.9M154.3 227h31.9M154.3 223.2h31.9M154.3 219.5h31.9M154.3 215.7h31.9M154.3 211.9h31.9M154.3 208.2h31.9M154.3 204.4h31.9M154.3 200.7h31.9M154.3 196.9h31.9M154.3 193.1h31.9M154.3 189.4h31.9M154.2 430.3h32.1M154.2 426.5h32.1M154.2 422.8h32.1M154.2 419h32.1M154.2 415.3h32.1M154.2 411.5h32M154.2 407.7h32M154.2 404h32M154.2 400.2h32M154.2 396.5h32M154.2 392.7h32M154.2 388.9h32M154.2 385.2h32M154.2 381.4h32M154.2 377.6h32M154.2 373.9h32M154.2 366.4h32M154.2 370.1h32M154.2 362.6h32M154.2 358.8h32M154.2 355.1h32M350.1 118.1h36.2M350.1 114.4h36.2M350.1 110.6h36.2M350.2 106.8h36.1M350.2 103.1h36M350.2 99.3h36M350.2 95.6h36M566.4 71.4V29.7M562.6 71.4V29.7M558.8 71.4V29.7M555.1 71.3V29.8M551.3 71.3V29.8M547.5 71.3V29.8M543.8 71.3V29.8M540 71.3V29.8M536.3 71.3V29.8M532.5 71.3V29.8M528.7 71.3V29.8M525 71.3V29.8M521.2 71.3V29.8M407.6 81h9.7V19.1h-9.7"></path><path d="M407.6 77.2h5.9V22.8h-5.9"></path><path d="M407.6 73.4h2.2V26.6h-2.2M406 71.8V28.2M402.2 71.8V28.2M398.5 71.8V28.2M394.7 71.8V28.2"></path><path d="M407.6 4.5v23.7H391v43.6h16.6v23.8M107.7 440.3H67.8v7.4"></path><circle cx="57.9" cy="291.9" r="5.8"></circle><circle cx="57.9" cy="328.4" r="5.8"></circle><circle cx="57.9" cy="365" r="5.8"></circle><circle cx="57.9" cy="401.5" r="5.8"></circle><circle cx="57.9" cy="255.4" r="5.8"></circle><circle cx="57.9" cy="218.8" r="5.8"></circle><circle cx="57.9" cy="182.2" r="5.8"></circle><circle cx="57.6" cy="438.1" r="5.8"></circle><path d="M30.9 434.2v8.5l-1.4 1.4H21l-1.4-1.4v-8.5l1.4-1.4h8.5zM62.8 518.8v7.6l-1.3 1.2H54l-1.3-1.2v-7.6l1.3-1.3h7.5zM30.9 178.3v8.5l-1.4 1.4H21l-1.4-1.4v-8.5l1.4-1.4h8.5zM366 134h4.8v4H366zM298.1 154.8h4v5.5h-4zM260.8 209.4h41.3v23.9h-41.3z"></path><path d="M213.6 249v8h8.9v8.5h14.2v-4.6h5.3V257h-5.3v-71.5h65.4v-10.2h-4v2.2h-84.5v8h8.9V249zM142.2 177.5v8h8.1V249h-8.1v8h8.1v8.5h4v-80h32V257h-.1v8.5h4v-8.4h.1v-.1h8.3v-8h-8.3v-63.5h8.3v-8zM260.8 385.7h41.3v23.9h-41.3zM258.5 257h29v4h-29zM258.5 357.5h29v4h-29zM308.1 357.5v-19.2h-4v23.2h4zM308.1 257h-4V280.1h4v-19.2zM304.1 296.7h4v25h-4zM226.5 317.4h7.1v21.8h-7.1zM226.5 280.6h7.1v21.8h-7.1zM329.4 481.2h5.5v4h-5.5zM142.2 442.1v-8h8.1v-63.5h-8.1v-8h8.1v-8.4h4V434.1h31.9V354.2h4v8.4h8.4v8h-8.4v63.5h8.4v8z"></path><path d="M213.6 434.1v8H295v2.6h7.1v-10.6H236.7v-72.6h5.3v-4h-5.3v-3.3h-14.2v8.4h-8.9v8h8.9v63.5zM444.8 201.1v-22.4h-13.9v23.1c4.4-.5 8.8-.8 13.2-.8l.7.1z"></path><path d="M503.3 209.5v-30.6h-4.7v36.9c8.3 5.2 14.8 9.8 18.2 13.3v8.5l46.1 9.5v-24h16.4V.5H51.8v103.8h55.9v86.8h11.9v-5.7h7.5v-8h-7.5v-73.1h178.5v35.4h4V138h48v-33.7l-.3-99.9h177.3v21.3h-10.9v4h59.1v41.7l-59 .1v24.1h-130V138h151.4v71.5h-34.4z"></path><path d="M478.5 178.8h-13.9v24.3c4.7.9 9.3 2.1 13.9 3.7v-28zM411.1 178.8H404v8.8c-14 5-26.9 12.8-37.9 22.8l12.6 12.6c9.7-7.4 20.7-13 32.3-16.7l.1-27.5zM323.5 309.8c0 34.2 12.1 65.2 31.7 88.2l11.1-11.1c-41.5-42.5-41.5-110.4 0-152.9l-11.7-11.7c-19.3 22.9-31.1 53.7-31.1 87.5zM411.1 440.4v-25.8c-11.6-3.7-22.6-9.4-32.3-16.8l-11.9 11.9c10.8 9.7 23.5 17.3 37.2 22.2v8.4l7 .1zM107.7 206.2h11.9v22h-11.9zM107.7 265.2h12V257h7.5v-8h-7.5v-5.8h-12zM107.7 280.3h11.9v22h-11.9zM107.7 317.3h11.9v22h-11.9zM107.7 376.4h12v-5.8h7.5v-8h-7.5v-8.2h-12z"></path><path d="M537.6 409.5h-34.4v30.9h-4.9v-35.2c5.3-3.1 10.4-6.6 15.1-10.6 1.1-.9 2.2-1.9 3.3-2.8l-.1-8.6 46.2-9.4v20.5h16.4v129.9H107.7v-95.8h11.9v5.7h7.5v8h-11.5v74.2H294v-57h8v22h12.3v4H302v31h139.3v-31.1H350v-4h187.7v-71.7h-.1zM107.7 391.4h11.9v22h-11.9z"></path><path d="M464.7 440.4h13.9v-26.2c-4.5 1.5-9.2 2.7-13.9 3.6v22.6zM430.9 440.4h13.9v-20.7h-.7c-4.4 0-8.8-.3-13.2-.8v21.5z"></path></g><g fill="#a0a0a0"><path d="M272.2 295.1h-6.1c-.2 0-.4-.1-.4-.3v-.1c0-.2.1-.4.3-.4h.1l1.7-.1c.2 0 .2-.1.2-.3v-9.5c0-.4-.2-.7-.6-.7h-1.8c-.2 0-.4-.2-.4-.4s.2-.4.4-.4h.8c.7 0 1.4 0 2.1-.1l.5-.1c.3 0 .6-.1.7-.1.2 0 .4.2.4.4v11c0 .2.1.3.2.3l1.7.1c.2 0 .4.1.5.3 0 .2-.1.4-.3.4 0 .1 0 .1 0 0zm-3.4-14.9c-.9 0-1.6-.7-1.6-1.6s.7-1.6 1.6-1.6 1.6.7 1.6 1.6-.6 1.6-1.6 1.6c.1 0 0 0 0 0zM229.5 456c.1-.1.2-.3.1-.5s-.3-.3-.4-.3h-15.1c-.2 0-.4.1-.4.3-.1.2 0 .4.1.5l7.4 8v9.2h-4.4c-.3 0-.5.2-.5.5s.2.5.5.5h9.8c.3 0 .5-.2.5-.5s-.2-.5-.5-.5h-4.4V464l7.3-8zm-1.4.1l-6.5 7-6.5-7h13z"></path><g class="snacks" fill="none" stroke="#a0a0a0"><path d="M241.2 465c-.5.9-2 4.5-1.7 5.3.2.4.9.5 1.3.4 1.1-.3 3.7-1.5 3.9-2-.4-.2-2.7-2.4-3.5-3.7z"></path><path d="M245.6 469c.4-.1 2.6-1.1 2.5-1.4-.5-1-2-6.8-2-6.8-1.2 0-5.3 2.5-5.4 2.9-.3 1.1 4.2 5.7 4.9 5.3zm14-4.1c.5.9 2 4.5 1.7 5.3-.2.4-.9.5-1.3.4-1.1-.3-3.7-1.5-3.9-2 .4-.3 2.8-2.4 3.5-3.7z"></path><path d="M255.2 468.9c-.3-.2-2.5-1.1-2.4-1.4.5-1 2-6.8 2-6.8 1.2 0 5.3 2.5 5.4 2.9.3 1.1-4.2 5.7-5 5.3z"></path><path d="M252.4 468.3c.5-.1 2.4-7.6 2.4-7.7.2-1.1.2-1.8-.1-1.8-3.1-.4-5.6-.3-8.6.1-.3 0-.2.8-.1 1.9 0 .2 1.9 7.7 2.4 7.7l4-.2z"></path></g><path d="M214.3 209c.2-.2.2-.5 0-.7-.1-.1-.2-.1-.3-.1h-15.1c-.3 0-.5.2-.5.5 0 .1 0 .2.1.3l7.4 8v9.2h-4.4c-.3 0-.5.2-.5.5s.2.5.5.5h9.8c.3 0 .5-.2.5-.5s-.2-.5-.5-.5h-4.4V217l7.4-8zm-1.5.1l-6.5 7-6.5-7h13zM221 139.2c-2.5 0-8.9-3.2-12.2-3.4.1-1.6 2.7-1.9 2.7-4.1 0-1.4-1.1-2.6-2.6-2.7h-.1c-1.4.1-2.6 1.2-2.6 2.7 0 .2.1.4.3.4s.4-.1.4-.3v-.1c0-1 .8-1.9 1.9-1.9 1 0 1.9.8 1.9 1.9 0 2.3-2.6 1.9-2.7 4.1-3.4.3-9.3 3.3-11.9 3.3-2.1.1-3.7 1.9-3.6 4 .1 1.9 1.6 3.5 3.6 3.6 7 0 7-.5 12.4-.5s5.4.5 12.4.5c2.1-.1 3.7-1.9 3.6-4-.1-1.9-1.6-3.4-3.5-3.5zm0 6.2c-7 0-6.9-.5-12.4-.5-6.8 0-5.5.5-12.4.5-1.3-.1-2.4-1.2-2.3-2.6.1-1.2 1-2.2 2.3-2.3 3.3 0 8.8-3.2 12.1-3.2s9.2 3.2 12.7 3.2c1.3.1 2.4 1.2 2.3 2.6-.1 1.2-1.1 2.2-2.3 2.3zM457.5 27.1c.1-.1.2-.3.1-.5s-.3-.3-.4-.3H442c-.2 0-.4.1-.4.3-.1.2 0 .4.1.5l7.4 8.1v9.2h-4.4c-.3 0-.5.2-.5.5s.2.5.5.5h9.8c.3 0 .5-.2.5-.5s-.2-.5-.5-.5H450v-9.2l7.5-8.1zm-1.5.2l-6.5 7-6.5-7h13z"></path><g class="snacks" fill="none" stroke="#a0a0a0"><path d="M468.2 35c-.5.9-2 4.5-1.7 5.3.2.4.9.5 1.3.4 1.1-.3 3.7-1.5 3.9-2-.4-.2-2.7-2.4-3.5-3.7z"></path><path d="M472.6 39c.4-.1 2.6-1.1 2.5-1.4-.5-1-2-6.8-2-6.8-1.2 0-5.3 2.5-5.4 2.9-.3 1.1 4.2 5.7 4.9 5.3zm14-4.1c.5.9 2 4.5 1.7 5.3-.2.4-.9.5-1.3.4-1.1-.3-3.7-1.5-3.9-2 .4-.3 2.8-2.4 3.5-3.7z"></path><path d="M482.2 38.9c-.3-.2-2.5-1.1-2.4-1.4.5-1 2-6.8 2-6.8 1.2 0 5.3 2.5 5.4 2.9.3 1.1-4.2 5.7-5 5.3z"></path><path d="M479.4 38.3c.5-.1 2.4-7.6 2.4-7.7.2-1.1.2-1.8-.1-1.8-3.1-.4-5.6-.3-8.6.1-.3 0-.2.8-.1 1.9 0 .2 1.9 7.7 2.4 7.7l4-.2z"></path></g><path d="M518.3 193.2l-3.7-3c0 5.7.5 7.7.5 9.1 0 .4-.4.8-.8.8s-.8-.4-.8-.8c0-1.4.5-3.4.5-9.1l-3.7 3c-.1.1-.4-.1-.2-.3 2.6-2.1 4.1-5.3 4.2-8.6 0-.1 0-.1.1-.1s.1 0 .1.1c.1 3.4 1.6 6.5 4.2 8.6 0 .2-.2.5-.4.3zM522.9 191.1l3.7 3c0-5.7-.5-7.7-.5-9.1 0-.4.3-.8.7-.9.4 0 .8.3.9.7v.2c0 1.4-.5 3.4-.5 9.1l3.7-3.1c.2-.1.4.1.2.3-2.6 2.1-4.1 5.3-4.2 8.6 0 .1-.1.1-.1.1s-.1 0-.1-.1c-.1-3.3-1.6-6.5-4.2-8.6 0-.1.3-.3.4-.2zM521.1 183.8c0-.3-.2-.5-.5-.5s-.5.2-.5.5v15.8c0 .3.2.5.5.5s.5-.2.5-.5v-15.8zM518.5 428.2l-3.7-3c0 5.7.5 7.7.5 9.1 0 .4-.3.8-.7.9-.4 0-.8-.3-.9-.7v-.2c0-1.4.5-3.4.5-9.1l-3.7 3c-.2.1-.4-.1-.2-.3 2.6-2.1 4.1-5.3 4.2-8.6 0-.1.2-.1.2 0 .1 3.3 1.6 6.5 4.2 8.6 0 .2-.3.5-.4.3zM523 426.1l3.7 3c0-5.7-.5-7.7-.5-9.1 0-.4.4-.8.8-.8s.8.4.8.8c0 1.4-.5 3.4-.5 9.1l3.7-3.1c.1-.1.4.1.2.3-2.6 2.1-4.1 5.3-4.2 8.6 0 .1 0 .1-.1.1s-.1 0-.1-.1c-.1-3.3-1.6-6.5-4.2-8.6 0-.1.3-.4.4-.2zM521.3 418.8c0-.3-.2-.5-.5-.5s-.5.2-.5.5v15.8c0 .3.2.5.5.5s.5-.2.5-.5v-15.8z"></path></g><g fill="none" stroke="#a0a0a0"><path d="M507.2 178.8H534v26.8h-26.8zM256.8 274.2h24v24h-24zM507.3 413.8h26.8v26.8h-26.8z"></path></g></symbol><symbol viewBox="0 0 540.5 509.3" id="icon-layoutplan-second-gallery"><g class="hover-elements" fill="none"><path class="elevator" d="M456 100h26.8v26.8H456zM456 384h26.8v26.8H456z"></path><path class="wardrobe" d="M369 92h36v25h-36zM369 394h36v25h-36z"></path><path class="bathroom-men" d="M228 12h25v30h-25zM308 468h25v30h-25z"></path><path class="bathroom-women" d="M320 12h25v30h-25zM259 468h25v30h-25z"></path></g><g fill="none" stroke="#000"><path d="M171.3 346.1h46.2V373h-46.2zM171.3 137.5h46.2v26.9h-46.2zM251.3 402.7h7.7v7.7h-7.7zM251.3 99.9h7.7v7.7h-7.7zM293 99.9h7.7v7.7H293zM292.9 402.7h7.7v7.7h-7.7zM144.7 147.4h26.6M144.7 151.1h26.6M144.7 154.7h26.6M144.7 158.3h26.6M144.7 162h26.6M178.9 137.5v-30M182.5 137.5v-30M186.1 137.5v-30M189.7 137.4v-29.8M193.4 137.4v-29.8M197 137.4v-29.8M200.6 137.4v-29.8M204.3 137.4v-29.8M207.9 137.4v-29.8M211.5 137.4v-29.8M144.7 363.7h26.6M144.7 360h26.6M144.7 356.4h26.6M144.7 352.8h26.6M144.7 349.1h26.6M178.9 373.6v30M182.5 373.6v30M186.1 373.6v30M189.7 373.7v29.8M193.4 373.7v29.8M197 373.7v29.8M200.6 373.7v29.8M204.3 373.7v29.8M207.9 373.7v29.8M211.5 373.7v29.8"></path><path d="M486.2 130.8h-33.7v-30.3h-5.3v39.7c12.1 6.1 23.1 14.1 32.8 23.6l1 1.9 4.6 1h.2c1.7-11.2 9.7-19.7 19.2-19.7s17.5 8.5 19.2 19.7H540V.5H.5v508.3h539.1v-165h-16c-1.8 11.1-9.7 19.5-19.2 19.5s-17.2-8.1-19.1-19l-.1-.5-2.6.6-1.6.4-1 2.3c-9.7 9.2-20.8 17-32.8 22.8v41.5h5.3V381h33.9v78.3h-159v3.8h18.9v40.3h-50.6V463h17v-3.8h-27.3v3.8h6.4v40.3H251V463h19.7v-3.8h-52.8v-55.6h-73.1v-86.7h77.6v-23.7h30c1.2 5.1 2.7 10 4.4 14.8l10.2-5c-3.5-8.5-6-17.3-7.5-26.4h40.9c-2.6-13.9-2.6-28.2 0-42.1h-40.5c1.7-9.3 4.4-18.4 8-27.2l-11.8-5.6c-1.8 5.3-3.3 10.8-4.6 16.3h-29.2v-23.7h-77.6v-86.8h73.1V50.2h13.1v-4h-13.3v-39h45.8v39h-18v4h70.8v-4H299v-39h67.3v39h-35.6v4h155.4v50.2l.1 30.4z"></path><path d="M273.2 316.1l-11.2 5.3c6.3 13.9 14.7 26.8 24.9 38.2l11.4-11.4c-10-9.3-18.5-20.1-25.1-32.1zM346 390.2v21.2h-4.5v-14.8c-16.4-5.9-31.5-14.9-44.4-26.7l12.3-12.3c35.2 25.8 80.8 32.8 122.2 18.8v35.1h-5.3v-21.2l-80.3-.1zM383.6 119.4H346v-18.9h-4.5v10.9c-16.7 6-32.1 15.3-45.1 27.4l13.8 13.8c34.8-26.3 80.4-33.4 121.5-18.9v-33.2h-5.3v18.9h-42.8zM261.3 188.2l12.8 6.1c6.6-12 15-22.9 25-32.3l-12.8-12.8c-10.3 11.6-18.7 24.7-25 39zM476.3 160.3c-2.1 5.8-8.6 8.8-14.4 6.7-.9-.3-1.7-.7-2.5-1.3-16.7-11.5-36.6-17.7-56.9-17.7-27.7 0-53.8 11.3-73.4 31.7-19.7 20.7-30.8 48.2-30.8 76.8.1 27.8 11.2 54.5 30.8 74.2 34.6 35 89 40.8 130.1 13.7 3.5-2.3 8-2.5 11.6-.5 2.8 1.5 4.8 4.1 5.7 7.1"></path></g><g fill="#a0a0a0"><path d="M400 406.7c-2.5 0-8.8-3.2-12.2-3.4.1-1.6 2.7-1.9 2.7-4.1 0-1.4-1.1-2.6-2.6-2.7h-.1c-1.4.1-2.6 1.3-2.6 2.7 0 .2.2.4.4.3.2 0 .3-.2.3-.3 0-1 .8-1.9 1.9-1.9 1 0 1.9.8 1.9 1.9 0 2.3-2.6 1.9-2.7 4.1-3.4.3-9.3 3.3-11.9 3.3-2.1 0-3.8 1.7-3.8 3.8 0 2.1 1.7 3.8 3.8 3.8 7 0 7-.5 12.4-.5s5.4.5 12.4.5c2.1 0 3.8-1.7 3.8-3.8.1-2-1.6-3.7-3.7-3.7zm0 6.2c-7 0-6.9-.5-12.4-.5-6.8 0-5.5.5-12.4.5-1.3-.1-2.4-1.2-2.3-2.6.1-1.2 1-2.2 2.3-2.3 3.3 0 8.8-3.2 12.1-3.2s9.2 3.2 12.7 3.2c1.3.1 2.4 1.2 2.3 2.6-.1 1.3-1 2.2-2.3 2.3zM399.2 104.9c-2.5 0-8.8-3.2-12.2-3.4.1-1.6 2.7-1.8 2.7-4.1 0-1.4-1.1-2.6-2.6-2.7h-.1c-1.4.1-2.6 1.2-2.6 2.7 0 .2.2.4.4.4s.4-.2.4-.4c-.1-1 .7-1.9 1.7-2s1.9.7 2 1.7v.3c0 2.3-2.6 1.9-2.7 4.1-3.4.3-9.3 3.3-11.9 3.3-2.1.1-3.7 1.9-3.6 4 .1 1.9 1.6 3.5 3.6 3.6 7 0 7-.5 12.4-.5s5.4.5 12.3.5c2.1 0 3.8-1.7 3.8-3.8.2-2-1.5-3.7-3.6-3.7zm0 6.2c-7 0-6.9-.5-12.3-.5-6.8 0-5.5.5-12.4.5-1.3.1-2.5-.9-2.6-2.3-.1-1.3.9-2.5 2.3-2.6h.3c3.3 0 8.8-3.2 12.1-3.2s9.2 3.2 12.7 3.2c1.3-.1 2.5.9 2.6 2.3.1 1.3-.9 2.5-2.3 2.6h-.4zM321.1 474.3c.8 0 1.4-.6 1.4-1.4s-.6-1.4-1.4-1.4c-.8 0-1.4.6-1.4 1.4 0 .8.6 1.4 1.4 1.4zM321.1 475.5c-3.5 0-3.7 3.9-3.7 10.3 0 .3.3.6.6.6h1.1v7.9c0 .3.3.6.6.6s.6-.3.6-.6v-8.5c0-.3-.3-.6-.6-.6h-1.1c0-6.8.6-8.5 2.5-8.5s2.5 1.8 2.5 8.5h-1.1c-.3 0-.6.3-.6.6v8.5c0 .3.3.6.6.6s.6-.3.6-.6v-7.9h1.1c.3 0 .6-.3.6-.6 0-6.4-.2-10.3-3.7-10.3zM271 474.3c.8 0 1.4-.6 1.4-1.4s-.6-1.4-1.4-1.4c-.8 0-1.4.6-1.4 1.4 0 .8.6 1.4 1.4 1.4zM275.9 487.6c-.9-6.5-1.7-12.1-4.9-12.1s-3.9 5.5-4.9 11.9l-.2 1.4c0 .3.2.6.5.7h2.6v4.8c0 .3.3.6.6.6s.6-.3.6-.6v-5.4c0-.3-.3-.6-.6-.6h-2.4l.1-.8c.8-5.3 1.5-10.8 3.7-10.8s2.9 5.6 3.7 11l.1.5h-2.4c-.2 0-.3.1-.4.2-.1.1-.2.3-.2.4v5.4c0 .3.3.6.6.6s.6-.3.6-.6v-4.8h2.5c.2 0 .3-.1.5-.2.1-.1.2-.3.1-.5l-.2-1.1zM240.3 17.3c.8 0 1.4-.6 1.4-1.4s-.6-1.4-1.4-1.4c-.8 0-1.4.6-1.4 1.4 0 .8.6 1.4 1.4 1.4zM240.3 18.5c-3.5 0-3.7 3.9-3.7 10.3 0 .3.3.6.6.6h1.1v7.9c0 .3.3.6.6.6s.6-.3.6-.6v-8.5c0-.3-.3-.6-.6-.6h-1.1c0-6.8.6-8.5 2.5-8.5s2.5 1.8 2.5 8.5h-1.1c-.3 0-.6.3-.6.6v8.5c0 .3.3.6.6.6s.6-.3.6-.6v-7.9h1.1c.3 0 .6-.3.6-.6 0-6.4-.3-10.3-3.7-10.3zM333.1 17.3c.8 0 1.4-.6 1.4-1.4s-.6-1.4-1.4-1.4c-.8 0-1.4.6-1.4 1.4 0 .8.6 1.4 1.4 1.4zM338 30.6c-.9-6.5-1.7-12.1-4.9-12.1s-4 5.5-4.8 11.9l-.2 1.5c0 .2 0 .3.1.5.1.1.3.2.5.2h2.5v4.8c0 .3.3.6.6.6s.6-.3.6-.6V32c0-.3-.3-.6-.6-.6h-2.4l.1-.8c.8-5.3 1.5-10.8 3.6-10.8s2.9 5.6 3.7 11.1l.1.5h-2.4c-.2 0-.3.1-.4.2-.1.1-.2.3-.2.4v5.4c0 .3.3.6.6.6s.6-.3.6-.6v-4.8h2.5c.2 0 .3-.1.5-.2.1-.1.2-.3.1-.5l-.2-1.3zM467 114.9l-3.7-3c0 5.7.5 7.7.5 9.1 0 .4-.3.8-.7.9-.4 0-.8-.3-.9-.7v-.2c0-1.4.5-3.4.5-9.1l-3.7 3c-.2.1-.4-.1-.2-.3 2.6-2.1 4.1-5.3 4.2-8.6 0-.1.2-.1.2 0 .1 3.3 1.6 6.5 4.2 8.6 0 .2-.3.4-.4.3zM471.6 112.8l3.7 3c0-5.7-.5-7.7-.5-9.1 0-.4.4-.8.8-.8s.8.4.8.8c0 1.4-.5 3.4-.5 9.1l3.7-3.1c.1-.1.4.1.2.3-2.6 2.1-4.1 5.3-4.2 8.7 0 .1-.1.1-.1.1s-.1 0-.1-.1c-.1-3.3-1.6-6.5-4.2-8.6 0-.2.2-.5.4-.3zM469.8 105.5c0-.3-.2-.5-.5-.5s-.5.2-.5.5v15.8c0 .3.2.5.5.5s.5-.2.5-.5v-15.8zM467.1 399l-3.7-3c0 5.7.5 7.7.5 9.1 0 .4-.3.8-.7.9-.4 0-.8-.3-.9-.7v-.2c0-1.4.5-3.4.5-9.1l-3.7 3c-.1.1-.4-.1-.2-.3 2.6-2.1 4.1-5.3 4.2-8.6 0-.1.1-.1.1-.1s.1 0 .1.1c.1 3.3 1.6 6.5 4.2 8.6.1.2-.2.4-.4.3zM471.7 396.9l3.7 3c0-5.7-.5-7.7-.5-9.1 0-.4.3-.8.7-.9.4 0 .8.3.9.7v.2c0 1.4-.5 3.4-.5 9.1l3.7-3.1c.2-.1.4.1.2.3-2.6 2.1-4.1 5.3-4.2 8.7 0 .1-.1.1-.1.1s-.1 0-.1-.1c-.1-3.3-1.6-6.5-4.2-8.6 0-.2.3-.4.4-.3zM470 389.6c0-.3-.2-.5-.5-.5s-.5.2-.5.5v15.8c0 .3.2.5.5.5s.5-.2.5-.5v-15.8z"></path></g><g fill="none" stroke="#a0a0a0"><path d="M455.8 100.5h26.8v26.8h-26.8zM456 384.6h26.8v26.8H456z"></path></g></symbol><symbol viewBox="0 0 565.2 509.2" id="icon-layoutplan-third-gallery"><g class="hover-elements" fill="none"><path class="elevator" d="M471 95h26.8v26.8H471zM471 379h26.8v26.8H471z"></path><path class="wardrobe" d="M383 86h36v25h-36zM383 390h36v25h-36z"></path><path class="bathroom-men" d="M240 12h25v30h-25zM321 468h25v30h-25z"></path><path class="bathroom-women" d="M333 12h25v30h-25zM272 468h25v30h-25z"></path><path class="snacks" d="M178 224h30v30h-30z"></path><path class="drinks" d="M178 254h30v30h-30z"></path></g><g fill="none" stroke="#000"><path d="M499.7 339c-1.8-8.4 31.5-15.5 33.2-7.1M183.6 337.8h47v28.5h-47zM153.9 355.6h29.7M153.9 352h29.7M153.9 348.3h29.7M154 344.7h29.5M154 341.1h29.5M192 366.3v29.1M195.7 366.3v29.1M199.3 366.3v29.1M202.9 366.4v28.9M206.6 366.4v28.9M210.2 366.4v28.9M213.8 366.4v28.9M217.5 366.4v28.9M221.1 366.4v28.9M224.7 366.4v28.9M183.6 142.8h47v28.5h-47zM153.9 153.6h29.7M153.9 157.2h29.7M153.9 160.8h29.7M154 164.5h29.5M154 168.1h29.5M192 142.8v-29M195.7 142.8v-29M199.3 142.8v-29M202.9 142.8v-28.9M206.6 142.8v-28.9M210.2 142.8v-28.9M213.8 142.8v-28.9M217.5 142.8v-28.9M221.1 142.8v-28.9M224.7 142.8v-28.9M204.5 307.4v3.8H235.6V197.9H204.5v3.9h27.2v105.6zM467.7 125.5V95.2h-4.5V135c11.4 5.8 21.9 13.2 31.2 22.1 1 1 1.9 2.2 2.6 3.4l4.6 1c-.5-1.8-.8-3.6-.8-5.4 0-5.4 2.3-10.6 6.4-14.2V95.2h-5.4v30.3h-34.1zM314.1 342.8c-10.1-9.4-18.7-20.4-25.3-32.6l-11.1 5.3c6.3 14.1 14.8 27.1 25.1 38.7l11.3-11.4zM315 156.6l-12.8-12.8c-10.3 11.6-18.7 24.8-25 39l12.8 6.1c6.7-12 15.1-22.9 25-32.3zM362.1 384.9v21.2h-4.5v-14.9c-16.5-5.9-31.6-15-44.6-26.9l12.3-12.3c22.9 17 50.7 26.1 79.2 26 14.7 0 29.3-2.4 43.2-7.1V406h-5.3v-21.1h-80.3zM362.1 114.1V95.2h-4.5V106c-16.8 6-32.1 15.3-45.2 27.4l13.8 13.8c34.8-26.3 80.4-33.4 121.6-18.9V95.2h-5.3v18.9h-80.4zM263.6 248.6c0 18.1 2.9 36.1 8.8 53.3l10.3-4.9c-5.8-14.4-8.8-29.8-8.9-45.3.1-17 3.5-33.9 10-49.7l-11.8-5.6c-5.6 16.9-8.5 34.5-8.4 52.2z"></path><path d="M468 406h-4.9v-41.4c11.3-5.5 21.7-12.7 31-21.2 1.2-1.1 2.2-2.5 2.8-4l4.5-1c-.6 1.9-.9 3.8-.9 5.8-.1 6.8 3.6 13 9.5 16.3V406h-8v-30.4h-34.1l.1 30.4z"></path><path d="M492.7.5H.5v508.2h564.2V332.2l-27.2-1.4-6.3 1.3c2.9 3.4 4.4 7.7 4.4 12.1.1 7.4-4.3 14.2-11.2 17.1v67h-31.8V459H340.1v3.8H359v40.3h-50.5v-40.3h17V459h-27.3v3.8h6.4v40.3h-40.8v-40.3h19.7V459h-52.9v-63.7h-76.7v-84.1H190v-3.8h-36.1V201.8H190V198h-36.1v-84.1h76.7V50.2h13.2v-4h-13.2v-39h45.6v39h-18v4H329v-4h-17.1v-39h67.3v39h-35.6v4h149.1v22.3h28.9v65.4c8.4 1.9 14.4 9.4 14.2 18.1 0 4.3-1.4 8.5-4.1 11.9l5.8 1.2 27.2-1.4V.5h-72z"></path><path d="M491.6 154.8c-1 2.6-2.9 4.7-5.3 6-3.7 2-8.3 1.8-11.8-.6-41.5-28.2-97.2-22.2-131.9 14-20 20.6-31.1 48.1-31.2 76.8.3 58.2 47.8 105.2 106.1 104.9 20.2-.1 39.9-6 56.8-17 3.5-2.3 8.1-2.5 11.8-.5 2.8 1.5 4.9 4.1 5.7 7.1M500 161.4c-1.8 8.4 31.4 15.5 33.2 7.1"></path></g><g fill="#a0a0a0"><path d="M334.1 474.6c.8 0 1.4-.6 1.4-1.4s-.6-1.4-1.4-1.4-1.4.6-1.4 1.4.7 1.4 1.4 1.4zM334.1 475.8c-3.5 0-3.7 3.9-3.7 10.3 0 .3.3.6.6.6h1.1v7.9c0 .3.3.6.6.6s.6-.3.6-.6v-8.5c0-.3-.3-.6-.6-.6h-1.1c0-6.8.6-8.5 2.5-8.5s2.5 1.8 2.5 8.5h-1.2c-.3 0-.6.3-.6.6v8.5c0 .3.3.6.6.6s.6-.3.6-.6v-7.9h1.1c.3 0 .6-.3.6-.6.2-6.4-.1-10.3-3.6-10.3zM283.7 474.6c.8 0 1.4-.6 1.4-1.4s-.6-1.4-1.4-1.4-1.4.6-1.4 1.4.6 1.4 1.4 1.4zM288.6 487.9c-.9-6.5-1.7-12.1-4.9-12.1s-3.9 5.5-4.8 11.9l-.2 1.5c0 .2 0 .3.1.5.1.1.3.2.5.2h2.5v4.8c0 .3.3.6.6.6s.6-.3.6-.6v-5.4c0-.3-.3-.6-.6-.6H280l.1-.8c.8-5.3 1.5-10.8 3.7-10.8s2.9 5.6 3.7 11l.1.5h-2.4c-.2 0-.3.1-.4.2-.1.1-.2.3-.2.4v5.4c0 .3.3.6.6.6s.6-.3.6-.6v-4.8h2.5c.2 0 .3-.1.5-.2.1-.1.2-.3.1-.5l-.3-1.2zM253.4 17.7c.8 0 1.4-.6 1.4-1.4s-.6-1.4-1.4-1.4c-.8 0-1.4.6-1.4 1.4 0 .8.6 1.4 1.4 1.4zM253.4 18.9c-3.5 0-3.7 3.9-3.7 10.3 0 .3.3.6.6.6h1.1v7.9c0 .3.3.6.6.6s.6-.3.6-.6v-8.5c0-.3-.3-.6-.6-.6h-1.1c0-6.8.6-8.5 2.5-8.5s2.5 1.8 2.5 8.5h-1.1c-.3 0-.6.3-.6.6v8.4c0 .3.3.6.6.6s.6-.3.6-.6v-7.9h1.1c.3 0 .6-.3.6-.6 0-6.3-.2-10.2-3.7-10.2zM345.8 17.7c.8 0 1.4-.6 1.4-1.4s-.6-1.4-1.4-1.4c-.8 0-1.4.6-1.4 1.4 0 .8.6 1.4 1.4 1.4zM350.7 31c-.9-6.5-1.7-12.1-4.9-12.1s-3.9 5.5-4.8 11.9l-.2 1.5c0 .2 0 .3.1.5.1.1.3.2.5.2h2.5v4.8c0 .3.3.6.6.6s.6-.3.6-.6v-5.4c0-.3-.3-.6-.6-.6H342l.1-.8c.8-5.3 1.5-10.8 3.7-10.8s2.9 5.6 3.7 11l.1.5h-2.4c-.2 0-.3.1-.4.2-.1.1-.2.3-.2.4v5.4c0 .3.3.6.6.6s.6-.3.6-.6v-4.8h2.5c.2 0 .3-.1.5-.2.1-.1.2-.3.1-.5l-.2-1.2zM413.4 99.1c-2.5 0-8.8-3.2-12.2-3.4.1-1.6 2.7-1.8 2.7-4.1 0-1.4-1.1-2.6-2.6-2.7h-.1c-1.4.1-2.6 1.2-2.6 2.7 0 .2.1.4.3.4s.4-.1.4-.3v-.1c0-1 .8-1.9 1.9-1.9 1 0 1.9.8 1.9 1.9 0 2.3-2.6 1.9-2.7 4.1-3.4.3-9.3 3.3-11.9 3.3-2.1.1-3.7 1.9-3.6 4 .1 1.9 1.6 3.5 3.6 3.6 7 0 7-.5 12.4-.5s5.4.5 12.4.5c2.1 0 3.8-1.7 3.8-3.8 0-2-1.6-3.7-3.7-3.7zm0 6.1c-7 0-6.9-.5-12.4-.5-6.8 0-5.5.5-12.4.5-1.3-.1-2.4-1.2-2.3-2.6.1-1.2 1-2.2 2.3-2.3 3.3 0 8.8-3.2 12.1-3.2s9.2 3.2 12.7 3.2c1.3.1 2.4 1.2 2.3 2.6-.1 1.3-1.1 2.3-2.3 2.3zM414.6 401.5c-2.5 0-8.8-3.2-12.2-3.4.1-1.6 2.7-1.9 2.7-4.1 0-1.4-1.1-2.6-2.6-2.7h-.1c-1.4.1-2.6 1.2-2.6 2.7 0 .2.1.4.3.4.2 0 .4-.1.4-.3v-.1c0-1 .8-1.9 1.9-1.9 1 0 1.9.8 1.9 1.9 0 2.3-2.6 1.9-2.7 4.1-3.4.3-9.3 3.3-11.9 3.3-2.1-.1-3.9 1.5-4 3.6s1.5 3.9 3.6 4h.4c7 0 7-.5 12.4-.5s5.4.5 12.4.5c2.1-.1 3.7-1.9 3.6-4-.1-1.9-1.6-3.4-3.5-3.5zm0 6.2c-7 0-6.9-.5-12.4-.5-6.8 0-5.5.5-12.4.5-1.3.1-2.5-.9-2.6-2.3-.1-1.3.9-2.5 2.3-2.6h.3c3.3 0 8.8-3.2 12.1-3.2s9.2 3.2 12.7 3.2c1.3-.1 2.5.9 2.6 2.3.1 1.3-.9 2.5-2.3 2.6h-.3zM201.1 260.2c.2-.2.2-.5 0-.7-.1-.1-.2-.1-.3-.1h-15.1c-.2 0-.4.1-.4.3-.1.2 0 .4.1.5l7.4 8v9.2h-4.4c-.3 0-.5.2-.5.5s.2.5.5.5h9.8c.3 0 .5-.2.5-.5s-.2-.5-.5-.5h-4.4v-9.2l7.3-8zm-1.4.1l-6.5 7-6.5-7h13z"></path><g class="snacks" fill="none" stroke="#a0a0a0"><path d="M184.2 239c-.5.9-2 4.5-1.7 5.3.2.4.9.5 1.3.4 1.1-.3 3.7-1.5 3.9-2-.4-.2-2.7-2.4-3.5-3.7z"></path><path d="M188.6 243c.4-.1 2.6-1.1 2.5-1.4-.5-1-2-6.8-2-6.8-1.2 0-5.3 2.5-5.4 2.9-.3 1.1 4.2 5.7 4.9 5.3zm14-4.1c.5.9 2 4.5 1.7 5.3-.2.4-.9.5-1.3.4-1.1-.3-3.7-1.5-3.9-2 .4-.3 2.8-2.4 3.5-3.7z"></path><path d="M198.2 242.9c-.3-.2-2.5-1.1-2.4-1.4.5-1 2-6.8 2-6.8 1.2 0 5.3 2.5 5.4 2.9.3 1.1-4.2 5.7-5 5.3z"></path><path d="M195.4 242.3c.5-.1 2.4-7.6 2.4-7.7.2-1.1.2-1.8-.1-1.8-3.1-.4-5.6-.3-8.6.1-.3 0-.2.8-.1 1.9 0 .2 1.9 7.7 2.4 7.7l4-.2z"></path></g><path d="M482.5 109.5l-3.7-3c0 5.7.5 7.7.5 9.1 0 .4-.3.8-.7.9-.4 0-.8-.3-.9-.7v-.2c0-1.4.5-3.4.5-9.1l-3.7 3c-.2.1-.4-.1-.2-.3 2.6-2.1 4.1-5.3 4.2-8.6 0-.1.1-.1.1-.1s.1 0 .1.1c.1 3.3 1.6 6.5 4.2 8.6 0 .2-.3.4-.4.3zM487.1 107.3l3.7 3c0-5.7-.5-7.7-.5-9.1 0-.4.4-.8.8-.8s.8.4.8.8c0 1.4-.5 3.4-.5 9.1l3.7-3.1c.1-.1.4.1.2.3-2.6 2.1-4.1 5.3-4.2 8.7 0 .1-.1.1-.1.1s-.1 0-.1-.1c-.1-3.3-1.6-6.5-4.2-8.6 0-.1.2-.4.4-.3zM485.3 100.1c0-.3-.2-.5-.5-.5s-.5.2-.5.5v15.8c0 .3.2.5.5.5s.5-.2.5-.5v-15.8zM482.7 393.7l-3.7-3c0 5.7.5 7.7.5 9.1 0 .4-.3.8-.7.9-.4 0-.8-.3-.9-.7v-.2c0-1.4.5-3.4.5-9.1l-3.7 3c-.2.1-.4-.1-.2-.3 2.6-2.1 4.1-5.3 4.2-8.6 0-.1.2-.1.2 0 .1 3.3 1.6 6.5 4.2 8.6 0 .2-.2.5-.4.3zM487.3 391.6l3.7 3c0-5.7-.5-7.7-.5-9.1 0-.4.4-.8.8-.8s.8.4.8.8c0 1.4-.5 3.4-.5 9.1l3.7-3.1c.1-.1.4.1.2.3-2.6 2.1-4.1 5.3-4.2 8.6 0 .1 0 .1-.1.1s-.1 0-.1-.1c-.1-3.3-1.6-6.5-4.2-8.6 0-.1.3-.4.4-.2zM485.5 384.3c0-.3-.2-.5-.5-.5s-.5.2-.5.5v15.8c0 .3.2.5.5.5s.5-.2.5-.5v-15.8z"></path></g><g fill="none" stroke="#a0a0a0"><path d="M471.3 95h26.8v26.8h-26.8zM471.6 379.3h26.8v26.8h-26.8z"></path></g></symbol><symbol viewBox="0 0 15 15" id="icon-link"><path d="M7 3.5h4.5V8M3.5 11.5l8-8"></path></symbol><symbol viewBox="0 0 20 20" id="icon-linkedin"><path fill="currentColor" d="M10 .4C4.698.4.4 4.698.4 10s4.298 9.6 9.6 9.6 9.6-4.298 9.6-9.6S15.302.4 10 .4zM7.65 13.979H5.706V7.723H7.65v6.256zm-.984-7.024c-.614 0-1.011-.435-1.011-.973 0-.549.409-.971 1.036-.971s1.011.422 1.023.971c0 .538-.396.973-1.048.973zm8.084 7.024h-1.944v-3.467c0-.807-.282-1.355-.985-1.355-.537 0-.856.371-.997.728-.052.127-.065.307-.065.486v3.607H8.814v-4.26c0-.781-.025-1.434-.051-1.996h1.689l.089.869h.039c.256-.408.883-1.01 1.932-1.01 1.279 0 2.238.857 2.238 2.699v3.699z"></path></symbol><symbol viewBox="0 0 40 40" id="icon-mail"><path d="M38.9 17.55c-.7-5.3-3.1-9.7-7.4-13-4.3-3.3-9.1-4.6-14.4-3.9-5.3.7-9.7 3.1-13 7.4-3.3 4.3-4.6 9.1-3.9 14.4.7 5.3 3.1 9.7 7.4 13 4.3 3.3 9.1 4.6 14.4 3.9 5.3-.7 9.7-3.1 13-7.4 3.3-4.3 4.6-9.1 3.9-14.4zm-9.6-5.5l-9.7 9.2-9.7-9.2h19.4zm-21.1 1.7l6.6 6.2-6.6 6.8v-13zm1.3 14.2l6.6-6.8 3.5 3.3 3.5-3.3 6.6 6.8H9.5zm21.4-1.2l-6.6-6.8 6.6-6.2v13z" fill="#020202" fill-rule="nonzero"></path></symbol><symbol viewBox="0 0 15 15" id="icon-menu"><path d="M2 3.5h11M2 11.5h11M2 7.5h11"></path></symbol><symbol viewBox="0 0 24 24" id="icon-open-in-full"><path d="M21 11V3h-8l3.29 3.29-10 10L3 13v8h8l-3.29-3.29 10-10z"></path></symbol><symbol viewBox="0 0 15 15" id="icon-pause"><path d="M5.5 3v9M9.5 3v9"></path></symbol><symbol viewBox="0 0 512 512" id="icon-pdf"><path d="M352 192v96h32V152L232 0H0v512h96v-32H32V32h160v160h160zm-5.3-32H224V37.3L346.7 160zM176 352h-16v160h32v-48h16c30.9 0 56-25.1 56-56s-25.1-56-56-56h-32zm32 80h-16v-48h16c13.3 0 24 10.7 24 24s-10.7 24-24 24zm96-80h-16v160h48c26.5 0 48-21.5 48-48v-64c0-26.5-21.5-48-48-48h-32zm32 128h-16v-96h16c8.8 0 16 7.2 16 16v64c0 8.8-7.2 16-16 16zm80-128v160h32v-64h48v-32h-48v-32h48v-32h-80z"></path></symbol><symbol viewBox="0 0 15 15" id="icon-pip"><path d="M7 3.5h4.5V8M3.5 11.5l8-8M8 11.5H3.5V7"></path></symbol><symbol viewBox="0 0 15 15" id="icon-play"><path d="M11.5 7.5L4.5 3v9l7-4.5z"></path></symbol><symbol viewBox="0 0 15 15" id="icon-plus"><path d="M7 3h1v9H7z"></path><path d="M12 7v1H3V7z"></path></symbol><symbol viewBox="0 0 40 40" id="icon-rss"><path d="M33.787 6.213C29.979 2.404 25.382.5 20 .5c-5.383 0-9.979 1.904-13.787 5.713C2.405 10.022.5 14.618.5 20c0 5.383 1.904 9.978 5.713 13.787C10.022 37.596 14.617 39.5 20 39.5c5.382 0 9.978-1.904 13.787-5.713C37.596 29.978 39.5 25.383 39.5 20c0-5.382-1.904-9.979-5.713-13.787zM10.25 26.094c0-1.015.355-1.878 1.066-2.59.711-.711 1.573-1.066 2.59-1.066 1.015 0 1.878.356 2.59 1.066.711.712 1.066 1.575 1.066 2.59 0 1.016-.356 1.879-1.066 2.59-.712.712-1.575 1.066-2.59 1.066-1.016 0-1.879-.355-2.59-1.066-.711-.711-1.066-1.574-1.066-2.59zm0-9.979a12.554 12.554 0 0 1 3.047-.381c3.301 0 6.106 1.156 8.417 3.466 2.31 2.311 3.466 5.092 3.466 8.341 0 .712-.076 1.447-.228 2.209h-4.799a7.945 7.945 0 0 0 .457-2.666c0-2.133-.75-3.948-2.247-5.446-1.498-1.497-3.313-2.247-5.446-2.247-.914 0-1.803.152-2.666.457v-3.733h-.001zm16.034-2.399c3.935 3.936 5.903 8.697 5.903 14.282 0 .457-.026 1.041-.076 1.752h-4.113c.05-.609.076-1.193.076-1.752 0-4.418-1.574-8.201-4.723-11.35-3.149-3.148-6.932-4.723-11.35-4.723-.559 0-1.142.026-1.752.076V7.888c.711-.05 1.295-.076 1.752-.076 5.587.001 10.347 1.969 14.283 5.904z" fill-rule="nonzero"></path></symbol><symbol viewBox="0 0 15 15" id="icon-search"><path d="M13 13L9 9"></path><circle cx="6.5" cy="6.5" r="4"></circle></symbol><symbol viewBox="0 0 640 512" id="icon-sound"><path d="M336 0v512h-32V0h32zm192 64v384h-32V64h32zM240 96v320h-32V96h32zm192 32v256h-32V128h32zm-288 64v128h-32V192h32zm-96 32v64H16v-64h32zm576 0v64h-32v-64h32z"></path></symbol><symbol viewBox="0 0 12.043 13" id="icon-trailer-play"><g data-name="Polygon 1" fill="#fff"><path d="M.5 12.162V.838L10.99 6.5.5 12.162z"></path><path d="M9.938 6.5L1 1.676v9.648L9.938 6.5m2.105 0L0 13V0l12.043 6.5z" fill="#000"></path></g></symbol><symbol viewBox="0 0 40 40" id="icon-twitter"><g transform="matrix(.04051 0 0 .04051 -13.799 -4.737)"><circle cx="834.28" cy="610.6" r="481.33" stroke="#fff"></circle><path d="M537.78 331.731l230.07 307.62-231.52 250.11h52.11l202.7-218.98 163.77 218.98h177.32l-243.02-324.92 215.5-232.81h-52.11l-186.67 201.67-150.83-201.67H537.78zm76.63 38.38h81.46l359.72 480.97h-81.46l-359.72-480.97z" fill="#fff" fill-rule="nonzero"></path></g></symbol><symbol viewBox="0 0 512 512" id="icon-video"><path d="M128 448V272h256v176H128zm256-208H128V64h256v176zM96 448H32v-80h64v80zM32 336v-64h64v64H32zm64-160v64H32v-64h64zm0-112v80H32V64h64zm320 272v-64h64v64h-64zm0 112v-80h64v80h-64zm0-272h64v64h-64v-64zm64-32h-64V64h64v80zm32-112H0v448h512V32z"></path></symbol><symbol viewBox="0 0 15 15" id="icon-volume"><path d="M2.5 9v3M5.5 7v5M8.5 5v7M11.5 3v9"></path></symbol><symbol viewBox="0 0 40 40" id="icon-website"><path d="M15.5 14h-2v-2h2v2zm-4-2h-2v2h2v-2zm18 2h-12v-2h12v2zm9.5 6c0 5.4-1.9 10-5.7 13.8-3.8 3.8-8.4 5.7-13.8 5.7s-10-1.9-13.8-5.7C1.9 30 0 25.4 0 20S1.9 10 5.7 6.2C9.5 2.4 14.1.5 19.5.5s10 1.9 13.8 5.7C37.1 10 39 14.6 39 20zm-6.5-10h-26v20.8h26V10zm-3 18h-20V16h20v12zm-12-10h-6v8h6v-8zm10 7h-8v1h8v-1zm0-2h-8v1h8v-1zm0-2h-8v1h8v-1zm0-3h-8v2h8v-2z" fill-rule="nonzero"></path></symbol><symbol viewBox="0 0 40 40" id="icon-youtube"><path d="M33.787 6.213C29.979 2.404 25.382.5 20 .5c-5.383 0-9.978 1.904-13.787 5.713C2.404 10.021.5 14.618.5 20c0 5.383 1.904 9.979 5.713 13.787C10.022 37.596 14.617 39.5 20 39.5c5.382 0 9.979-1.904 13.787-5.713C37.596 29.978 39.5 25.383 39.5 20c0-5.382-1.904-9.979-5.713-13.787zM22.221 9.856h1.16v5.024c0 .13.015.241.048.338.032.097.112.145.241.145l.773-.966V9.856h1.159v6.666h-1.159v-1.256c-.258.516-.548.903-.869 1.159-.451.386-.806.451-1.063.193-.193-.193-.29-.611-.29-1.256V9.856zm-4.443 1.932c0-.58.16-1.03.483-1.353.45-.386.869-.58 1.256-.58s.74.193 1.063.58c.322.323.483.773.483 1.353v2.898c0 .645-.178 1.128-.531 1.449-.355.323-.693.483-1.014.483-.451 0-.854-.177-1.207-.531-.355-.353-.531-.821-.531-1.401v-2.898h-.002zm-3.864-4.154l1.063 3.864h.097l.966-3.864h1.642l-2.125 6.183v2.802H14.3v-2.608l-2.029-6.376h1.643v-.001zm18.452 20.095c0 1.289-.435 2.384-1.304 3.285-.869.903-1.949 1.353-3.236 1.353H12.175c-1.289 0-2.367-.45-3.236-1.353-.87-.901-1.304-1.995-1.304-3.285v-4.251c0-1.288.435-2.382 1.304-3.285.869-.901 1.947-1.353 3.236-1.353h15.651c1.288 0 2.367.451 3.236 1.353.869.903 1.304 1.997 1.304 3.285v4.251zm-14.588-4.348h1.063v6.763h-1.159v-.869c-.323.386-.548.613-.676.676-.193.13-.42.193-.676.193-.258 0-.451-.097-.58-.29-.193-.193-.29-.483-.29-.869v-5.603h1.159v5.217c0 .13.032.226.097.29.063.065.128.097.193.097a.852.852 0 0 0 .386-.097c.257-.128.418-.225.483-.29v-5.218zm1.642-7.922c.128 0 .257-.063.386-.193.129-.128.194-.256.194-.386v-3.188c0-.128-.065-.242-.193-.338a.643.643 0 0 0-.386-.145c-.193 0-.338.048-.435.145a.464.464 0 0 0-.145.338v3.188c0 .193.048.338.145.435.096.096.241.144.434.144zm3.671 8.164c.193.29.29.693.29 1.208v3.961c0 .386-.097.709-.29.966a.917.917 0 0 1-.773.386c-.258 0-.468-.048-.628-.145a2.894 2.894 0 0 1-.531-.435v.483H20v-8.888h1.063v2.608c.128-.128.321-.257.58-.386.193-.128.386-.193.58-.193.385 0 .675.145.868.435zm-.869 1.207c0-.063-.065-.225-.193-.483-.065-.063-.193-.097-.386-.097h-.193c-.193.13-.323.193-.386.193v4.444c.063.065.193.13.386.193.063.065.16.097.29.097.128 0 .225-.063.29-.193.128-.128.193-.257.193-.386V24.83h-.001zm-6.666-3.671h-3.381v1.063h1.063v7.922h1.159v-7.922h1.159v-1.063zm11.883 2.657c.257.29.386.886.386 1.787v1.159H25.7v1.449c0 .323.032.548.097.676.063.13.193.193.386.193s.322-.048.386-.145c.063-.097.097-.338.097-.725v-.193h1.159v.29c0 .58-.145 1.031-.435 1.353-.29.323-.693.483-1.208.483-.516 0-.934-.16-1.256-.483-.323-.321-.483-.773-.483-1.353v-2.705c0-.836.16-1.416.483-1.739.322-.322.74-.483 1.256-.483.581.001.999.146 1.257.436zm-.773 1.787c0-.58-.033-.918-.097-1.014-.065-.096-.193-.145-.386-.145s-.323.048-.386.145c-.065.097-.097.435-.097 1.014v.193h.966v-.193z" fill-rule="nonzero"></path></symbol></svg></div>
+
+
+
+<nav id="navSkipLinks">
+	<ul>
+        
+		<li><a href="#main-nav">Zur Haupt-Navigation</a></li>
+		
+		<li><a href="#content">Zum Inhalt</a></li>
+		
+		
+		
+	</ul>
+</nav>
+
+
+
+
+<div class="page" data-component="02_atoms/PreFilter" data-filter-ids="[&quot;&quot;]">
+
+    <div class="page__header">
+
+        
+    <header class="page-header" role="banner" id="page-header">
+        <div class="page-header__main-nav-container" data-component="03_molecules/MainNavHeader">
+            <div class="page-header__main-nav-header">
+                <a href="/close" role="button" aria-label="Menü">
+                    <span class="visuallyhidden">Klicken um Navigation zu öffnen/schließen</span>
+                    <svg class="icon">
+                        <use xlink:href="#icon-close"></use>
+                    </svg>
+                </a>
+            </div>
+        </div>
+
+        <div class="page-header__content-container">
+
+            <div class="page-header__content-container-row">
+
+                <div class="page-header__menu">
+                    <a class="menu-button" href="/" data-component="03_molecules/MenuButton" role="button">
+                        <span>Menü</span>
+                        <span class="visuallyhidden">Klicken um Navigation zu öffnen/schließen</span>
+                    </a>
+                    <a class="home-link" href="/">
+                        <svg class="icon icon--fill-current" aria-hidden="true"><use xlink:href="#icon-bso-favicon"></use></svg>
+                        <span class="visuallyhidden">Zur Startseite</span>
+                    </a>
+                </div>
+
+                
+    <div class="page-header__logo">
+        
+        <div class="brand-switch-wrapper container-query-mobile" data-component="02_atoms/BrandSwitchObserver">
+            <label class="brand-switch-mobile" data-component="03_molecules/BrandSwitch" data-target=".brand-switch-wrapper .brand-switch" data-toggle="show">
+                <input class="brand-switch-mobile__input" type="checkbox" name="brand-switch" value="open" aria-label="Auswählen um die Häuser zu wechseln">
+                <span>
+                
+                        Bayerische Staatsoper
+                    
+                </span>
+                <svg class="icon icon--stroke-current" aria-hidden="true"><use xlink:href="#icon-arrow-down"></use></svg>
+            </label>
+            <ul class="brand-switch" aria-label="Auswählen um die Häuser zu wechseln">
+                <li class="brand-switch__active">
+                    <a href="/">
+                        Bayerische Staatsoper
+                    </a>
+                </li>
+                <li>
+                    <a href="/staatsballett">
+                        Bayerisches Staatsballett
+                    </a>
+                </li>
+                <li>
+                    <a href="/staatsorchester">
+                        Bayerisches Staatsorchester
+                    </a>
+                </li>
+                <li class=" brand-switch--only-mobile">
+                    
+                    
+    
+            <a class="skip-external remove-external-hint uppercase" title="Staatsoper.tv" href="/tv">
+                Staatsoper.tv
+            </a>
+        
+
+                </li>
+            </ul>
+        </div>
+    </div>
+
+
+                <div class="page-header__actions">
+                    <button class="button button--plain button--dark button--header button--a11y" data-component="02_atoms/A11yButton" data-text-size="&lt;span&gt;Kleinere&lt;/span&gt;&lt;span&gt;Grössere&lt;/span&gt;&amp;nbsp;Schrift" data-reset-text="Zurücksetzen" data-close-text="Suche schließen" aria-label="Accessibility Einstellungen">
+                        <span class="icon-fontsize"></span>
+                    </button>
+                    
+    
+        <div class="language-switch">
+        
+            
+        
+            
+                <a href="/en/schedule" hreflang="en" data-tracking-event="changeLanguage" data-tracking-eventlabel="angepasst" data-tracking-eventaction="English" data-tracking-eventcategory="Sprache" data-tracking-trigger="click">EN</a>
+            
+        
+        </div>
+    
+
+                    
+                    
+    
+            
+            <a class="skip-external remove-external-hint button--header  hide-on-md uppercase" href="/tv">
+                Staatsoper.tv
+            </a>
+        
+
+                    <a data-component="03_molecules/ScheduleButton" class="button--header page-header__schedule hide-on-sm uppercase" href="/spielplan">
+                        <svg class="icon -mt-0.5 mr-1"><use xlink:href="#icon-calendar"></use></svg> Spielplan
+                    </a>
+                </div>
+            </div>
+
+            <div class="row">
+                <div class="page-header__action-wrapper">
+                    <div class="page-header__action" data-component="03_molecules/PageHeaderAction"></div>
+                </div>
+            </div>
+        </div>
+
+        <div class="page-header__aside-container">
+            <div class="page-header__aside-header" data-component="03_molecules/ScheduleAside" data-action="toggle">
+                
+                        <span class="page-header__aside-header-center">Kalender</span>
+                    
+            </div>
+        </div>
+    </header>
+
+
+    </div>
+
+    <div class="page__main">
+
+        <div class="page__main-nav">
+            
+    <nav class="main-nav">
+
+        
+    <ul class="main-nav__section" id="main-nav" data-component="03_molecules/MainNav">
+        
+            <li>
+                <input id="main-nav-121" type="checkbox" aria-labelledby="main-nav-heading-121" role="button" aria-pressed="false" class="visuallyhidden" aria-controls="main-nav-panel-121">
+
+                <div class="main-nav__section-content">
+                    
+                            
+                                    <label for="main-nav-121" id="main-nav-heading-121">
+                                        Spielplan &amp; Repertoire
+                                        <svg class="icon"><use xlink:href="#icon-arrow-down"></use></svg>
+                                    </label>
+                                
+                        
+
+                    <ul id="main-nav-panel-121" role="region" aria-labelledby="main-nav-heading-121" data-parent="#main-nav">
+                        
+                            <li>
+                                <a href="/spielplan" title="Spielplan" class="navigation__sub-item-link">
+                                    Spielplan
+                                </a>
+                            </li>
+                        
+                            <li>
+                                <a href="/spielzeit-2025-26" title="Spielzeit 2025–26" class="navigation__sub-item-link">
+                                    Spielzeit 2025–26
+                                </a>
+                            </li>
+                        
+                            <li>
+                                <a href="/spielzeit-2026-27" title="Spielzeit 2026–27" class="navigation__sub-item-link">
+                                    Spielzeit 2026–27
+                                </a>
+                            </li>
+                        
+                            <li>
+                                <a href="/festivals" title="Festivals" class="navigation__sub-item-link">
+                                    Festivals
+                                </a>
+                            </li>
+                        
+                            <li>
+                                <a href="/archiv" title="Archiv" class="navigation__sub-item-link">
+                                    Archiv
+                                </a>
+                            </li>
+                        
+                    </ul>
+                </div>
+            </li>
+        
+            <li>
+                <input id="main-nav-1256" type="checkbox" aria-labelledby="main-nav-heading-1256" role="button" aria-pressed="false" class="visuallyhidden" aria-controls="main-nav-panel-1256">
+
+                <div class="main-nav__section-content">
+                    
+                            
+                                    <label for="main-nav-1256" id="main-nav-heading-1256">
+                                        Karten &amp; Abos
+                                        <svg class="icon"><use xlink:href="#icon-arrow-down"></use></svg>
+                                    </label>
+                                
+                        
+
+                    <ul id="main-nav-panel-1256" role="region" aria-labelledby="main-nav-heading-1256" data-parent="#main-nav">
+                        
+                            <li>
+                                <a href="/kartenkauf" title="Kartenkauf: So geht's" class="navigation__sub-item-link">
+                                    Kartenkauf: So geht's
+                                </a>
+                            </li>
+                        
+                            <li>
+                                <a href="/gutscheine" title="Gutscheine" class="navigation__sub-item-link">
+                                    Gutscheine
+                                </a>
+                            </li>
+                        
+                            <li>
+                                <a href="/ermaessigungen" title="Ermäßigungen" class="navigation__sub-item-link">
+                                    Ermäßigungen
+                                </a>
+                            </li>
+                        
+                            <li>
+                                <a href="/kleiner30" title="&lt;30" class="navigation__sub-item-link">
+                                    &lt;30
+                                </a>
+                            </li>
+                        
+                            <li>
+                                <a href="https://kartenboerse.staatsoper.de/" title="Kartenbörse" target="_blank" class="navigation__sub-item-link">
+                                    Kartenbörse
+                                </a>
+                            </li>
+                        
+                            <li>
+                                <a href="/abo" title="Abos" class="navigation__sub-item-link">
+                                    Abos
+                                </a>
+                            </li>
+                        
+                    </ul>
+                </div>
+            </li>
+        
+            <li>
+                <input id="main-nav-131" type="checkbox" aria-labelledby="main-nav-heading-131" role="button" aria-pressed="false" class="visuallyhidden" aria-controls="main-nav-panel-131">
+
+                <div class="main-nav__section-content">
+                    
+                            
+                                    <label for="main-nav-131" id="main-nav-heading-131">
+                                        Service
+                                        <svg class="icon"><use xlink:href="#icon-arrow-down"></use></svg>
+                                    </label>
+                                
+                        
+
+                    <ul id="main-nav-panel-131" role="region" aria-labelledby="main-nav-heading-131" data-parent="#main-nav">
+                        
+                            <li>
+                                <a href="/besuch" title="Alles zum Besuch" class="navigation__sub-item-link">
+                                    Alles zum Besuch
+                                </a>
+                            </li>
+                        
+                            <li>
+                                <a href="/ihr-besuch/gastronomie" title="Gastronomie" class="navigation__sub-item-link">
+                                    Gastronomie
+                                </a>
+                            </li>
+                        
+                            <li>
+                                <a href="/saalplaene" title="Saalpläne" class="navigation__sub-item-link">
+                                    Saalpläne
+                                </a>
+                            </li>
+                        
+                            <li>
+                                <a href="/fuehrungen" title="Führungen" class="navigation__sub-item-link">
+                                    Führungen
+                                </a>
+                            </li>
+                        
+                            <li>
+                                <a href="/umbesetzungen" title="Umbesetzungen" class="navigation__sub-item-link">
+                                    Umbesetzungen
+                                </a>
+                            </li>
+                        
+                            <li>
+                                <a href="/newsletter/anmeldung" title="Newsletter" class="navigation__sub-item-link">
+                                    Newsletter
+                                </a>
+                            </li>
+                        
+                            <li>
+                                <a href="/faq" title="FAQ" class="navigation__sub-item-link">
+                                    FAQ
+                                </a>
+                            </li>
+                        
+                            <li>
+                                <a href="/ihr-besuch/opernshop" title="Opernshop" target="_blank" class="navigation__sub-item-link">
+                                    Opernshop
+                                </a>
+                            </li>
+                        
+                            <li>
+                                <a href="/nationaltheater" title="Nationaltheater" class="navigation__sub-item-link">
+                                    Nationaltheater
+                                </a>
+                            </li>
+                        
+                    </ul>
+                </div>
+            </li>
+        
+            <li>
+                <input id="main-nav-141" type="checkbox" aria-labelledby="main-nav-heading-141" role="button" aria-pressed="false" class="visuallyhidden" aria-controls="main-nav-panel-141">
+
+                <div class="main-nav__section-content">
+                    
+                            
+                                    <label for="main-nav-141" id="main-nav-heading-141">
+                                        Haus &amp; Menschen
+                                        <svg class="icon"><use xlink:href="#icon-arrow-down"></use></svg>
+                                    </label>
+                                
+                        
+
+                    <ul id="main-nav-panel-141" role="region" aria-labelledby="main-nav-heading-141" data-parent="#main-nav">
+                        
+                            <li>
+                                <a href="/ueber-uns" title="Bayerische Staatsoper" class="navigation__sub-item-link">
+                                    Bayerische Staatsoper
+                                </a>
+                            </li>
+                        
+                            <li>
+                                <a href="/bayerisches-staatsballett" title="Bayerisches Staatsballett" class="navigation__sub-item-link">
+                                    Bayerisches Staatsballett
+                                </a>
+                            </li>
+                        
+                            <li>
+                                <a href="/staatsorchester" title="Bayerisches Staatsorchester" class="navigation__sub-item-link">
+                                    Bayerisches Staatsorchester
+                                </a>
+                            </li>
+                        
+                            <li>
+                                <a href="/junge-ensembles" title="Junge Ensembles" class="navigation__sub-item-link">
+                                    Junge Ensembles
+                                </a>
+                            </li>
+                        
+                            <li>
+                                <a href="/chor" title="Bayerischer Staatsopernchor" class="navigation__sub-item-link">
+                                    Bayerischer Staatsopernchor
+                                </a>
+                            </li>
+                        
+                            <li>
+                                <a href="/team" title="Team" class="navigation__sub-item-link">
+                                    Team
+                                </a>
+                            </li>
+                        
+                            <li>
+                                <a href="/jobs" title="Jobs" class="navigation__sub-item-link">
+                                    Jobs
+                                </a>
+                            </li>
+                        
+                    </ul>
+                </div>
+            </li>
+        
+            <li>
+                <input id="main-nav-148" type="checkbox" aria-labelledby="main-nav-heading-148" role="button" aria-pressed="false" class="visuallyhidden" aria-controls="main-nav-panel-148">
+
+                <div class="main-nav__section-content">
+                    
+                            
+                                    <label for="main-nav-148" id="main-nav-heading-148">
+                                        Communities und Kind &amp; Co
+                                        <svg class="icon"><use xlink:href="#icon-arrow-down"></use></svg>
+                                    </label>
+                                
+                        
+
+                    <ul id="main-nav-panel-148" role="region" aria-labelledby="main-nav-heading-148" data-parent="#main-nav">
+                        
+                            <li>
+                                <a href="/kind-und-co" title="Kind &amp; Co" class="navigation__sub-item-link">
+                                    Kind &amp; Co
+                                </a>
+                            </li>
+                        
+                            <li>
+                                <a href="/kulturelle-bildung" title="Kulturelle Bildung" class="navigation__sub-item-link">
+                                    Kulturelle Bildung
+                                </a>
+                            </li>
+                        
+                            <li>
+                                <a href="/community" title="Community" class="navigation__sub-item-link">
+                                    Community
+                                </a>
+                            </li>
+                        
+                    </ul>
+                </div>
+            </li>
+        
+            <li>
+                <input id="main-nav-1261" type="checkbox" aria-labelledby="main-nav-heading-1261" role="button" aria-pressed="false" class="visuallyhidden" aria-controls="main-nav-panel-1261">
+
+                <div class="main-nav__section-content">
+                    
+                            
+                                    <label for="main-nav-1261" id="main-nav-heading-1261">
+                                        Lesen, Sehen, Hören
+                                        <svg class="icon"><use xlink:href="#icon-arrow-down"></use></svg>
+                                    </label>
+                                
+                        
+
+                    <ul id="main-nav-panel-1261" role="region" aria-labelledby="main-nav-heading-1261" data-parent="#main-nav">
+                        
+                            <li>
+                                <a href="/tv" title="STAATSOPER.TV" class="navigation__sub-item-link">
+                                    STAATSOPER.TV
+                                </a>
+                            </li>
+                        
+                            <li>
+                                <a href="/podcast" title="Podcasts" class="navigation__sub-item-link">
+                                    Podcasts
+                                </a>
+                            </li>
+                        
+                            <li>
+                                <a href="https://www.apollon-dossier.de/" title="Apollon" target="_blank" class="navigation__sub-item-link">
+                                    Apollon
+                                </a>
+                            </li>
+                        
+                            <li>
+                                <a href="/recordings" title="Bayerische Staatsoper Recordings" class="navigation__sub-item-link">
+                                    Bayerische Staatsoper Recordings
+                                </a>
+                            </li>
+                        
+                    </ul>
+                </div>
+            </li>
+        
+            <li>
+                <input id="main-nav-157" type="checkbox" aria-labelledby="main-nav-heading-157" role="button" aria-pressed="false" class="visuallyhidden" aria-controls="main-nav-panel-157">
+
+                <div class="main-nav__section-content">
+                    
+                            
+                                    <label for="main-nav-157" id="main-nav-heading-157">
+                                        Danke
+                                        <svg class="icon"><use xlink:href="#icon-arrow-down"></use></svg>
+                                    </label>
+                                
+                        
+
+                    <ul id="main-nav-panel-157" role="region" aria-labelledby="main-nav-heading-157" data-parent="#main-nav">
+                        
+                            <li>
+                                <a href="/unser-dank" title="Unser Dank" class="navigation__sub-item-link">
+                                    Unser Dank
+                                </a>
+                            </li>
+                        
+                            <li>
+                                <a href="/unser-dank/global-partner" title="Global Partner" class="navigation__sub-item-link">
+                                    Global Partner
+                                </a>
+                            </li>
+                        
+                            <li>
+                                <a href="/partner" title="Partner:innen" class="navigation__sub-item-link">
+                                    Partner:innen
+                                </a>
+                            </li>
+                        
+                            <li>
+                                <a href="/foerdervereine" title="Fördervereine" class="navigation__sub-item-link">
+                                    Fördervereine
+                                </a>
+                            </li>
+                        
+                    </ul>
+                </div>
+            </li>
+        
+    </ul>
+
+
+        
+            
+    
+        
+            
+        
+            
+                <a href="/en/schedule" title="English" class="main-nav__language-switch hide-from-sm" hreflang="en" data-tracking-event="changeLanguage" data-tracking-eventlabel="angepasst" data-tracking-eventaction="English" data-tracking-eventcategory="Sprache" data-tracking-trigger="click">English</a>
+            
+        
+    
+
+        
+
+        
+            
+                
+                    
+                    <div class="main-nav__sponsor-logo">
+                        
+                                
+                                    <img src="/fileadmin/user_upload/2021/05/bmw_logo_gray.png" width="340" height="78" alt="BMW GLOBAL Partner">
+                                
+                            
+                    </div>
+                
+            
+        
+    </nav>
+
+        </div>
+
+        <div class="page__main-content">
+
+            
+                <div class="search-strip search-strip--schedule">
+                    <form data-component="03_molecules/ScheduleSearch" novalidate="novalidate">
+                        <input id="schedule-search" type="text" name="search" placeholder="Stück, Künstler, Ort, usw. suchen">
+                        <label for="schedule-search" class="visuallyhidden">Stück, Künstler, Ort, usw. suchen</label>
+                        <button type="submit" class="button button--header button--dark ml-auto hover-underline">
+                            <svg class="icon icon--stroke mr-2"><use xlink:href="#icon-search"></use></svg>
+                            Suchen
+                        </button>
+                        <button data-action="reset" type="reset" class="button button--header">
+                            Zurücksetzen
+                        </button>
+                    </form>
+                </div>
+            
+
+            
+            
+    
+        <div class="page-notice__container">
+            <div class="page-notice__container-inner">
+                
+                    
+                        
+                    
+                
+            </div>
+        </div>
+        
+            
+                
+            
+        
+    
+
+
+            
+    <!--TYPO3SEARCH_begin-->
+    <main id="content" class="main-content-container" role="main">
+        
+        
+<div id="c520" class="component-container component-headline-font--type- component-container--list component-container--no-spacing component-container--no-header component-container--plugin"><div class="content-container"><div data-component="03_molecules/FilterContent" data-has-root="" data-tags="[]"><div class="season-filter"><div class="season-filter__wrapper"><div class="season-filter__title">
+                Filter für den gesamten Spielplan
+            </div><form data-component="03_molecules/SeasonFilter" data-spielplan-url="/spielplan" method="get" name="schedulerfilter" class="season-filter__form" action="/spielplan" novalidate="novalidate"><div><input type="hidden" name="tx_sfstaatsoper_activitieslist[__referrer][@extension]" value="Sfstaatsoper"><input type="hidden" name="tx_sfstaatsoper_activitieslist[__referrer][@controller]" value="Activities"><input type="hidden" name="tx_sfstaatsoper_activitieslist[__referrer][@action]" value="list"><input type="hidden" name="tx_sfstaatsoper_activitieslist[__referrer][arguments]" value="YTowOnt93b28a4a1b705559f76ce1f37c6176733ad3b31ae"><input type="hidden" name="tx_sfstaatsoper_activitieslist[__referrer][@request]" value="{&quot;@extension&quot;:&quot;Sfstaatsoper&quot;,&quot;@controller&quot;:&quot;Activities&quot;,&quot;@action&quot;:&quot;list&quot;}26189384cbfea2bd572cda187ce3d557f8dc2cbd"><input type="hidden" name="tx_sfstaatsoper_activitieslist[__trustedProperties]" value="{&quot;premiere&quot;:1,&quot;staatsopertv&quot;:1,&quot;u30&quot;:1,&quot;family&quot;:1,&quot;operforall&quot;:1,&quot;operafestival&quot;:1,&quot;balletfestivalweek&quot;:1,&quot;submit&quot;:1}be06a9b4b25ac5d8d69c1b1818a99a0a663a735b"></div><label><input type="hidden" name="tx_sfstaatsoper_activitieslist[premiere]" value=""><input class="visuallyhidden" id="form-filter-premiere" type="checkbox" name="tx_sfstaatsoper_activitieslist[premiere]" value="1"><span>Premiere</span></label><label><input type="hidden" name="tx_sfstaatsoper_activitieslist[staatsopertv]" value=""><input class="visuallyhidden" id="form-filter-staatsopertv" type="checkbox" name="tx_sfstaatsoper_activitieslist[staatsopertv]" value="1"><span>Staatsoper TV</span></label><label><input type="hidden" name="tx_sfstaatsoper_activitieslist[u30]" value=""><input class="visuallyhidden" id="form-filter-u30" type="checkbox" name="tx_sfstaatsoper_activitieslist[u30]" value="1"><span>&lt;30</span></label><label><input type="hidden" name="tx_sfstaatsoper_activitieslist[family]" value=""><input class="visuallyhidden" id="form-filter-family" type="checkbox" name="tx_sfstaatsoper_activitieslist[family]" value="1"><span>Familienvorstellung</span></label><label><input type="hidden" name="tx_sfstaatsoper_activitieslist[operforall]" value=""><input class="visuallyhidden" id="form-filter-operforall" type="checkbox" name="tx_sfstaatsoper_activitieslist[operforall]" value="1"><span>Oper für alle</span></label><label><input type="hidden" name="tx_sfstaatsoper_activitieslist[operafestival]" value=""><input class="visuallyhidden" id="form-filter-operafestival" type="checkbox" name="tx_sfstaatsoper_activitieslist[operafestival]" value="1"><span>Opernfestspiele</span></label><label><input type="hidden" name="tx_sfstaatsoper_activitieslist[balletfestivalweek]" value=""><input class="visuallyhidden" id="form-filter-balletfestivalweek" type="checkbox" name="tx_sfstaatsoper_activitieslist[balletfestivalweek]" value="1"><span>Ballettfestwoche</span></label><input type="hidden" name="tx_sfstaatsoper_activitieslist[submit]" value="Submit"></form></div><a href="/spielplan"><svg class="icon icon--fill-current" aria-hidden="true"><use xlink:href="#icon-arrow-rotate-left"></use></svg>
+            Zurücksetzen
+        </a></div><div class="activity-navigation hide-on-sm" data-component="03_molecules/ActivityNavigation" data-language="de-DE"><button type="button" class="button"><svg class="icon"><use xlink:href="#icon-arrow-left"></use></svg><span class="visuallyhidden">Zum vorherigen Monat gehen</span></button><span><time>April 2026</time></span><button type="button" class="button activity-navigation__button-visible"><svg class="icon"><use xlink:href="#icon-arrow-right"></use></svg><span class="visuallyhidden">Zum nächsten Monat gehen</span></button></div><div class="activity-list" data-activity-list-root="" data-content-search="activity-list__row"><div class="activity-group"><div data-date="2026-04-02" class="activity-list__row" data-schedule-filter="{&quot;date&quot;:&quot;2026-04-02&quot;,&quot;filter&quot;:{&quot;type&quot;:[{&quot;name&quot;:&quot;Ballett&quot;,&quot;sort&quot;:-1}],&quot;availability&quot;:[],&quot;category&quot;:[],&quot;festival&quot;:[]}}" data-additional-info="{&quot;premiere&quot;:{&quot;state&quot;:false,&quot;color&quot;:&quot;&quot;,&quot;colorSecondary&quot;:&quot;&quot;,&quot;date&quot;:&quot;2026-04-02&quot;}}" data-filtered="false"><div class="activity-list__col activity-list__col--content"><a class="activity-list__content" href="/stuecke/illusionen-wie-schwanensee/2026-04-02-1930-15593"><div class="activity-list__date"><time datetime="2026-04-02" class=""><span>
+                
+                 2<span class="activity-list__date--month">. April 2026</span><span class="activity-list__date--month-short">.4.26</span></span><em class="activity-list__date-day-long">Donnerstag</em><em class="activity-list__date-day-short">Do</em></time></div><div class="activity-list__text"><span>19.30 Uhr | Nationaltheater</span><span class="h3">ILLUSIONEN - WIE SCHWANENSEE</span><input class="activity-list--toggle" type="checkbox" value="15593" id="toggle-15593-1dc05f8469" aria-label="Weitere Informationen zu ILLUSIONEN - WIE SCHWANENSEE anzeigen"><div class="activity-list--toggle__content"><p>John Neumeier<br></p><p class="activity-list-price-info"><span>
+            
+                    
+                        Preise I
+                    
+                
+        </span>
+        
+                                Ballettfestwoche 2026<br></p></div><label class="activity-list--toggle__button" for="toggle-15593-1dc05f8469"><span class="show-more">mehr anzeigen</span><span class="show-less">weniger anzeigen</span><svg class="icon"><use xlink:href="#icon-arrow-down"></use></svg></label></div><div class="activity-list__channel hide-on-md">
+        
+                Ballett
+            
+    </div></a></div><div class="activity-list__col activity-list__col--genre">
+                                
+                                        Ballett
+                                    
+                            </div><div class="activity-list__col activity-list__col--tickets"><div><span class="hide-on-xs">ausverkauft</span><span class="hide-from-xs">ausverk.</span></div></div><!-- sold out --></div></div><div class="activity-group"><div data-date="2026-04-04" class="activity-list__row" data-schedule-filter="{&quot;date&quot;:&quot;2026-04-04&quot;,&quot;filter&quot;:{&quot;type&quot;:[{&quot;name&quot;:&quot;Extra&quot;,&quot;sort&quot;:-1}],&quot;availability&quot;:[],&quot;category&quot;:[],&quot;festival&quot;:[]}}" data-additional-info="[]" data-filtered="false"><div class="activity-list__col activity-list__col--content"><a class="activity-list__content" href="/stuecke/fuehrung/04-04-2026-1400-16511"><div class="activity-list__date"><time datetime="2026-04-04" class=""><span>
+                
+                 4<span class="activity-list__date--month">. April 2026</span><span class="activity-list__date--month-short">.4.26</span></span><em class="activity-list__date-day-long">Samstag</em><em class="activity-list__date-day-short">Sa</em></time></div><div class="activity-list__text"><span>14.00 Uhr | Freunde-Foyer (Eingang Nord, Alfons-Goppel-Straße)</span><span class="h3">Führung</span><input class="activity-list--toggle" type="checkbox" value="16511" id="toggle-16511-e6d7f8b72d" aria-label="Weitere Informationen zu Führung anzeigen"><div class="activity-list--toggle__content"><p class="activity-list-price-info"><span>
+            
+                    
+                        Preise PG15/7
+                    
+                
+        </span>
+        
+                                Führung<br></p></div><label class="activity-list--toggle__button" for="toggle-16511-e6d7f8b72d"><span class="show-more">mehr anzeigen</span><span class="show-less">weniger anzeigen</span><svg class="icon"><use xlink:href="#icon-arrow-down"></use></svg></label></div><div class="activity-list__channel hide-on-md">
+        
+                Extra
+            
+    </div></a></div><div class="activity-list__col activity-list__col--genre">
+                                
+                                        Extra
+                                    
+                            </div><div class="activity-list__col activity-list__col--tickets"><div><span class="hide-on-xs">ausverkauft</span><span class="hide-from-xs">ausverk.</span></div></div><!-- sold out --></div><div data-date="2026-04-04" class="activity-list__row activity-list__row--is-same-date" data-schedule-filter="{&quot;date&quot;:&quot;2026-04-04&quot;,&quot;filter&quot;:{&quot;type&quot;:[{&quot;name&quot;:&quot;Ballett&quot;,&quot;sort&quot;:-1}],&quot;availability&quot;:[],&quot;category&quot;:[],&quot;festival&quot;:[]}}" data-additional-info="{&quot;premiere&quot;:{&quot;state&quot;:false,&quot;color&quot;:&quot;&quot;,&quot;colorSecondary&quot;:&quot;&quot;,&quot;date&quot;:&quot;2026-04-04&quot;}}" data-filtered="false"><div class="activity-list__col activity-list__col--content"><a class="activity-list__content" href="/stuecke/waves-and-circles/2026-04-04-1930-15594"><div class="activity-list__date"><time datetime="2026-04-04" class=""><span>
+                
+                 4<span class="activity-list__date--month">. April 2026</span><span class="activity-list__date--month-short">.4.26</span></span><em class="activity-list__date-day-long">Samstag</em><em class="activity-list__date-day-short">Sa</em></time></div><div class="activity-list__text"><span>19.30 Uhr | Nationaltheater</span><span class="h3">WAVES AND CIRCLES</span><input class="activity-list--toggle" type="checkbox" value="15594" id="toggle-15594-6fb3f0aa66" aria-label="Weitere Informationen zu WAVES AND CIRCLES anzeigen"><div class="activity-list--toggle__content"><p>William Forsythe, Emma Portner, Maurice Béjart<br></p><p class="activity-list-price-info"><span>
+            
+                    
+                        Preise I
+                    
+                
+        </span>
+        
+                                Ballettfestwoche 2026<br></p></div><label class="activity-list--toggle__button" for="toggle-15594-6fb3f0aa66"><span class="show-more">mehr anzeigen</span><span class="show-less">weniger anzeigen</span><svg class="icon"><use xlink:href="#icon-arrow-down"></use></svg></label></div><div class="activity-list__channel hide-on-md">
+        
+                Ballett
+            
+    </div></a></div><div class="activity-list__col activity-list__col--genre">
+                                
+                                        Ballett
+                                    
+                            </div><div class="activity-list__col activity-list__col--tickets"><div><span class="hide-on-xs">ausverkauft</span><span class="hide-from-xs">ausverk.</span></div></div><!-- sold out --></div></div><div class="activity-group"><div data-date="2026-04-05" class="activity-list__row" data-schedule-filter="{&quot;date&quot;:&quot;2026-04-05&quot;,&quot;filter&quot;:{&quot;type&quot;:[{&quot;name&quot;:&quot;Oper&quot;,&quot;sort&quot;:-1}],&quot;availability&quot;:[{&quot;name&quot;:&quot;verf\u00fcgbar&quot;,&quot;sort&quot;:-1}],&quot;category&quot;:[{&quot;name&quot;:&quot;&lt;30&quot;,&quot;sort&quot;:-1}],&quot;festival&quot;:[]}}" data-additional-info="{&quot;premiere&quot;:{&quot;state&quot;:false,&quot;color&quot;:&quot;&quot;,&quot;colorSecondary&quot;:&quot;&quot;,&quot;date&quot;:&quot;2026-04-05&quot;}}" data-filtered="false"><div class="activity-list__col activity-list__col--content"><a class="activity-list__content" href="/stuecke/parsifal/2026-04-05-1700-15595"><div class="activity-list__date"><time datetime="2026-04-05" class=""><span>
+                
+                 5<span class="activity-list__date--month">. April 2026</span><span class="activity-list__date--month-short">.4.26</span></span><em class="activity-list__date-day-long">Sonntag</em><em class="activity-list__date-day-short">So</em></time></div><div class="activity-list__text"><span>16.00 Uhr | Nationaltheater</span><span class="h3">PARSIFAL</span><input class="activity-list--toggle" type="checkbox" value="15595" id="toggle-15595-2d85fbef50" aria-label="Weitere Informationen zu PARSIFAL anzeigen"><div class="activity-list--toggle__content"><p>Richard Wagner<br></p><p class="activity-list-price-info"><span>
+            
+                    
+                            
+                                    
+                                            Preise
+                                            L
+                                                    
+                                                            , €
+                                                            163 /142 /117 /91 /64 /- /15 /11
+                                                        
+                                                
+                                        
+                                
+                        
+                
+        </span>
+        
+                                Abo-Geschenk-Abo I, &lt;30<br></p></div><label class="activity-list--toggle__button" for="toggle-15595-2d85fbef50"><span class="show-more">mehr anzeigen</span><span class="show-less">weniger anzeigen</span><svg class="icon"><use xlink:href="#icon-arrow-down"></use></svg></label></div><div class="activity-list__channel hide-on-md">
+        
+                Oper
+            
+    </div></a></div><div class="activity-list__col activity-list__col--genre">
+                                
+                                        Oper
+                                    
+                            </div><div class="activity-list__col activity-list__col--tickets"><div><a class="button button--ticket" href="https://tickets.staatstheater.bayern/bso.webshop/webticket/shop?language=de&amp;event=40150" target="_blank"><span>Tickets</span></a></div></div><div class="activity-list__col activity-list__col--actions"><a class="button-save-date" href="/stuecke/parsifal/2026-04-05-1700-15595/calendar.ics"><svg class="icon icon-stroke"><use xlink:href="#icon-calendar"></use></svg><span>Termin merken</span></a></div></div></div><div class="activity-group"><div data-date="2026-04-06" class="activity-list__row" data-schedule-filter="{&quot;date&quot;:&quot;2026-04-06&quot;,&quot;filter&quot;:{&quot;type&quot;:[{&quot;name&quot;:&quot;Extra&quot;,&quot;sort&quot;:-1}],&quot;availability&quot;:[{&quot;name&quot;:&quot;verf\u00fcgbar&quot;,&quot;sort&quot;:-1}],&quot;category&quot;:[],&quot;festival&quot;:[]}}" data-additional-info="[]" data-filtered="false"><div class="activity-list__col activity-list__col--content"><a class="activity-list__content" href="/stuecke/fuehrung/06-04-2026-1400-16512"><div class="activity-list__date"><time datetime="2026-04-06" class=""><span>
+                
+                 6<span class="activity-list__date--month">. April 2026</span><span class="activity-list__date--month-short">.4.26</span></span><em class="activity-list__date-day-long">Montag</em><em class="activity-list__date-day-short">Mo</em></time></div><div class="activity-list__text"><span>14.00 Uhr | Freunde-Foyer (Eingang Nord, Alfons-Goppel-Straße)</span><span class="h3">Führung</span><input class="activity-list--toggle" type="checkbox" value="16512" id="toggle-16512-a7711ee936" aria-label="Weitere Informationen zu Führung anzeigen"><div class="activity-list--toggle__content"><p class="activity-list-price-info"><span>
+            
+                    
+                            
+                                    
+                                            Preise
+                                            PG15/7
+                                                    
+                                                            , €
+                                                            15
+                                                        
+                                                
+                                        
+                                
+                        
+                
+        </span>
+        
+                                Führung<br></p></div><label class="activity-list--toggle__button" for="toggle-16512-a7711ee936"><span class="show-more">mehr anzeigen</span><span class="show-less">weniger anzeigen</span><svg class="icon"><use xlink:href="#icon-arrow-down"></use></svg></label></div><div class="activity-list__channel hide-on-md">
+        
+                Extra
+            
+    </div></a></div><div class="activity-list__col activity-list__col--genre">
+                                
+                                        Extra
+                                    
+                            </div><div class="activity-list__col activity-list__col--tickets"><div><a class="button button--ticket" href="https://tickets.staatstheater.bayern/bso.webshop/webticket/shop?language=de&amp;event=42165" target="_blank"><span>Tickets</span></a></div></div><div class="activity-list__col activity-list__col--actions"><a class="button-save-date" href="/stuecke/fuehrung/06-04-2026-1400-16512/calendar.ics"><svg class="icon icon-stroke"><use xlink:href="#icon-calendar"></use></svg><span>Termin merken</span></a></div></div><div data-date="2026-04-06" class="activity-list__row activity-list__row--is-same-date" data-schedule-filter="{&quot;date&quot;:&quot;2026-04-06&quot;,&quot;filter&quot;:{&quot;type&quot;:[{&quot;name&quot;:&quot;Extra&quot;,&quot;sort&quot;:-1}],&quot;availability&quot;:[{&quot;name&quot;:&quot;verf\u00fcgbar&quot;,&quot;sort&quot;:-1}],&quot;category&quot;:[],&quot;festival&quot;:[]}}" data-additional-info="[]" data-filtered="false"><div class="activity-list__col activity-list__col--content"><a class="activity-list__content" href="/stuecke/guided-tour-of-the-national-theatre/06-04-2026-1400-16526"><div class="activity-list__date"><time datetime="2026-04-06" class=""><span>
+                
+                 6<span class="activity-list__date--month">. April 2026</span><span class="activity-list__date--month-short">.4.26</span></span><em class="activity-list__date-day-long">Montag</em><em class="activity-list__date-day-short">Mo</em></time></div><div class="activity-list__text"><span>14.00 Uhr | Freunde-Foyer (Eingang Nord, Alfons-Goppel-Straße)</span><span class="h3">Guided tour of the Nationaltheater</span><input class="activity-list--toggle" type="checkbox" value="16526" id="toggle-16526-ccae56a0a7" aria-label="Weitere Informationen zu Guided tour of the Nationaltheater anzeigen"><div class="activity-list--toggle__content"><p class="activity-list-price-info"><span>
+            
+                    
+                            
+                                    
+                                            Preise
+                                            PG15/7
+                                                    
+                                                            , €
+                                                            15
+                                                        
+                                                
+                                        
+                                
+                        
+                
+        </span>
+        
+                                Führung<br></p></div><label class="activity-list--toggle__button" for="toggle-16526-ccae56a0a7"><span class="show-more">mehr anzeigen</span><span class="show-less">weniger anzeigen</span><svg class="icon"><use xlink:href="#icon-arrow-down"></use></svg></label></div><div class="activity-list__channel hide-on-md">
+        
+                Extra
+            
+    </div></a></div><div class="activity-list__col activity-list__col--genre">
+                                
+                                        Extra
+                                    
+                            </div><div class="activity-list__col activity-list__col--tickets"><div><a class="button button--ticket" href="https://tickets.staatstheater.bayern/bso.webshop/webticket/shop?language=de&amp;event=42170" target="_blank"><span>Tickets</span></a></div></div><div class="activity-list__col activity-list__col--actions"><a class="button-save-date" href="/stuecke/guided-tour-of-the-national-theatre/06-04-2026-1400-16526/calendar.ics"><svg class="icon icon-stroke"><use xlink:href="#icon-calendar"></use></svg><span>Termin merken</span></a></div></div><div data-date="2026-04-06" class="activity-list__row activity-list__row--is-same-date" data-schedule-filter="{&quot;date&quot;:&quot;2026-04-06&quot;,&quot;filter&quot;:{&quot;type&quot;:[{&quot;name&quot;:&quot;Oper&quot;,&quot;sort&quot;:-1}],&quot;availability&quot;:[{&quot;name&quot;:&quot;verf\u00fcgbar&quot;,&quot;sort&quot;:-1}],&quot;category&quot;:[{&quot;name&quot;:&quot;&lt;30&quot;,&quot;sort&quot;:-1}],&quot;festival&quot;:[]}}" data-additional-info="{&quot;premiere&quot;:{&quot;state&quot;:false,&quot;color&quot;:&quot;#b5e1f1&quot;,&quot;colorSecondary&quot;:&quot;&quot;,&quot;date&quot;:&quot;2026-04-06&quot;}}" data-filtered="false"><div class="activity-list__col activity-list__col--content"><a class="activity-list__content" href="/stuecke/tosca/2026-04-06-1800-15596"><div class="activity-list__date"><time datetime="2026-04-06" class=""><span>
+                
+                 6<span class="activity-list__date--month">. April 2026</span><span class="activity-list__date--month-short">.4.26</span></span><em class="activity-list__date-day-long">Montag</em><em class="activity-list__date-day-short">Mo</em></time></div><div class="activity-list__text"><span>18.00 Uhr | Nationaltheater</span><span class="h3">TOSCA</span><input class="activity-list--toggle" type="checkbox" value="15596" id="toggle-15596-6c1712e7fc" aria-label="Weitere Informationen zu TOSCA anzeigen"><div class="activity-list--toggle__content"><p>Giacomo Puccini<br></p><p class="activity-list-price-info"><span>
+            
+                    
+                            
+                                    
+                                            Preise
+                                            L
+                                                    
+                                                            , €
+                                                            163 /142 /117 /- /- /- /- /11
+                                                        
+                                                
+                                        
+                                
+                        
+                
+        </span>&lt;30<br></p></div><label class="activity-list--toggle__button" for="toggle-15596-6c1712e7fc"><span class="show-more">mehr anzeigen</span><span class="show-less">weniger anzeigen</span><svg class="icon"><use xlink:href="#icon-arrow-down"></use></svg></label></div><div class="activity-list__channel hide-on-md">
+        
+                Oper
+            
+    </div></a></div><div class="activity-list__col activity-list__col--genre">
+                                
+                                        Oper
+                                    
+                            </div><div class="activity-list__col activity-list__col--tickets"><div><a class="button button--ticket" href="https://tickets.staatstheater.bayern/bso.webshop/webticket/shop?language=de&amp;event=40082" target="_blank"><span>Tickets</span></a></div></div><div class="activity-list__col activity-list__col--actions"><a class="button-save-date" href="/stuecke/tosca/2026-04-06-1800-15596/calendar.ics"><svg class="icon icon-stroke"><use xlink:href="#icon-calendar"></use></svg><span>Termin merken</span></a></div></div></div><div class="activity-group"><div data-date="2026-04-07" class="activity-list__row" data-schedule-filter="{&quot;date&quot;:&quot;2026-04-07&quot;,&quot;filter&quot;:{&quot;type&quot;:[{&quot;name&quot;:&quot;Oper&quot;,&quot;sort&quot;:-1}],&quot;availability&quot;:[{&quot;name&quot;:&quot;verf\u00fcgbar&quot;,&quot;sort&quot;:-1}],&quot;category&quot;:[],&quot;festival&quot;:[]}}" data-additional-info="{&quot;premiere&quot;:{&quot;state&quot;:false,&quot;color&quot;:&quot;&quot;,&quot;colorSecondary&quot;:&quot;&quot;,&quot;date&quot;:&quot;2026-04-07&quot;}}" data-filtered="false"><div class="activity-list__col activity-list__col--content"><a class="activity-list__content" href="/stuecke/macbeth/2026-04-07-1900-15597"><div class="activity-list__date"><time datetime="2026-04-07" class=""><span>
+                
+                 7<span class="activity-list__date--month">. April 2026</span><span class="activity-list__date--month-short">.4.26</span></span><em class="activity-list__date-day-long">Dienstag</em><em class="activity-list__date-day-short">Di</em></time></div><div class="activity-list__text"><span>19.00 Uhr | Nationaltheater</span><span class="h3">MACBETH</span><input class="activity-list--toggle" type="checkbox" value="15597" id="toggle-15597-310106df09" aria-label="Weitere Informationen zu MACBETH anzeigen"><div class="activity-list--toggle__content"><p>Giuseppe Verdi<br></p><p class="activity-list-price-info"><span>
+            
+                    
+                            
+                                    
+                                            Preise
+                                            K
+                                                    
+                                                            , €
+                                                            132 /115 /95 /74 /- /- /14 /10
+                                                        
+                                                
+                                        
+                                
+                        
+                
+        </span>
+        
+                                Abo-Serie 11<br></p></div><label class="activity-list--toggle__button" for="toggle-15597-310106df09"><span class="show-more">mehr anzeigen</span><span class="show-less">weniger anzeigen</span><svg class="icon"><use xlink:href="#icon-arrow-down"></use></svg></label></div><div class="activity-list__channel hide-on-md">
+        
+                Oper
+            
+    </div></a></div><div class="activity-list__col activity-list__col--genre">
+                                
+                                        Oper
+                                    
+                            </div><div class="activity-list__col activity-list__col--tickets"><div><a class="button button--ticket" href="https://tickets.staatstheater.bayern/bso.webshop/webticket/shop?language=de&amp;event=40184" target="_blank"><span>Tickets</span></a></div></div><div class="activity-list__col activity-list__col--actions"><a class="button-save-date" href="/stuecke/macbeth/2026-04-07-1900-15597/calendar.ics"><svg class="icon icon-stroke"><use xlink:href="#icon-calendar"></use></svg><span>Termin merken</span></a></div></div></div><div class="activity-group"><div data-date="2026-04-08" class="activity-list__row" data-schedule-filter="{&quot;date&quot;:&quot;2026-04-08&quot;,&quot;filter&quot;:{&quot;type&quot;:[{&quot;name&quot;:&quot;Oper&quot;,&quot;sort&quot;:-1}],&quot;availability&quot;:[{&quot;name&quot;:&quot;verf\u00fcgbar&quot;,&quot;sort&quot;:-1}],&quot;category&quot;:[],&quot;festival&quot;:[]}}" data-additional-info="{&quot;premiere&quot;:{&quot;state&quot;:false,&quot;color&quot;:&quot;&quot;,&quot;colorSecondary&quot;:&quot;&quot;,&quot;date&quot;:&quot;2026-04-08&quot;}}" data-filtered="false"><div class="activity-list__col activity-list__col--content"><a class="activity-list__content" href="/stuecke/parsifal/2026-04-08-1700-15598"><div class="activity-list__date"><time datetime="2026-04-08" class=""><span>
+                
+                 8<span class="activity-list__date--month">. April 2026</span><span class="activity-list__date--month-short">.4.26</span></span><em class="activity-list__date-day-long">Mittwoch</em><em class="activity-list__date-day-short">Mi</em></time></div><div class="activity-list__text"><span>17.00 Uhr | Nationaltheater</span><span class="h3">PARSIFAL</span><input class="activity-list--toggle" type="checkbox" value="15598" id="toggle-15598-45f02ca0e8" aria-label="Weitere Informationen zu PARSIFAL anzeigen"><div class="activity-list--toggle__content"><p>Richard Wagner<br></p><p class="activity-list-price-info"><span>
+            
+                    
+                            
+                                    
+                                            Preise
+                                            L
+                                                    
+                                                            , €
+                                                            163 /142 /117 /91 /64 /- /15 /11
+                                                        
+                                                
+                                        
+                                
+                        
+                
+        </span>
+        
+                                Abo-Serie 22<br></p></div><label class="activity-list--toggle__button" for="toggle-15598-45f02ca0e8"><span class="show-more">mehr anzeigen</span><span class="show-less">weniger anzeigen</span><svg class="icon"><use xlink:href="#icon-arrow-down"></use></svg></label></div><div class="activity-list__channel hide-on-md">
+        
+                Oper
+            
+    </div></a></div><div class="activity-list__col activity-list__col--genre">
+                                
+                                        Oper
+                                    
+                            </div><div class="activity-list__col activity-list__col--tickets"><div><a class="button button--ticket" href="https://tickets.staatstheater.bayern/bso.webshop/webticket/shop?language=de&amp;event=40151" target="_blank"><span>Tickets</span></a></div></div><div class="activity-list__col activity-list__col--actions"><a class="button-save-date" href="/stuecke/parsifal/2026-04-08-1700-15598/calendar.ics"><svg class="icon icon-stroke"><use xlink:href="#icon-calendar"></use></svg><span>Termin merken</span></a></div></div></div><div class="activity-group"><div data-date="2026-04-09" class="activity-list__row" data-schedule-filter="{&quot;date&quot;:&quot;2026-04-09&quot;,&quot;filter&quot;:{&quot;type&quot;:[{&quot;name&quot;:&quot;Oper&quot;,&quot;sort&quot;:-1}],&quot;availability&quot;:[{&quot;name&quot;:&quot;verf\u00fcgbar&quot;,&quot;sort&quot;:-1}],&quot;category&quot;:[],&quot;festival&quot;:[]}}" data-additional-info="{&quot;premiere&quot;:{&quot;state&quot;:false,&quot;color&quot;:&quot;#b5e1f1&quot;,&quot;colorSecondary&quot;:&quot;&quot;,&quot;date&quot;:&quot;2026-04-09&quot;}}" data-filtered="false"><div class="activity-list__col activity-list__col--content"><a class="activity-list__content" href="/stuecke/tosca/2026-04-09-1900-15599"><div class="activity-list__date"><time datetime="2026-04-09" class=""><span>
+                
+                 9<span class="activity-list__date--month">. April 2026</span><span class="activity-list__date--month-short">.4.26</span></span><em class="activity-list__date-day-long">Donnerstag</em><em class="activity-list__date-day-short">Do</em></time></div><div class="activity-list__text"><span>19.00 Uhr | Nationaltheater</span><span class="h3">TOSCA</span><input class="activity-list--toggle" type="checkbox" value="15599" id="toggle-15599-9131eb6934" aria-label="Weitere Informationen zu TOSCA anzeigen"><div class="activity-list--toggle__content"><p>Giacomo Puccini<br></p><p class="activity-list-price-info"><span>
+            
+                    
+                            
+                                    
+                                            Preise
+                                            L
+                                                    
+                                                            , €
+                                                            163 /142 /117 /- /- /- /- /11
+                                                        
+                                                
+                                        
+                                
+                        
+                
+        </span>
+        
+                                Abo-Serie 19<br></p></div><label class="activity-list--toggle__button" for="toggle-15599-9131eb6934"><span class="show-more">mehr anzeigen</span><span class="show-less">weniger anzeigen</span><svg class="icon"><use xlink:href="#icon-arrow-down"></use></svg></label></div><div class="activity-list__channel hide-on-md">
+        
+                Oper
+            
+    </div></a></div><div class="activity-list__col activity-list__col--genre">
+                                
+                                        Oper
+                                    
+                            </div><div class="activity-list__col activity-list__col--tickets"><div><a class="button button--ticket" href="https://tickets.staatstheater.bayern/bso.webshop/webticket/shop?language=de&amp;event=40089" target="_blank"><span>Tickets</span></a></div></div><div class="activity-list__col activity-list__col--actions"><a class="button-save-date" href="/stuecke/tosca/2026-04-09-1900-15599/calendar.ics"><svg class="icon icon-stroke"><use xlink:href="#icon-calendar"></use></svg><span>Termin merken</span></a></div></div></div><div class="activity-group"><div data-date="2026-04-10" class="activity-list__row" data-schedule-filter="{&quot;date&quot;:&quot;2026-04-10&quot;,&quot;filter&quot;:{&quot;type&quot;:[{&quot;name&quot;:&quot;Oper&quot;,&quot;sort&quot;:-1}],&quot;availability&quot;:[{&quot;name&quot;:&quot;verf\u00fcgbar&quot;,&quot;sort&quot;:-1}],&quot;category&quot;:[],&quot;festival&quot;:[]}}" data-additional-info="{&quot;premiere&quot;:{&quot;state&quot;:false,&quot;color&quot;:&quot;&quot;,&quot;colorSecondary&quot;:&quot;&quot;,&quot;date&quot;:&quot;2026-04-10&quot;}}" data-filtered="false"><div class="activity-list__col activity-list__col--content"><a class="activity-list__content" href="/stuecke/macbeth/2026-04-10-1900-15600"><div class="activity-list__date"><time datetime="2026-04-10" class=""><span>
+                
+                10<span class="activity-list__date--month">. April 2026</span><span class="activity-list__date--month-short">.4.26</span></span><em class="activity-list__date-day-long">Freitag</em><em class="activity-list__date-day-short">Fr</em></time></div><div class="activity-list__text"><span>19.00 Uhr | Nationaltheater</span><span class="h3">MACBETH</span><input class="activity-list--toggle" type="checkbox" value="15600" id="toggle-15600-85d779be74" aria-label="Weitere Informationen zu MACBETH anzeigen"><div class="activity-list--toggle__content"><p>Giuseppe Verdi<br></p><p class="activity-list-price-info"><span>
+            
+                    
+                            
+                                    
+                                            Preise
+                                            K
+                                                    
+                                                            , €
+                                                            132 /115 /95 /74 /52 /- /14 /10
+                                                        
+                                                
+                                        
+                                
+                        
+                
+        </span>
+        
+                                Abo-Serie 14<br></p></div><label class="activity-list--toggle__button" for="toggle-15600-85d779be74"><span class="show-more">mehr anzeigen</span><span class="show-less">weniger anzeigen</span><svg class="icon"><use xlink:href="#icon-arrow-down"></use></svg></label></div><div class="activity-list__channel hide-on-md">
+        
+                Oper
+            
+    </div></a></div><div class="activity-list__col activity-list__col--genre">
+                                
+                                        Oper
+                                    
+                            </div><div class="activity-list__col activity-list__col--tickets"><div><a class="button button--ticket" href="https://tickets.staatstheater.bayern/bso.webshop/webticket/shop?language=de&amp;event=40187" target="_blank"><span>Tickets</span></a></div></div><div class="activity-list__col activity-list__col--actions"><a class="button-save-date" href="/stuecke/macbeth/2026-04-10-1900-15600/calendar.ics"><svg class="icon icon-stroke"><use xlink:href="#icon-calendar"></use></svg><span>Termin merken</span></a></div></div></div><div class="activity-group"><div data-date="2026-04-11" class="activity-list__row" data-schedule-filter="{&quot;date&quot;:&quot;2026-04-11&quot;,&quot;filter&quot;:{&quot;type&quot;:[{&quot;name&quot;:&quot;Oper&quot;,&quot;sort&quot;:-1}],&quot;availability&quot;:[{&quot;name&quot;:&quot;verf\u00fcgbar&quot;,&quot;sort&quot;:-1}],&quot;category&quot;:[],&quot;festival&quot;:[]}}" data-additional-info="{&quot;premiere&quot;:{&quot;state&quot;:false,&quot;color&quot;:&quot;&quot;,&quot;colorSecondary&quot;:&quot;&quot;,&quot;date&quot;:&quot;2026-04-11&quot;}}" data-filtered="false"><div class="activity-list__col activity-list__col--content"><a class="activity-list__content" href="/stuecke/parsifal/2026-04-11-1700-15601"><div class="activity-list__date"><time datetime="2026-04-11" class=""><span>
+                
+                11<span class="activity-list__date--month">. April 2026</span><span class="activity-list__date--month-short">.4.26</span></span><em class="activity-list__date-day-long">Samstag</em><em class="activity-list__date-day-short">Sa</em></time></div><div class="activity-list__text"><span>16.00 Uhr | Nationaltheater</span><span class="h3">PARSIFAL</span><input class="activity-list--toggle" type="checkbox" value="15601" id="toggle-15601-b89fb5e060" aria-label="Weitere Informationen zu PARSIFAL anzeigen"><div class="activity-list--toggle__content"><p>Richard Wagner<br></p><p class="activity-list-price-info"><span>
+            
+                    
+                            
+                                    
+                                            Preise
+                                            L
+                                                    
+                                                            , €
+                                                            163 /142 /117 /- /64 /- /15 /11
+                                                        
+                                                
+                                        
+                                
+                        
+                
+        </span>
+        
+                                Abo-Serie 12<br></p></div><label class="activity-list--toggle__button" for="toggle-15601-b89fb5e060"><span class="show-more">mehr anzeigen</span><span class="show-less">weniger anzeigen</span><svg class="icon"><use xlink:href="#icon-arrow-down"></use></svg></label></div><div class="activity-list__channel hide-on-md">
+        
+                Oper
+            
+    </div></a></div><div class="activity-list__col activity-list__col--genre">
+                                
+                                        Oper
+                                    
+                            </div><div class="activity-list__col activity-list__col--tickets"><div><a class="button button--ticket" href="https://tickets.staatstheater.bayern/bso.webshop/webticket/shop?language=de&amp;event=40152" target="_blank"><span>Tickets</span></a></div></div><div class="activity-list__col activity-list__col--actions"><a class="button-save-date" href="/stuecke/parsifal/2026-04-11-1700-15601/calendar.ics"><svg class="icon icon-stroke"><use xlink:href="#icon-calendar"></use></svg><span>Termin merken</span></a></div></div></div><div class="activity-group"><div data-date="2026-04-12" class="activity-list__row" data-schedule-filter="{&quot;date&quot;:&quot;2026-04-12&quot;,&quot;filter&quot;:{&quot;type&quot;:[{&quot;name&quot;:&quot;Oper&quot;,&quot;sort&quot;:-1}],&quot;availability&quot;:[{&quot;name&quot;:&quot;verf\u00fcgbar&quot;,&quot;sort&quot;:-1}],&quot;category&quot;:[],&quot;festival&quot;:[]}}" data-additional-info="{&quot;premiere&quot;:{&quot;state&quot;:false,&quot;color&quot;:&quot;#b5e1f1&quot;,&quot;colorSecondary&quot;:&quot;&quot;,&quot;date&quot;:&quot;2026-04-12&quot;}}" data-filtered="false"><div class="activity-list__col activity-list__col--content"><a class="activity-list__content" href="/stuecke/tosca/2026-04-12-1700-15602"><div class="activity-list__date"><time datetime="2026-04-12" class=""><span>
+                
+                12<span class="activity-list__date--month">. April 2026</span><span class="activity-list__date--month-short">.4.26</span></span><em class="activity-list__date-day-long">Sonntag</em><em class="activity-list__date-day-short">So</em></time></div><div class="activity-list__text"><span>17.00 Uhr | Nationaltheater</span><span class="h3">TOSCA</span><input class="activity-list--toggle" type="checkbox" value="15602" id="toggle-15602-a90c2d0566" aria-label="Weitere Informationen zu TOSCA anzeigen"><div class="activity-list--toggle__content"><p>Giacomo Puccini<br></p><p class="activity-list-price-info"><span>
+            
+                    
+                            
+                                    
+                                            Preise
+                                            L
+                                                    
+                                                            , €
+                                                            163 /142 /117 /- /- /- /- /11
+                                                        
+                                                
+                                        
+                                
+                        
+                
+        </span>
+        
+                                Abo-Serie 16<br></p></div><label class="activity-list--toggle__button" for="toggle-15602-a90c2d0566"><span class="show-more">mehr anzeigen</span><span class="show-less">weniger anzeigen</span><svg class="icon"><use xlink:href="#icon-arrow-down"></use></svg></label></div><div class="activity-list__channel hide-on-md">
+        
+                Oper
+            
+    </div></a></div><div class="activity-list__col activity-list__col--genre">
+                                
+                                        Oper
+                                    
+                            </div><div class="activity-list__col activity-list__col--tickets"><div><a class="button button--ticket" href="https://tickets.staatstheater.bayern/bso.webshop/webticket/shop?language=de&amp;event=40090" target="_blank"><span>Tickets</span></a></div></div><div class="activity-list__col activity-list__col--actions"><a class="button-save-date" href="/stuecke/tosca/2026-04-12-1700-15602/calendar.ics"><svg class="icon icon-stroke"><use xlink:href="#icon-calendar"></use></svg><span>Termin merken</span></a></div></div></div><div class="activity-group"><div data-date="2026-04-13" class="activity-list__row" data-schedule-filter="{&quot;date&quot;:&quot;2026-04-13&quot;,&quot;filter&quot;:{&quot;type&quot;:[{&quot;name&quot;:&quot;Oper&quot;,&quot;sort&quot;:-1}],&quot;availability&quot;:[{&quot;name&quot;:&quot;verf\u00fcgbar&quot;,&quot;sort&quot;:-1}],&quot;category&quot;:[{&quot;name&quot;:&quot;&lt;30&quot;,&quot;sort&quot;:-1}],&quot;festival&quot;:[]}}" data-additional-info="{&quot;premiere&quot;:{&quot;state&quot;:false,&quot;color&quot;:&quot;&quot;,&quot;colorSecondary&quot;:&quot;&quot;,&quot;date&quot;:&quot;2026-04-13&quot;}}" data-filtered="false"><div class="activity-list__col activity-list__col--content"><a class="activity-list__content" href="/stuecke/macbeth/2026-04-13-1900-15603"><div class="activity-list__date"><time datetime="2026-04-13" class=""><span>
+                
+                13<span class="activity-list__date--month">. April 2026</span><span class="activity-list__date--month-short">.4.26</span></span><em class="activity-list__date-day-long">Montag</em><em class="activity-list__date-day-short">Mo</em></time></div><div class="activity-list__text"><span>19.00 Uhr | Nationaltheater</span><span class="h3">MACBETH</span><input class="activity-list--toggle" type="checkbox" value="15603" id="toggle-15603-79e73cb062" aria-label="Weitere Informationen zu MACBETH anzeigen"><div class="activity-list--toggle__content"><p>Giuseppe Verdi<br></p><p class="activity-list-price-info"><span>
+            
+                    
+                            
+                                    
+                                            Preise
+                                            K
+                                                    
+                                                            , €
+                                                            132 /115 /95 /74 /52 /- /14 /10
+                                                        
+                                                
+                                        
+                                
+                        
+                
+        </span>
+        
+                                Abo-Serie 10, &lt;30<br></p></div><label class="activity-list--toggle__button" for="toggle-15603-79e73cb062"><span class="show-more">mehr anzeigen</span><span class="show-less">weniger anzeigen</span><svg class="icon"><use xlink:href="#icon-arrow-down"></use></svg></label></div><div class="activity-list__channel hide-on-md">
+        
+                Oper
+            
+    </div></a></div><div class="activity-list__col activity-list__col--genre">
+                                
+                                        Oper
+                                    
+                            </div><div class="activity-list__col activity-list__col--tickets"><div><a class="button button--ticket" href="https://tickets.staatstheater.bayern/bso.webshop/webticket/shop?language=de&amp;event=40188" target="_blank"><span>Tickets</span></a></div></div><div class="activity-list__col activity-list__col--actions"><a class="button-save-date" href="/stuecke/macbeth/2026-04-13-1900-15603/calendar.ics"><svg class="icon icon-stroke"><use xlink:href="#icon-calendar"></use></svg><span>Termin merken</span></a></div></div></div><div class="activity-group"><div data-date="2026-04-14" class="activity-list__row" data-schedule-filter="{&quot;date&quot;:&quot;2026-04-14&quot;,&quot;filter&quot;:{&quot;type&quot;:[{&quot;name&quot;:&quot;Community&quot;,&quot;sort&quot;:-1}],&quot;availability&quot;:[{&quot;name&quot;:&quot;verf\u00fcgbar&quot;,&quot;sort&quot;:-1}],&quot;category&quot;:[],&quot;festival&quot;:[]}}" data-additional-info="{&quot;premiere&quot;:{&quot;state&quot;:false,&quot;color&quot;:&quot;&quot;,&quot;colorSecondary&quot;:&quot;&quot;,&quot;date&quot;:&quot;2026-04-14&quot;}}" data-filtered="false"><div class="activity-list__col activity-list__col--content"><a class="activity-list__content" href="/stuecke/open-stage-backstage/2026-04-14-2000-16455"><div class="activity-list__date"><time datetime="2026-04-14" class=""><span>
+                
+                14<span class="activity-list__date--month">. April 2026</span><span class="activity-list__date--month-short">.4.26</span></span><em class="activity-list__date-day-long">Dienstag</em><em class="activity-list__date-day-short">Di</em></time></div><div class="activity-list__text"><span>20.00 Uhr | Königssaal im Nationaltheater</span><span class="h3">Open Stage</span><input class="activity-list--toggle" type="checkbox" value="16455" id="toggle-16455-f31ab5f4da" aria-label="Weitere Informationen zu Open Stage anzeigen"><div class="activity-list--toggle__content"><p class="activity-list-price-info"><span></span><br></p></div><label class="activity-list--toggle__button" for="toggle-16455-f31ab5f4da"><span class="show-more">mehr anzeigen</span><span class="show-less">weniger anzeigen</span><svg class="icon"><use xlink:href="#icon-arrow-down"></use></svg></label></div><div class="activity-list__channel hide-on-md">
+        
+                Community
+            
+    </div></a></div><div class="activity-list__col activity-list__col--genre">
+                                
+                                        Community
+                                    
+                            </div><div class="activity-list__col activity-list__col--tickets"><div><span title="Kein verk."><!-- Kein verk. --></span></div></div><!-- NoSale 3 --></div></div><div class="activity-group"><div data-date="2026-04-16" class="activity-list__row" data-schedule-filter="{&quot;date&quot;:&quot;2026-04-16&quot;,&quot;filter&quot;:{&quot;type&quot;:[{&quot;name&quot;:&quot;Ballett&quot;,&quot;sort&quot;:-1}],&quot;availability&quot;:[{&quot;name&quot;:&quot;verf\u00fcgbar&quot;,&quot;sort&quot;:-1}],&quot;category&quot;:[],&quot;festival&quot;:[]}}" data-additional-info="{&quot;premiere&quot;:{&quot;state&quot;:false,&quot;color&quot;:&quot;&quot;,&quot;colorSecondary&quot;:&quot;&quot;,&quot;date&quot;:&quot;2026-04-16&quot;}}" data-filtered="false"><div class="activity-list__col activity-list__col--content"><a class="activity-list__content" href="/stuecke/common-ground/2026-04-16-1930-15604"><div class="activity-list__date"><time datetime="2026-04-16" class=""><span>
+                
+                16<span class="activity-list__date--month">. April 2026</span><span class="activity-list__date--month-short">.4.26</span></span><em class="activity-list__date-day-long">Donnerstag</em><em class="activity-list__date-day-short">Do</em></time></div><div class="activity-list__text"><span>19.30 Uhr | Nationaltheater</span><span class="h3">COMMON GROUND</span><input class="activity-list--toggle" type="checkbox" value="15604" id="toggle-15604-1a9c3106bf" aria-label="Weitere Informationen zu COMMON GROUND anzeigen"><div class="activity-list--toggle__content"><p>Alexander Ekman, Johan Inger, Jiří Kylián<br></p><p class="activity-list-price-info"><span>
+            
+                    
+                            
+                                    
+                                            Preise
+                                            H
+                                                    
+                                                            , €
+                                                            88 /77 /63 /50 /35 /- /- /8
+                                                        
+                                                
+                                        
+                                
+                        
+                
+        </span>
+        
+                                Abo-Serie 61<br></p></div><label class="activity-list--toggle__button" for="toggle-15604-1a9c3106bf"><span class="show-more">mehr anzeigen</span><span class="show-less">weniger anzeigen</span><svg class="icon"><use xlink:href="#icon-arrow-down"></use></svg></label></div><div class="activity-list__channel hide-on-md">
+        
+                Ballett
+            
+    </div></a></div><div class="activity-list__col activity-list__col--genre">
+                                
+                                        Ballett
+                                    
+                            </div><div class="activity-list__col activity-list__col--tickets"><div><a class="button button--ticket" href="https://tickets.staatstheater.bayern/bso.webshop/webticket/shop?language=de&amp;event=40278" target="_blank"><span>Tickets</span></a></div></div><div class="activity-list__col activity-list__col--actions"><a class="button-save-date" href="/stuecke/common-ground/2026-04-16-1930-15604/calendar.ics"><svg class="icon icon-stroke"><use xlink:href="#icon-calendar"></use></svg><span>Termin merken</span></a></div></div></div><div class="activity-group"><div data-date="2026-04-17" class="activity-list__row" data-schedule-filter="{&quot;date&quot;:&quot;2026-04-17&quot;,&quot;filter&quot;:{&quot;type&quot;:[{&quot;name&quot;:&quot;Extra&quot;,&quot;sort&quot;:-1}],&quot;availability&quot;:[{&quot;name&quot;:&quot;verf\u00fcgbar&quot;,&quot;sort&quot;:-1}],&quot;category&quot;:[],&quot;festival&quot;:[]}}" data-additional-info="[]" data-filtered="false"><div class="activity-list__col activity-list__col--content"><a class="activity-list__content" href="/stuecke/fuehrung-bayerisches-staatsorchester/17-04-2026-1745-15987"><div class="activity-list__date"><time datetime="2026-04-17" class=""><span>
+                
+                17<span class="activity-list__date--month">. April 2026</span><span class="activity-list__date--month-short">.4.26</span></span><em class="activity-list__date-day-long">Freitag</em><em class="activity-list__date-day-short">Fr</em></time></div><div class="activity-list__text"><span>17.45 Uhr | Tageskasse (Marstallplatz 5)</span><span class="h3">Führung Bayerisches Staatsorchester</span><input class="activity-list--toggle" type="checkbox" value="15987" id="toggle-15987-d98d710122" aria-label="Weitere Informationen zu Führung Bayerisches Staatsorchester anzeigen"><div class="activity-list--toggle__content"><p class="activity-list-price-info"><span>
+            
+                    
+                            
+                                    
+                                            Preise
+                                            PG16/10
+                                                    
+                                                            , €
+                                                            16
+                                                        
+                                                
+                                        
+                                
+                        
+                
+        </span>
+        
+                                Führung<br></p></div><label class="activity-list--toggle__button" for="toggle-15987-d98d710122"><span class="show-more">mehr anzeigen</span><span class="show-less">weniger anzeigen</span><svg class="icon"><use xlink:href="#icon-arrow-down"></use></svg></label></div><div class="activity-list__channel hide-on-md">
+        
+                Extra
+            
+    </div></a></div><div class="activity-list__col activity-list__col--genre">
+                                
+                                        Extra
+                                    
+                            </div><div class="activity-list__col activity-list__col--tickets"><div><a class="button button--ticket" href="https://tickets.staatstheater.bayern/bso.webshop/webticket/shop?language=de&amp;event=41205" target="_blank"><span>Tickets</span></a></div></div><div class="activity-list__col activity-list__col--actions"><a class="button-save-date" href="/stuecke/fuehrung-bayerisches-staatsorchester/17-04-2026-1745-15987/calendar.ics"><svg class="icon icon-stroke"><use xlink:href="#icon-calendar"></use></svg><span>Termin merken</span></a></div></div><div data-date="2026-04-17" class="activity-list__row activity-list__row--is-same-date" data-schedule-filter="{&quot;date&quot;:&quot;2026-04-17&quot;,&quot;filter&quot;:{&quot;type&quot;:[{&quot;name&quot;:&quot;Liederabend&quot;,&quot;sort&quot;:-1}],&quot;availability&quot;:[],&quot;category&quot;:[{&quot;name&quot;:&quot;&lt;30&quot;,&quot;sort&quot;:-1}],&quot;festival&quot;:[]}}" data-additional-info="{&quot;premiere&quot;:{&quot;state&quot;:false,&quot;color&quot;:&quot;&quot;,&quot;colorSecondary&quot;:&quot;&quot;,&quot;date&quot;:&quot;2026-04-17&quot;}}" data-filtered="false"><div class="activity-list__col activity-list__col--content"><a class="activity-list__content" href="/stuecke/portraetkonzert-des-opernstudios/2026-04-17-1930-15822"><div class="activity-list__date"><time datetime="2026-04-17" class=""><span>
+                
+                17<span class="activity-list__date--month">. April 2026</span><span class="activity-list__date--month-short">.4.26</span></span><em class="activity-list__date-day-long">Freitag</em><em class="activity-list__date-day-short">Fr</em></time></div><div class="activity-list__text"><span>19.30 Uhr | Künstlerhaus</span><span class="h3">Porträtkonzert des Opernstudios</span><input class="activity-list--toggle" type="checkbox" value="15822" id="toggle-15822-ce6368282f" aria-label="Weitere Informationen zu Porträtkonzert des Opernstudios anzeigen"><div class="activity-list--toggle__content"><p class="activity-list-price-info"><span>
+            
+                    
+                        Preise 20 Euro
+                    
+                
+        </span>&lt;30<br></p></div><label class="activity-list--toggle__button" for="toggle-15822-ce6368282f"><span class="show-more">mehr anzeigen</span><span class="show-less">weniger anzeigen</span><svg class="icon"><use xlink:href="#icon-arrow-down"></use></svg></label></div><div class="activity-list__channel hide-on-md">
+        
+                Liederabend
+            
+    </div></a></div><div class="activity-list__col activity-list__col--genre">
+                                
+                                        Liederabend
+                                    
+                            </div><div class="activity-list__col activity-list__col--tickets"><div><span class="hide-on-xs">ausverkauft</span><span class="hide-from-xs">ausverk.</span></div></div><!-- sold out --></div><div data-date="2026-04-17" class="activity-list__row activity-list__row--is-same-date" data-schedule-filter="{&quot;date&quot;:&quot;2026-04-17&quot;,&quot;filter&quot;:{&quot;type&quot;:[{&quot;name&quot;:&quot;Konzert&quot;,&quot;sort&quot;:-1}],&quot;availability&quot;:[{&quot;name&quot;:&quot;verf\u00fcgbar&quot;,&quot;sort&quot;:-1}],&quot;category&quot;:[{&quot;name&quot;:&quot;&lt;30&quot;,&quot;sort&quot;:-1}],&quot;festival&quot;:[]}}" data-additional-info="{&quot;premiere&quot;:{&quot;state&quot;:false,&quot;color&quot;:&quot;&quot;,&quot;colorSecondary&quot;:&quot;&quot;,&quot;date&quot;:&quot;2026-04-17&quot;}}" data-filtered="false"><div class="activity-list__col activity-list__col--content"><a class="activity-list__content" href="/stuecke/5-akademiekonzert-pablo-heras-casado/2026-04-17-2000-15605"><div class="activity-list__date"><time datetime="2026-04-17" class=""><span>
+                
+                17<span class="activity-list__date--month">. April 2026</span><span class="activity-list__date--month-short">.4.26</span></span><em class="activity-list__date-day-long">Freitag</em><em class="activity-list__date-day-short">Fr</em></time></div><div class="activity-list__text"><span>20.00 Uhr | Nationaltheater</span><span class="h3">5. Akademiekonzert: Pablo Heras-Casado</span><input class="activity-list--toggle" type="checkbox" value="15605" id="toggle-15605-ed1acb9675" aria-label="Weitere Informationen zu 5. Akademiekonzert: Pablo Heras-Casado anzeigen"><div class="activity-list--toggle__content"><p class="activity-list-price-info"><span>
+            
+                    
+                            
+                                    
+                                            Preise
+                                            G
+                                                    
+                                                            , €
+                                                            70 /63 /- /40 /29 /- /10 /7
+                                                        
+                                                
+                                        
+                                
+                        
+                
+        </span>
+        
+                                Abo-Serie 40, &lt;30<br></p></div><label class="activity-list--toggle__button" for="toggle-15605-ed1acb9675"><span class="show-more">mehr anzeigen</span><span class="show-less">weniger anzeigen</span><svg class="icon"><use xlink:href="#icon-arrow-down"></use></svg></label></div><div class="activity-list__channel hide-on-md">
+        
+                Konzert
+            
+    </div></a></div><div class="activity-list__col activity-list__col--genre">
+                                
+                                        Konzert
+                                    
+                            </div><div class="activity-list__col activity-list__col--tickets"><div><a class="button button--ticket" href="https://tickets.staatstheater.bayern/bso.webshop/webticket/shop?language=de&amp;event=40045" target="_blank"><span>Tickets</span></a></div></div><div class="activity-list__col activity-list__col--actions"><a class="button-save-date" href="/stuecke/5-akademiekonzert-pablo-heras-casado/2026-04-17-2000-15605/calendar.ics"><svg class="icon icon-stroke"><use xlink:href="#icon-calendar"></use></svg><span>Termin merken</span></a></div></div></div><div class="activity-group"><div data-date="2026-04-18" class="activity-list__row" data-schedule-filter="{&quot;date&quot;:&quot;2026-04-18&quot;,&quot;filter&quot;:{&quot;type&quot;:[{&quot;name&quot;:&quot;Kind&amp;Co&quot;,&quot;sort&quot;:-1}],&quot;availability&quot;:[],&quot;category&quot;:[],&quot;festival&quot;:[]}}" data-additional-info="{&quot;premiere&quot;:{&quot;state&quot;:false,&quot;color&quot;:&quot;&quot;,&quot;colorSecondary&quot;:&quot;&quot;,&quot;date&quot;:&quot;2026-04-18&quot;}}" data-filtered="false"><div class="activity-list__col activity-list__col--content"><a class="activity-list__content" href="/stuecke/einfuehrungsworkshop/2026-04-18-1000-15823"><div class="activity-list__date"><time datetime="2026-04-18" class=""><span>
+                
+                18<span class="activity-list__date--month">. April 2026</span><span class="activity-list__date--month-short">.4.26</span></span><em class="activity-list__date-day-long">Samstag</em><em class="activity-list__date-day-short">Sa</em></time></div><div class="activity-list__text"><span>10.00 Uhr | Große Probebühne</span><span class="h3">Workshop - Rhythmus und Klang</span><input class="activity-list--toggle" type="checkbox" value="15823" id="toggle-15823-96f3886456" aria-label="Weitere Informationen zu Workshop - Rhythmus und Klang anzeigen"><div class="activity-list--toggle__content"><p class="activity-list-price-info"><span>
+            
+                    
+                        Preise PG18
+                    
+                
+        </span>
+        
+                                Workshop<br></p></div><label class="activity-list--toggle__button" for="toggle-15823-96f3886456"><span class="show-more">mehr anzeigen</span><span class="show-less">weniger anzeigen</span><svg class="icon"><use xlink:href="#icon-arrow-down"></use></svg></label></div><div class="activity-list__channel hide-on-md">
+        
+                Kind&amp;Co
+            
+    </div></a></div><div class="activity-list__col activity-list__col--genre">
+                                
+                                        Kind&amp;Co
+                                    
+                            </div><div class="activity-list__col activity-list__col--tickets"><div><span class="hide-on-xs">ausverkauft</span><span class="hide-from-xs">ausverk.</span></div></div><!-- sold out --></div><div data-date="2026-04-18" class="activity-list__row activity-list__row--is-same-date" data-schedule-filter="{&quot;date&quot;:&quot;2026-04-18&quot;,&quot;filter&quot;:{&quot;type&quot;:[{&quot;name&quot;:&quot;Konzert&quot;,&quot;sort&quot;:-1}],&quot;availability&quot;:[{&quot;name&quot;:&quot;verf\u00fcgbar&quot;,&quot;sort&quot;:-1}],&quot;category&quot;:[{&quot;name&quot;:&quot;&lt;30&quot;,&quot;sort&quot;:-1}],&quot;festival&quot;:[]}}" data-additional-info="{&quot;premiere&quot;:{&quot;state&quot;:false,&quot;color&quot;:&quot;&quot;,&quot;colorSecondary&quot;:&quot;&quot;,&quot;date&quot;:&quot;2026-04-18&quot;}}" data-filtered="false"><div class="activity-list__col activity-list__col--content"><a class="activity-list__content" href="/stuecke/5-akademiekonzert-pablo-heras-casado/2026-04-18-1900-15606"><div class="activity-list__date"><time datetime="2026-04-18" class=""><span>
+                
+                18<span class="activity-list__date--month">. April 2026</span><span class="activity-list__date--month-short">.4.26</span></span><em class="activity-list__date-day-long">Samstag</em><em class="activity-list__date-day-short">Sa</em></time></div><div class="activity-list__text"><span>19.00 Uhr | Nationaltheater</span><span class="h3">5. Akademiekonzert: Pablo Heras-Casado</span><input class="activity-list--toggle" type="checkbox" value="15606" id="toggle-15606-060fd76d91" aria-label="Weitere Informationen zu 5. Akademiekonzert: Pablo Heras-Casado  anzeigen"><div class="activity-list--toggle__content"><p class="activity-list-price-info"><span>
+            
+                    
+                            
+                                    
+                                            Preise
+                                            G
+                                                    
+                                                            , €
+                                                            70 /63 /53 /40 /29 /- /10 /7
+                                                        
+                                                
+                                        
+                                
+                        
+                
+        </span>
+        
+                                Abo-Serie 41, &lt;30<br></p></div><label class="activity-list--toggle__button" for="toggle-15606-060fd76d91"><span class="show-more">mehr anzeigen</span><span class="show-less">weniger anzeigen</span><svg class="icon"><use xlink:href="#icon-arrow-down"></use></svg></label></div><div class="activity-list__channel hide-on-md">
+        
+                Konzert
+            
+    </div></a></div><div class="activity-list__col activity-list__col--genre">
+                                
+                                        Konzert
+                                    
+                            </div><div class="activity-list__col activity-list__col--tickets"><div><a class="button button--ticket" href="https://tickets.staatstheater.bayern/bso.webshop/webticket/shop?language=de&amp;event=40046" target="_blank"><span>Tickets</span></a></div></div><div class="activity-list__col activity-list__col--actions"><a class="button-save-date" href="/stuecke/5-akademiekonzert-pablo-heras-casado/2026-04-18-1900-15606/calendar.ics"><svg class="icon icon-stroke"><use xlink:href="#icon-calendar"></use></svg><span>Termin merken</span></a></div></div><div data-date="2026-04-18" class="activity-list__row activity-list__row--is-same-date" data-schedule-filter="{&quot;date&quot;:&quot;2026-04-18&quot;,&quot;filter&quot;:{&quot;type&quot;:[{&quot;name&quot;:&quot;Ballett&quot;,&quot;sort&quot;:-1}],&quot;availability&quot;:[],&quot;category&quot;:[],&quot;festival&quot;:[]}}" data-additional-info="{&quot;premiere&quot;:{&quot;state&quot;:false,&quot;color&quot;:&quot;&quot;,&quot;colorSecondary&quot;:&quot;&quot;,&quot;date&quot;:&quot;2026-04-18&quot;}}" data-filtered="false"><div class="activity-list__col activity-list__col--content"><a class="activity-list__content" href="/stuecke/mvhs-workshop-ballett/2026-04-18-1900-16451"><div class="activity-list__date"><time datetime="2026-04-18" class=""><span>
+                
+                18<span class="activity-list__date--month">. April 2026</span><span class="activity-list__date--month-short">.4.26</span></span><em class="activity-list__date-day-long">Samstag</em><em class="activity-list__date-day-short">Sa</em></time></div><div class="activity-list__text"><span>19.00 Uhr | Ballett-Probenhaus Platzl 7</span><span class="h3">MVHS Workshop zu "Common Ground": Cacti</span><input class="activity-list--toggle" type="checkbox" value="16451" id="toggle-16451-a830af6f65" aria-label="Weitere Informationen zu MVHS Workshop zu &quot;Common Ground&quot;: Cacti anzeigen"><div class="activity-list--toggle__content"><p class="activity-list-price-info"><span></span><br></p></div><label class="activity-list--toggle__button" for="toggle-16451-a830af6f65"><span class="show-more">mehr anzeigen</span><span class="show-less">weniger anzeigen</span><svg class="icon"><use xlink:href="#icon-arrow-down"></use></svg></label></div><div class="activity-list__channel hide-on-md">
+        
+                Ballett
+            
+    </div></a></div><div class="activity-list__col activity-list__col--genre">
+                                
+                                        Ballett
+                                    
+                            </div><div class="activity-list__col activity-list__col--tickets"><div><span class="hide-on-xs"><!-- hide button --></span><span class="hide-from-xs"><!-- hide button --></span></div></div><!-- NoSale 3 --></div></div><div class="activity-group"><div data-date="2026-04-19" class="activity-list__row" data-schedule-filter="{&quot;date&quot;:&quot;2026-04-19&quot;,&quot;filter&quot;:{&quot;type&quot;:[{&quot;name&quot;:&quot;Extra&quot;,&quot;sort&quot;:-1}],&quot;availability&quot;:[],&quot;category&quot;:[],&quot;festival&quot;:[]}}" data-additional-info="[]" data-filtered="false"><div class="activity-list__col activity-list__col--content"><a class="activity-list__content" href="/stuecke/fuehrung/19-04-2026-1400-16514"><div class="activity-list__date"><time datetime="2026-04-19" class=""><span>
+                
+                19<span class="activity-list__date--month">. April 2026</span><span class="activity-list__date--month-short">.4.26</span></span><em class="activity-list__date-day-long">Sonntag</em><em class="activity-list__date-day-short">So</em></time></div><div class="activity-list__text"><span>14.00 Uhr | Freunde-Foyer (Eingang Nord, Alfons-Goppel-Straße)</span><span class="h3">Führung</span><input class="activity-list--toggle" type="checkbox" value="16514" id="toggle-16514-523f6e921b" aria-label="Weitere Informationen zu Führung anzeigen"><div class="activity-list--toggle__content"><p class="activity-list-price-info"><span>
+            
+                    
+                        Preise PG15/7
+                    
+                
+        </span>
+        
+                                Führung<br></p></div><label class="activity-list--toggle__button" for="toggle-16514-523f6e921b"><span class="show-more">mehr anzeigen</span><span class="show-less">weniger anzeigen</span><svg class="icon"><use xlink:href="#icon-arrow-down"></use></svg></label></div><div class="activity-list__channel hide-on-md">
+        
+                Extra
+            
+    </div></a></div><div class="activity-list__col activity-list__col--genre">
+                                
+                                        Extra
+                                    
+                            </div><div class="activity-list__col activity-list__col--tickets"><div><span class="hide-on-xs">ausverkauft</span><span class="hide-from-xs">ausverk.</span></div></div><!-- sold out --></div><div data-date="2026-04-19" class="activity-list__row activity-list__row--is-same-date" data-schedule-filter="{&quot;date&quot;:&quot;2026-04-19&quot;,&quot;filter&quot;:{&quot;type&quot;:[{&quot;name&quot;:&quot;Extra&quot;,&quot;sort&quot;:-1}],&quot;availability&quot;:[],&quot;category&quot;:[],&quot;festival&quot;:[]}}" data-additional-info="[]" data-filtered="false"><div class="activity-list__col activity-list__col--content"><a class="activity-list__content" href="/stuecke/kinderfuehrung-durch-das-nationaltheater-abenteuer-oper/19-04-2026-1400-16524"><div class="activity-list__date"><time datetime="2026-04-19" class=""><span>
+                
+                19<span class="activity-list__date--month">. April 2026</span><span class="activity-list__date--month-short">.4.26</span></span><em class="activity-list__date-day-long">Sonntag</em><em class="activity-list__date-day-short">So</em></time></div><div class="activity-list__text"><span>14.00 Uhr | Freunde-Foyer (Eingang Nord, Alfons-Goppel-Straße)</span><span class="h3">Kinderführung „Abenteuer Oper"</span><input class="activity-list--toggle" type="checkbox" value="16524" id="toggle-16524-3719945695" aria-label="Weitere Informationen zu Kinderführung „Abenteuer Oper&quot; anzeigen"><div class="activity-list--toggle__content"><p class="activity-list-price-info"><span>
+            
+                    
+                        Preise PG5
+                    
+                
+        </span>
+        
+                                Führung<br></p></div><label class="activity-list--toggle__button" for="toggle-16524-3719945695"><span class="show-more">mehr anzeigen</span><span class="show-less">weniger anzeigen</span><svg class="icon"><use xlink:href="#icon-arrow-down"></use></svg></label></div><div class="activity-list__channel hide-on-md">
+        
+                Extra
+            
+    </div></a></div><div class="activity-list__col activity-list__col--genre">
+                                
+                                        Extra
+                                    
+                            </div><div class="activity-list__col activity-list__col--tickets"><div><span class="hide-on-xs">ausverkauft</span><span class="hide-from-xs">ausverk.</span></div></div><!-- sold out --></div><div data-date="2026-04-19" class="activity-list__row activity-list__row--is-same-date" data-schedule-filter="{&quot;date&quot;:&quot;2026-04-19&quot;,&quot;filter&quot;:{&quot;type&quot;:[{&quot;name&quot;:&quot;Konzert&quot;,&quot;sort&quot;:-1}],&quot;availability&quot;:[{&quot;name&quot;:&quot;verf\u00fcgbar&quot;,&quot;sort&quot;:-1}],&quot;category&quot;:[],&quot;festival&quot;:[]}}" data-additional-info="{&quot;premiere&quot;:{&quot;state&quot;:false,&quot;color&quot;:&quot;&quot;,&quot;colorSecondary&quot;:&quot;&quot;,&quot;date&quot;:&quot;2026-04-19&quot;}}" data-filtered="false"><div class="activity-list__col activity-list__col--content"><a class="activity-list__content" href="/stuecke/gastspielkonzert-des-opernstudios/2026-04-19-1500-15855"><div class="activity-list__date"><time datetime="2026-04-19" class=""><span>
+                
+                19<span class="activity-list__date--month">. April 2026</span><span class="activity-list__date--month-short">.4.26</span></span><em class="activity-list__date-day-long">Sonntag</em><em class="activity-list__date-day-short">So</em></time></div><div class="activity-list__text"><span>15.00 Uhr | Aschaffenburg</span><span class="h3">Gastspielkonzert des Opernstudios</span><input class="activity-list--toggle" type="checkbox" value="15855" id="toggle-15855-b24589b7e0" aria-label="Weitere Informationen zu Gastspielkonzert des Opernstudios anzeigen"><div class="activity-list--toggle__content"><p class="activity-list-price-info"><span></span><br></p></div><label class="activity-list--toggle__button" for="toggle-15855-b24589b7e0"><span class="show-more">mehr anzeigen</span><span class="show-less">weniger anzeigen</span><svg class="icon"><use xlink:href="#icon-arrow-down"></use></svg></label></div><div class="activity-list__channel hide-on-md">
+        
+                Konzert
+            
+    </div></a></div><div class="activity-list__col activity-list__col--genre">
+                                
+                                        Konzert
+                                    
+                            </div><div class="activity-list__col activity-list__col--tickets"><div><a class="button button--ticket" target="_blank" href="http://www.stadttheater-aschaffenburg.de"><span>Tickets</span></a></div></div><!-- NoSale 3 --></div><div data-date="2026-04-19" class="activity-list__row activity-list__row--is-same-date" data-schedule-filter="{&quot;date&quot;:&quot;2026-04-19&quot;,&quot;filter&quot;:{&quot;type&quot;:[{&quot;name&quot;:&quot;Oper&quot;,&quot;sort&quot;:-1}],&quot;availability&quot;:[{&quot;name&quot;:&quot;verf\u00fcgbar&quot;,&quot;sort&quot;:-1}],&quot;category&quot;:[],&quot;festival&quot;:[]}}" data-additional-info="{&quot;premiere&quot;:{&quot;state&quot;:false,&quot;color&quot;:&quot;&quot;,&quot;colorSecondary&quot;:&quot;&quot;,&quot;date&quot;:&quot;2026-04-19&quot;}}" data-filtered="false"><div class="activity-list__col activity-list__col--content"><a class="activity-list__content" href="/stuecke/lelisir-damore/2026-04-19-1800-15607"><div class="activity-list__date"><time datetime="2026-04-19" class=""><span>
+                
+                19<span class="activity-list__date--month">. April 2026</span><span class="activity-list__date--month-short">.4.26</span></span><em class="activity-list__date-day-long">Sonntag</em><em class="activity-list__date-day-short">So</em></time></div><div class="activity-list__text"><span>18.00 Uhr | Nationaltheater</span><span class="h3">L’ELISIR D’AMORE</span><input class="activity-list--toggle" type="checkbox" value="15607" id="toggle-15607-dd5b14e20b" aria-label="Weitere Informationen zu L’ELISIR D’AMORE anzeigen"><div class="activity-list--toggle__content"><p>Gaetano Donizetti<br></p><p class="activity-list-price-info"><span>
+            
+                    
+                            
+                                    
+                                            Preise
+                                            K
+                                                    
+                                                            , €
+                                                            132 /115 /95 /74 /52 /30 /14 /10
+                                                        
+                                                
+                                        
+                                
+                        
+                
+        </span>
+        
+                                Abo-Serie 51<br></p></div><label class="activity-list--toggle__button" for="toggle-15607-dd5b14e20b"><span class="show-more">mehr anzeigen</span><span class="show-less">weniger anzeigen</span><svg class="icon"><use xlink:href="#icon-arrow-down"></use></svg></label></div><div class="activity-list__channel hide-on-md">
+        
+                Oper
+            
+    </div></a></div><div class="activity-list__col activity-list__col--genre">
+                                
+                                        Oper
+                                    
+                            </div><div class="activity-list__col activity-list__col--tickets"><div><a class="button button--ticket" href="https://tickets.staatstheater.bayern/bso.webshop/webticket/shop?language=de&amp;event=40194" target="_blank"><span>Tickets</span></a></div></div><div class="activity-list__col activity-list__col--actions"><a class="button-save-date" href="/stuecke/lelisir-damore/2026-04-19-1800-15607/calendar.ics"><svg class="icon icon-stroke"><use xlink:href="#icon-calendar"></use></svg><span>Termin merken</span></a></div></div></div><div class="activity-group"><div data-date="2026-04-20" class="activity-list__row" data-schedule-filter="{&quot;date&quot;:&quot;2026-04-20&quot;,&quot;filter&quot;:{&quot;type&quot;:[{&quot;name&quot;:&quot;Konzert&quot;,&quot;sort&quot;:-1}],&quot;availability&quot;:[{&quot;name&quot;:&quot;verf\u00fcgbar&quot;,&quot;sort&quot;:-1}],&quot;category&quot;:[{&quot;name&quot;:&quot;&lt;30&quot;,&quot;sort&quot;:-1}],&quot;festival&quot;:[]}}" data-additional-info="{&quot;premiere&quot;:{&quot;state&quot;:false,&quot;color&quot;:&quot;&quot;,&quot;colorSecondary&quot;:&quot;&quot;,&quot;date&quot;:&quot;2026-04-20&quot;}}" data-filtered="false"><div class="activity-list__col activity-list__col--content"><a class="activity-list__content" href="/stuecke/konzert-der-hermann-levi-akademie/2026-04-20-1900-16033"><div class="activity-list__date"><time datetime="2026-04-20" class=""><span>
+                
+                20<span class="activity-list__date--month">. April 2026</span><span class="activity-list__date--month-short">.4.26</span></span><em class="activity-list__date-day-long">Montag</em><em class="activity-list__date-day-short">Mo</em></time></div><div class="activity-list__text"><span>19.00 Uhr | Alte Pinakothek</span><span class="h3">UN:ERHÖRT - Kammerkonzert der Hermann-Levi-Akademie</span><input class="activity-list--toggle" type="checkbox" value="16033" id="toggle-16033-772f1dbac4" aria-label="Weitere Informationen zu UN:ERHÖRT - Kammerkonzert der Hermann-Levi-Akademie anzeigen"><div class="activity-list--toggle__content"><p class="activity-list-price-info"><span>
+            
+                    
+                            
+                                    
+                                            Preise
+                                            20 Euro
+                                                    
+                                                            , €
+                                                            20
+                                                        
+                                                
+                                        
+                                
+                        
+                
+        </span>&lt;30, Hermann-Levi-Akademie<br></p></div><label class="activity-list--toggle__button" for="toggle-16033-772f1dbac4"><span class="show-more">mehr anzeigen</span><span class="show-less">weniger anzeigen</span><svg class="icon"><use xlink:href="#icon-arrow-down"></use></svg></label></div><div class="activity-list__channel hide-on-md">
+        
+                Konzert
+            
+    </div></a></div><div class="activity-list__col activity-list__col--genre">
+                                
+                                        Konzert
+                                    
+                            </div><div class="activity-list__col activity-list__col--tickets"><div><a class="button button--ticket" href="https://tickets.staatstheater.bayern/bso.webshop/webticket/shop?language=de&amp;event=41527" target="_blank"><span>Letzte Tickets</span></a></div></div><div class="activity-list__col activity-list__col--actions"><a class="button-save-date" href="/stuecke/konzert-der-hermann-levi-akademie/2026-04-20-1900-16033/calendar.ics"><svg class="icon icon-stroke"><use xlink:href="#icon-calendar"></use></svg><span>Termin merken</span></a></div></div><div data-date="2026-04-20" class="activity-list__row activity-list__row--is-same-date" data-schedule-filter="{&quot;date&quot;:&quot;2026-04-20&quot;,&quot;filter&quot;:{&quot;type&quot;:[{&quot;name&quot;:&quot;Ballett&quot;,&quot;sort&quot;:-1}],&quot;availability&quot;:[{&quot;name&quot;:&quot;verf\u00fcgbar&quot;,&quot;sort&quot;:-1}],&quot;category&quot;:[],&quot;festival&quot;:[]}}" data-additional-info="{&quot;premiere&quot;:{&quot;state&quot;:false,&quot;color&quot;:&quot;&quot;,&quot;colorSecondary&quot;:&quot;&quot;,&quot;date&quot;:&quot;2026-04-20&quot;}}" data-filtered="false"><div class="activity-list__col activity-list__col--content"><a class="activity-list__content" href="/stuecke/common-ground/2026-04-20-1930-15608"><div class="activity-list__date"><time datetime="2026-04-20" class=""><span>
+                
+                20<span class="activity-list__date--month">. April 2026</span><span class="activity-list__date--month-short">.4.26</span></span><em class="activity-list__date-day-long">Montag</em><em class="activity-list__date-day-short">Mo</em></time></div><div class="activity-list__text"><span>19.30 Uhr | Nationaltheater</span><span class="h3">COMMON GROUND</span><input class="activity-list--toggle" type="checkbox" value="15608" id="toggle-15608-f46e0ec22e" aria-label="Weitere Informationen zu COMMON GROUND anzeigen"><div class="activity-list--toggle__content"><p>Alexander Ekman, Johan Inger, Jiří Kylián<br></p><p class="activity-list-price-info"><span>
+            
+                    
+                            
+                                    
+                                            Preise
+                                            G
+                                                    
+                                                            , €
+                                                            - /- /- /- /- /- /10 /7
+                                                        
+                                                
+                                        
+                                
+                        
+                
+        </span>
+        
+                                Abo-Serie 50<br></p></div><label class="activity-list--toggle__button" for="toggle-15608-f46e0ec22e"><span class="show-more">mehr anzeigen</span><span class="show-less">weniger anzeigen</span><svg class="icon"><use xlink:href="#icon-arrow-down"></use></svg></label></div><div class="activity-list__channel hide-on-md">
+        
+                Ballett
+            
+    </div></a></div><div class="activity-list__col activity-list__col--genre">
+                                
+                                        Ballett
+                                    
+                            </div><div class="activity-list__col activity-list__col--tickets"><div><a class="button button--ticket" href="https://tickets.staatstheater.bayern/bso.webshop/webticket/shop?language=de&amp;event=40279" target="_blank"><span>Tickets</span></a></div></div><div class="activity-list__col activity-list__col--actions"><a class="button-save-date" href="/stuecke/common-ground/2026-04-20-1930-15608/calendar.ics"><svg class="icon icon-stroke"><use xlink:href="#icon-calendar"></use></svg><span>Termin merken</span></a></div></div></div><div class="activity-group"><div data-date="2026-04-21" class="activity-list__row" data-schedule-filter="{&quot;date&quot;:&quot;2026-04-21&quot;,&quot;filter&quot;:{&quot;type&quot;:[{&quot;name&quot;:&quot;Extra&quot;,&quot;sort&quot;:-1}],&quot;availability&quot;:[],&quot;category&quot;:[],&quot;festival&quot;:[]}}" data-additional-info="[]" data-filtered="false"><div class="activity-list__col activity-list__col--content"><a class="activity-list__content" href="/stuecke/ballett-fuehrung/21-04-2026-1400-15979"><div class="activity-list__date"><time datetime="2026-04-21" class=""><span>
+                
+                21<span class="activity-list__date--month">. April 2026</span><span class="activity-list__date--month-short">.4.26</span></span><em class="activity-list__date-day-long">Dienstag</em><em class="activity-list__date-day-short">Di</em></time></div><div class="activity-list__text"><span>14.00 Uhr | Freunde-Foyer (Eingang Nord, Alfons-Goppel-Straße)</span><span class="h3">Ballettführung – Platzl spezial</span><input class="activity-list--toggle" type="checkbox" value="15979" id="toggle-15979-f07ccb9548" aria-label="Weitere Informationen zu Ballettführung – Platzl spezial anzeigen"><div class="activity-list--toggle__content"><p class="activity-list-price-info"><span>
+            
+                    
+                        Preise PG25/10
+                    
+                
+        </span>
+        
+                                Ballett-Führung, Führung<br></p></div><label class="activity-list--toggle__button" for="toggle-15979-f07ccb9548"><span class="show-more">mehr anzeigen</span><span class="show-less">weniger anzeigen</span><svg class="icon"><use xlink:href="#icon-arrow-down"></use></svg></label></div><div class="activity-list__channel hide-on-md">
+        
+                Extra
+            
+    </div></a></div><div class="activity-list__col activity-list__col--genre">
+                                
+                                        Extra
+                                    
+                            </div><div class="activity-list__col activity-list__col--tickets"><div><span class="hide-on-xs">ausverkauft</span><span class="hide-from-xs">ausverk.</span></div></div><!-- sold out --></div><div data-date="2026-04-21" class="activity-list__row activity-list__row--is-same-date" data-schedule-filter="{&quot;date&quot;:&quot;2026-04-21&quot;,&quot;filter&quot;:{&quot;type&quot;:[{&quot;name&quot;:&quot;Oper&quot;,&quot;sort&quot;:-1}],&quot;availability&quot;:[{&quot;name&quot;:&quot;verf\u00fcgbar&quot;,&quot;sort&quot;:-1}],&quot;category&quot;:[{&quot;name&quot;:&quot;&lt;30&quot;,&quot;sort&quot;:-1}],&quot;festival&quot;:[]}}" data-additional-info="{&quot;premiere&quot;:{&quot;state&quot;:false,&quot;color&quot;:&quot;&quot;,&quot;colorSecondary&quot;:&quot;&quot;,&quot;date&quot;:&quot;2026-04-21&quot;}}" data-filtered="false"><div class="activity-list__col activity-list__col--content"><a class="activity-list__content" href="/stuecke/lelisir-damore/2026-04-21-1900-15609"><div class="activity-list__date"><time datetime="2026-04-21" class=""><span>
+                
+                21<span class="activity-list__date--month">. April 2026</span><span class="activity-list__date--month-short">.4.26</span></span><em class="activity-list__date-day-long">Dienstag</em><em class="activity-list__date-day-short">Di</em></time></div><div class="activity-list__text"><span>19.00 Uhr | Nationaltheater</span><span class="h3">L’ELISIR D’AMORE</span><input class="activity-list--toggle" type="checkbox" value="15609" id="toggle-15609-497c933d55" aria-label="Weitere Informationen zu L’ELISIR D’AMORE anzeigen"><div class="activity-list--toggle__content"><p>Gaetano Donizetti<br></p><p class="activity-list-price-info"><span>
+            
+                    
+                            
+                                    
+                                            Preise
+                                            K
+                                                    
+                                                            , €
+                                                            132 /115 /95 /74 /52 /30 /14 /10
+                                                        
+                                                
+                                        
+                                
+                        
+                
+        </span>
+        
+                                Abo-Serie 31, &lt;30<br></p></div><label class="activity-list--toggle__button" for="toggle-15609-497c933d55"><span class="show-more">mehr anzeigen</span><span class="show-less">weniger anzeigen</span><svg class="icon"><use xlink:href="#icon-arrow-down"></use></svg></label></div><div class="activity-list__channel hide-on-md">
+        
+                Oper
+            
+    </div></a></div><div class="activity-list__col activity-list__col--genre">
+                                
+                                        Oper
+                                    
+                            </div><div class="activity-list__col activity-list__col--tickets"><div><a class="button button--ticket" href="https://tickets.staatstheater.bayern/bso.webshop/webticket/shop?language=de&amp;event=40202" target="_blank"><span>Tickets</span></a></div></div><div class="activity-list__col activity-list__col--actions"><a class="button-save-date" href="/stuecke/lelisir-damore/2026-04-21-1900-15609/calendar.ics"><svg class="icon icon-stroke"><use xlink:href="#icon-calendar"></use></svg><span>Termin merken</span></a></div></div></div><div class="activity-group"><div data-date="2026-04-23" class="activity-list__row" data-schedule-filter="{&quot;date&quot;:&quot;2026-04-23&quot;,&quot;filter&quot;:{&quot;type&quot;:[{&quot;name&quot;:&quot;Extra&quot;,&quot;sort&quot;:-1}],&quot;availability&quot;:[{&quot;name&quot;:&quot;verf\u00fcgbar&quot;,&quot;sort&quot;:-1}],&quot;category&quot;:[],&quot;festival&quot;:[]}}" data-additional-info="[]" data-filtered="false"><div class="activity-list__col activity-list__col--content"><a class="activity-list__content" href="/stuecke/fuehrung/23-04-2026-1400-16515"><div class="activity-list__date"><time datetime="2026-04-23" class=""><span>
+                
+                23<span class="activity-list__date--month">. April 2026</span><span class="activity-list__date--month-short">.4.26</span></span><em class="activity-list__date-day-long">Donnerstag</em><em class="activity-list__date-day-short">Do</em></time></div><div class="activity-list__text"><span>14.00 Uhr | Freunde-Foyer (Eingang Nord, Alfons-Goppel-Straße)</span><span class="h3">Führung</span><input class="activity-list--toggle" type="checkbox" value="16515" id="toggle-16515-d470138378" aria-label="Weitere Informationen zu Führung anzeigen"><div class="activity-list--toggle__content"><p class="activity-list-price-info"><span>
+            
+                    
+                            
+                                    
+                                            Preise
+                                            PG15/7
+                                                    
+                                                            , €
+                                                            15
+                                                        
+                                                
+                                        
+                                
+                        
+                
+        </span>
+        
+                                Führung<br></p></div><label class="activity-list--toggle__button" for="toggle-16515-d470138378"><span class="show-more">mehr anzeigen</span><span class="show-less">weniger anzeigen</span><svg class="icon"><use xlink:href="#icon-arrow-down"></use></svg></label></div><div class="activity-list__channel hide-on-md">
+        
+                Extra
+            
+    </div></a></div><div class="activity-list__col activity-list__col--genre">
+                                
+                                        Extra
+                                    
+                            </div><div class="activity-list__col activity-list__col--tickets"><div><a class="button button--ticket" href="https://tickets.staatstheater.bayern/bso.webshop/webticket/shop?language=de&amp;event=42167" target="_blank"><span>Tickets</span></a></div></div><div class="activity-list__col activity-list__col--actions"><a class="button-save-date" href="/stuecke/fuehrung/23-04-2026-1400-16515/calendar.ics"><svg class="icon icon-stroke"><use xlink:href="#icon-calendar"></use></svg><span>Termin merken</span></a></div></div><div data-date="2026-04-23" class="activity-list__row activity-list__row--is-same-date" data-schedule-filter="{&quot;date&quot;:&quot;2026-04-23&quot;,&quot;filter&quot;:{&quot;type&quot;:[{&quot;name&quot;:&quot;Extra&quot;,&quot;sort&quot;:-1}],&quot;availability&quot;:[{&quot;name&quot;:&quot;verf\u00fcgbar&quot;,&quot;sort&quot;:-1}],&quot;category&quot;:[],&quot;festival&quot;:[]}}" data-additional-info="[]" data-filtered="false"><div class="activity-list__col activity-list__col--content"><a class="activity-list__content" href="/stuecke/guided-tour-of-the-national-theatre/23-04-2026-1400-16527"><div class="activity-list__date"><time datetime="2026-04-23" class=""><span>
+                
+                23<span class="activity-list__date--month">. April 2026</span><span class="activity-list__date--month-short">.4.26</span></span><em class="activity-list__date-day-long">Donnerstag</em><em class="activity-list__date-day-short">Do</em></time></div><div class="activity-list__text"><span>14.00 Uhr | Freunde-Foyer (Eingang Nord, Alfons-Goppel-Straße)</span><span class="h3">Guided tour of the Nationaltheater</span><input class="activity-list--toggle" type="checkbox" value="16527" id="toggle-16527-5d9cbad075" aria-label="Weitere Informationen zu Guided tour of the Nationaltheater anzeigen"><div class="activity-list--toggle__content"><p class="activity-list-price-info"><span>
+            
+                    
+                            
+                                    
+                                            Preise
+                                            PG15/7
+                                                    
+                                                            , €
+                                                            15
+                                                        
+                                                
+                                        
+                                
+                        
+                
+        </span>
+        
+                                Führung<br></p></div><label class="activity-list--toggle__button" for="toggle-16527-5d9cbad075"><span class="show-more">mehr anzeigen</span><span class="show-less">weniger anzeigen</span><svg class="icon"><use xlink:href="#icon-arrow-down"></use></svg></label></div><div class="activity-list__channel hide-on-md">
+        
+                Extra
+            
+    </div></a></div><div class="activity-list__col activity-list__col--genre">
+                                
+                                        Extra
+                                    
+                            </div><div class="activity-list__col activity-list__col--tickets"><div><a class="button button--ticket" href="https://tickets.staatstheater.bayern/bso.webshop/webticket/shop?language=de&amp;event=42171" target="_blank"><span>Tickets</span></a></div></div><div class="activity-list__col activity-list__col--actions"><a class="button-save-date" href="/stuecke/guided-tour-of-the-national-theatre/23-04-2026-1400-16527/calendar.ics"><svg class="icon icon-stroke"><use xlink:href="#icon-calendar"></use></svg><span>Termin merken</span></a></div></div><div data-date="2026-04-23" class="activity-list__row activity-list__row--is-same-date" data-schedule-filter="{&quot;date&quot;:&quot;2026-04-23&quot;,&quot;filter&quot;:{&quot;type&quot;:[{&quot;name&quot;:&quot;Ballett&quot;,&quot;sort&quot;:-1}],&quot;availability&quot;:[{&quot;name&quot;:&quot;verf\u00fcgbar&quot;,&quot;sort&quot;:-1}],&quot;category&quot;:[],&quot;festival&quot;:[]}}" data-additional-info="{&quot;premiere&quot;:{&quot;state&quot;:false,&quot;color&quot;:&quot;&quot;,&quot;colorSecondary&quot;:&quot;&quot;,&quot;date&quot;:&quot;2026-04-23&quot;}}" data-filtered="false"><div class="activity-list__col activity-list__col--content"><a class="activity-list__content" href="/stuecke/common-ground/2026-04-23-1930-15610"><div class="activity-list__date"><time datetime="2026-04-23" class=""><span>
+                
+                23<span class="activity-list__date--month">. April 2026</span><span class="activity-list__date--month-short">.4.26</span></span><em class="activity-list__date-day-long">Donnerstag</em><em class="activity-list__date-day-short">Do</em></time></div><div class="activity-list__text"><span>19.30 Uhr | Nationaltheater</span><span class="h3">COMMON GROUND</span><input class="activity-list--toggle" type="checkbox" value="15610" id="toggle-15610-6506094d59" aria-label="Weitere Informationen zu COMMON GROUND anzeigen"><div class="activity-list--toggle__content"><p>Alexander Ekman, Johan Inger, Jiří Kylián<br></p><p class="activity-list-price-info"><span>
+            
+                    
+                            
+                                    
+                                            Preise
+                                            G
+                                                    
+                                                            , €
+                                                            - /63 /53 /- /- /- /10 /7
+                                                        
+                                                
+                                        
+                                
+                        
+                
+        </span>
+        
+                                Abo-Serie 42<br></p></div><label class="activity-list--toggle__button" for="toggle-15610-6506094d59"><span class="show-more">mehr anzeigen</span><span class="show-less">weniger anzeigen</span><svg class="icon"><use xlink:href="#icon-arrow-down"></use></svg></label></div><div class="activity-list__channel hide-on-md">
+        
+                Ballett
+            
+    </div></a></div><div class="activity-list__col activity-list__col--genre">
+                                
+                                        Ballett
+                                    
+                            </div><div class="activity-list__col activity-list__col--tickets"><div><a class="button button--ticket" href="https://tickets.staatstheater.bayern/bso.webshop/webticket/shop?language=de&amp;event=40280" target="_blank"><span>Tickets</span></a></div></div><div class="activity-list__col activity-list__col--actions"><a class="button-save-date" href="/stuecke/common-ground/2026-04-23-1930-15610/calendar.ics"><svg class="icon icon-stroke"><use xlink:href="#icon-calendar"></use></svg><span>Termin merken</span></a></div></div></div><div class="activity-group"><div data-date="2026-04-24" class="activity-list__row" data-schedule-filter="{&quot;date&quot;:&quot;2026-04-24&quot;,&quot;filter&quot;:{&quot;type&quot;:[{&quot;name&quot;:&quot;Oper&quot;,&quot;sort&quot;:-1}],&quot;availability&quot;:[{&quot;name&quot;:&quot;verf\u00fcgbar&quot;,&quot;sort&quot;:-1}],&quot;category&quot;:[],&quot;festival&quot;:[]}}" data-additional-info="{&quot;premiere&quot;:{&quot;state&quot;:false,&quot;color&quot;:&quot;&quot;,&quot;colorSecondary&quot;:&quot;&quot;,&quot;date&quot;:&quot;2026-04-24&quot;}}" data-filtered="false"><div class="activity-list__col activity-list__col--content"><a class="activity-list__content" href="/stuecke/lelisir-damore/2026-04-24-1900-15611"><div class="activity-list__date"><time datetime="2026-04-24" class=""><span>
+                
+                24<span class="activity-list__date--month">. April 2026</span><span class="activity-list__date--month-short">.4.26</span></span><em class="activity-list__date-day-long">Freitag</em><em class="activity-list__date-day-short">Fr</em></time></div><div class="activity-list__text"><span>19.00 Uhr | Nationaltheater</span><span class="h3">L’ELISIR D’AMORE</span><input class="activity-list--toggle" type="checkbox" value="15611" id="toggle-15611-ef2d16f815" aria-label="Weitere Informationen zu L’ELISIR D’AMORE anzeigen"><div class="activity-list--toggle__content"><p>Gaetano Donizetti<br></p><p class="activity-list-price-info"><span>
+            
+                    
+                            
+                                    
+                                            Preise
+                                            K
+                                                    
+                                                            , €
+                                                            132 /115 /95 /74 /52 /30 /14 /10
+                                                        
+                                                
+                                        
+                                
+                        
+                
+        </span>
+        
+                                Abo-Serie 24<br></p></div><label class="activity-list--toggle__button" for="toggle-15611-ef2d16f815"><span class="show-more">mehr anzeigen</span><span class="show-less">weniger anzeigen</span><svg class="icon"><use xlink:href="#icon-arrow-down"></use></svg></label></div><div class="activity-list__channel hide-on-md">
+        
+                Oper
+            
+    </div></a></div><div class="activity-list__col activity-list__col--genre">
+                                
+                                        Oper
+                                    
+                            </div><div class="activity-list__col activity-list__col--tickets"><div><a class="button button--ticket" href="https://tickets.staatstheater.bayern/bso.webshop/webticket/shop?language=de&amp;event=40203" target="_blank"><span>Tickets</span></a></div></div><div class="activity-list__col activity-list__col--actions"><a class="button-save-date" href="/stuecke/lelisir-damore/2026-04-24-1900-15611/calendar.ics"><svg class="icon icon-stroke"><use xlink:href="#icon-calendar"></use></svg><span>Termin merken</span></a></div></div></div><div class="activity-group"><div data-date="2026-04-25" class="activity-list__row" data-schedule-filter="{&quot;date&quot;:&quot;2026-04-25&quot;,&quot;filter&quot;:{&quot;type&quot;:[{&quot;name&quot;:&quot;Ballett&quot;,&quot;sort&quot;:-1}],&quot;availability&quot;:[{&quot;name&quot;:&quot;verf\u00fcgbar&quot;,&quot;sort&quot;:-1}],&quot;category&quot;:[],&quot;festival&quot;:[]}}" data-additional-info="{&quot;premiere&quot;:{&quot;state&quot;:false,&quot;color&quot;:&quot;&quot;,&quot;colorSecondary&quot;:&quot;&quot;,&quot;date&quot;:&quot;2026-04-25&quot;}}" data-filtered="false"><div class="activity-list__col activity-list__col--content"><a class="activity-list__content" href="/stuecke/common-ground/2026-04-25-1930-15612"><div class="activity-list__date"><time datetime="2026-04-25" class=""><span>
+                
+                25<span class="activity-list__date--month">. April 2026</span><span class="activity-list__date--month-short">.4.26</span></span><em class="activity-list__date-day-long">Samstag</em><em class="activity-list__date-day-short">Sa</em></time></div><div class="activity-list__text"><span>19.30 Uhr | Nationaltheater</span><span class="h3">COMMON GROUND</span><input class="activity-list--toggle" type="checkbox" value="15612" id="toggle-15612-10c9a903a7" aria-label="Weitere Informationen zu COMMON GROUND anzeigen"><div class="activity-list--toggle__content"><p>Alexander Ekman, Johan Inger, Jiří Kylián<br></p><p class="activity-list-price-info"><span>
+            
+                    
+                            
+                                    
+                                            Preise
+                                            H
+                                                    
+                                                            , €
+                                                            - /- /- /- /- /- /11 /8
+                                                        
+                                                
+                                        
+                                
+                        
+                
+        </span>
+        
+                                Abo-Serie 17<br></p></div><label class="activity-list--toggle__button" for="toggle-15612-10c9a903a7"><span class="show-more">mehr anzeigen</span><span class="show-less">weniger anzeigen</span><svg class="icon"><use xlink:href="#icon-arrow-down"></use></svg></label></div><div class="activity-list__channel hide-on-md">
+        
+                Ballett
+            
+    </div></a></div><div class="activity-list__col activity-list__col--genre">
+                                
+                                        Ballett
+                                    
+                            </div><div class="activity-list__col activity-list__col--tickets"><div><a class="button button--ticket" href="https://tickets.staatstheater.bayern/bso.webshop/webticket/shop?language=de&amp;event=40281" target="_blank"><span>Tickets</span></a></div></div><div class="activity-list__col activity-list__col--actions"><a class="button-save-date" href="/stuecke/common-ground/2026-04-25-1930-15612/calendar.ics"><svg class="icon icon-stroke"><use xlink:href="#icon-calendar"></use></svg><span>Termin merken</span></a></div></div></div><div class="activity-group"><div data-date="2026-04-26" class="activity-list__row" data-schedule-filter="{&quot;date&quot;:&quot;2026-04-26&quot;,&quot;filter&quot;:{&quot;type&quot;:[{&quot;name&quot;:&quot;Konzert&quot;,&quot;sort&quot;:-1}],&quot;availability&quot;:[{&quot;name&quot;:&quot;verf\u00fcgbar&quot;,&quot;sort&quot;:-1}],&quot;category&quot;:[{&quot;name&quot;:&quot;&lt;30&quot;,&quot;sort&quot;:-1}],&quot;festival&quot;:[]}}" data-additional-info="{&quot;premiere&quot;:{&quot;state&quot;:false,&quot;color&quot;:&quot;&quot;,&quot;colorSecondary&quot;:&quot;&quot;,&quot;date&quot;:&quot;2026-04-26&quot;}}" data-filtered="false"><div class="activity-list__col activity-list__col--content"><a class="activity-list__content" href="/stuecke/5-kammerkonzert-time-stands-still/2026-04-26-1100-15613"><div class="activity-list__date"><time datetime="2026-04-26" class=""><span>
+                
+                26<span class="activity-list__date--month">. April 2026</span><span class="activity-list__date--month-short">.4.26</span></span><em class="activity-list__date-day-long">Sonntag</em><em class="activity-list__date-day-short">So</em></time></div><div class="activity-list__text"><span>11.00 Uhr | Allerheiligen Hofkirche</span><span class="h3">5. Kammerkonzert: Time Stands Still</span><input class="activity-list--toggle" type="checkbox" value="15613" id="toggle-15613-f0f7071d0e" aria-label="Weitere Informationen zu 5. Kammerkonzert: Time Stands Still anzeigen"><div class="activity-list--toggle__content"><p class="activity-list-price-info"><span>
+            
+                    
+                            
+                                    
+                                            Preise
+                                            AS
+                                                    
+                                                            , €
+                                                            24 /21 /19 /16
+                                                        
+                                                
+                                        
+                                
+                        
+                
+        </span>
+        
+                                Abo-Serie 47, &lt;30<br></p></div><label class="activity-list--toggle__button" for="toggle-15613-f0f7071d0e"><span class="show-more">mehr anzeigen</span><span class="show-less">weniger anzeigen</span><svg class="icon"><use xlink:href="#icon-arrow-down"></use></svg></label></div><div class="activity-list__channel hide-on-md">
+        
+                Konzert
+            
+    </div></a></div><div class="activity-list__col activity-list__col--genre">
+                                
+                                        Konzert
+                                    
+                            </div><div class="activity-list__col activity-list__col--tickets"><div><a class="button button--ticket" href="https://tickets.staatstheater.bayern/bso.webshop/webticket/shop?language=de&amp;event=40053" target="_blank"><span>Tickets</span></a></div></div><div class="activity-list__col activity-list__col--actions"><a class="button-save-date" href="/stuecke/5-kammerkonzert-time-stands-still/2026-04-26-1100-15613/calendar.ics"><svg class="icon icon-stroke"><use xlink:href="#icon-calendar"></use></svg><span>Termin merken</span></a></div></div><div data-date="2026-04-26" class="activity-list__row activity-list__row--is-same-date" data-schedule-filter="{&quot;date&quot;:&quot;2026-04-26&quot;,&quot;filter&quot;:{&quot;type&quot;:[{&quot;name&quot;:&quot;Extra&quot;,&quot;sort&quot;:-1}],&quot;availability&quot;:[],&quot;category&quot;:[],&quot;festival&quot;:[]}}" data-additional-info="{&quot;premiere&quot;:{&quot;state&quot;:false,&quot;color&quot;:&quot;&quot;,&quot;colorSecondary&quot;:&quot;&quot;,&quot;date&quot;:&quot;2026-04-26&quot;}}" data-filtered="false"><div class="activity-list__col activity-list__col--content"><a class="activity-list__content" href="/stuecke/brundibar/2026-04-26-1100-16479"><div class="activity-list__date"><time datetime="2026-04-26" class=""><span>
+                
+                26<span class="activity-list__date--month">. April 2026</span><span class="activity-list__date--month-short">.4.26</span></span><em class="activity-list__date-day-long">Sonntag</em><em class="activity-list__date-day-short">So</em></time></div><div class="activity-list__text"><span>11.00 Uhr | Pasinger Fabrik</span><span class="h3">Brundibár</span><input class="activity-list--toggle" type="checkbox" value="16479" id="toggle-16479-5a25d6cba7" aria-label="Weitere Informationen zu Brundibár anzeigen"><div class="activity-list--toggle__content"><p>Hans Krása, in einem Arrangement von Richard Whilds<br></p><p class="activity-list-price-info"><span></span><br></p></div><label class="activity-list--toggle__button" for="toggle-16479-5a25d6cba7"><span class="show-more">mehr anzeigen</span><span class="show-less">weniger anzeigen</span><svg class="icon"><use xlink:href="#icon-arrow-down"></use></svg></label></div><div class="activity-list__channel hide-on-md">
+        
+                Extra
+            
+    </div></a></div><div class="activity-list__col activity-list__col--genre">
+                                
+                                        Extra
+                                    
+                            </div><div class="activity-list__col activity-list__col--tickets"><div><span class="hide-on-xs"><!-- hide button --></span><span class="hide-from-xs"><!-- hide button --></span></div></div><!-- NoSale 3 --></div><div data-date="2026-04-26" class="activity-list__row activity-list__row--is-same-date" data-schedule-filter="{&quot;date&quot;:&quot;2026-04-26&quot;,&quot;filter&quot;:{&quot;type&quot;:[{&quot;name&quot;:&quot;Offstage 360&quot;,&quot;sort&quot;:-1}],&quot;availability&quot;:[{&quot;name&quot;:&quot;verf\u00fcgbar&quot;,&quot;sort&quot;:-1}],&quot;category&quot;:[{&quot;name&quot;:&quot;&lt;30&quot;,&quot;sort&quot;:-1}],&quot;festival&quot;:[]}}" data-additional-info="{&quot;premiere&quot;:{&quot;state&quot;:false,&quot;color&quot;:&quot;&quot;,&quot;colorSecondary&quot;:&quot;&quot;,&quot;date&quot;:&quot;2026-04-26&quot;}}" data-filtered="false"><div class="activity-list__col activity-list__col--content"><a class="activity-list__content" href="/stuecke/stelldichein/2026-04-26-1400-16457"><div class="activity-list__date"><time datetime="2026-04-26" class=""><span>
+                
+                26<span class="activity-list__date--month">. April 2026</span><span class="activity-list__date--month-short">.4.26</span></span><em class="activity-list__date-day-long">Sonntag</em><em class="activity-list__date-day-short">So</em></time></div><div class="activity-list__text"><span>14.00 Uhr | Literaturhaus</span><span class="h3">Stelldichein!</span><input class="activity-list--toggle" type="checkbox" value="16457" id="toggle-16457-cc1d699892" aria-label="Weitere Informationen zu Stelldichein! anzeigen"><div class="activity-list--toggle__content"><p class="activity-list-price-info"><span>
+            
+                    
+                            
+                                    
+                                            Preise
+                                            20 Euro
+                                                    
+                                                
+                                        
+                                
+                        
+                
+        </span>&lt;30<br></p></div><label class="activity-list--toggle__button" for="toggle-16457-cc1d699892"><span class="show-more">mehr anzeigen</span><span class="show-less">weniger anzeigen</span><svg class="icon"><use xlink:href="#icon-arrow-down"></use></svg></label></div><div class="activity-list__channel hide-on-md">
+        
+                Offstage 360
+            
+    </div></a></div><div class="activity-list__col activity-list__col--genre">
+                                
+                                        Offstage 360
+                                    
+                            </div><div class="activity-list__col activity-list__col--tickets"><div><a class="button button--ticket" href="https://tickets.staatstheater.bayern/bso.webshop/webticket/shop?language=de&amp;event=42118" target="_blank"><span>Letzte Tickets</span></a></div></div><div class="activity-list__col activity-list__col--actions"><a class="button-save-date" href="/stuecke/stelldichein/2026-04-26-1400-16457/calendar.ics"><svg class="icon icon-stroke"><use xlink:href="#icon-calendar"></use></svg><span>Termin merken</span></a></div></div><div data-date="2026-04-26" class="activity-list__row activity-list__row--is-same-date" data-schedule-filter="{&quot;date&quot;:&quot;2026-04-26&quot;,&quot;filter&quot;:{&quot;type&quot;:[{&quot;name&quot;:&quot;Extra&quot;,&quot;sort&quot;:-1}],&quot;availability&quot;:[],&quot;category&quot;:[],&quot;festival&quot;:[]}}" data-additional-info="{&quot;premiere&quot;:{&quot;state&quot;:false,&quot;color&quot;:&quot;&quot;,&quot;colorSecondary&quot;:&quot;&quot;,&quot;date&quot;:&quot;2026-04-26&quot;}}" data-filtered="false"><div class="activity-list__col activity-list__col--content"><a class="activity-list__content" href="/stuecke/brundibar/2026-04-26-1400-16480"><div class="activity-list__date"><time datetime="2026-04-26" class=""><span>
+                
+                26<span class="activity-list__date--month">. April 2026</span><span class="activity-list__date--month-short">.4.26</span></span><em class="activity-list__date-day-long">Sonntag</em><em class="activity-list__date-day-short">So</em></time></div><div class="activity-list__text"><span>14.00 Uhr | Pasinger Fabrik</span><span class="h3">Brundibár</span><input class="activity-list--toggle" type="checkbox" value="16480" id="toggle-16480-56b7919c50" aria-label="Weitere Informationen zu Brundibár anzeigen"><div class="activity-list--toggle__content"><p>Hans Krása, in einem Arrangement von Richard Whilds<br></p><p class="activity-list-price-info"><span></span><br></p></div><label class="activity-list--toggle__button" for="toggle-16480-56b7919c50"><span class="show-more">mehr anzeigen</span><span class="show-less">weniger anzeigen</span><svg class="icon"><use xlink:href="#icon-arrow-down"></use></svg></label></div><div class="activity-list__channel hide-on-md">
+        
+                Extra
+            
+    </div></a></div><div class="activity-list__col activity-list__col--genre">
+                                
+                                        Extra
+                                    
+                            </div><div class="activity-list__col activity-list__col--tickets"><div><span class="hide-on-xs"><!-- hide button --></span><span class="hide-from-xs"><!-- hide button --></span></div></div><!-- NoSale 3 --></div><div data-date="2026-04-26" class="activity-list__row activity-list__row--is-same-date" data-schedule-filter="{&quot;date&quot;:&quot;2026-04-26&quot;,&quot;filter&quot;:{&quot;type&quot;:[{&quot;name&quot;:&quot;Extra&quot;,&quot;sort&quot;:-1}],&quot;availability&quot;:[{&quot;name&quot;:&quot;verf\u00fcgbar&quot;,&quot;sort&quot;:-1}],&quot;category&quot;:[],&quot;festival&quot;:[]}}" data-additional-info="[]" data-filtered="false"><div class="activity-list__col activity-list__col--content"><a class="activity-list__content" href="/stuecke/fuehrung/26-04-2026-1400-16516"><div class="activity-list__date"><time datetime="2026-04-26" class=""><span>
+                
+                26<span class="activity-list__date--month">. April 2026</span><span class="activity-list__date--month-short">.4.26</span></span><em class="activity-list__date-day-long">Sonntag</em><em class="activity-list__date-day-short">So</em></time></div><div class="activity-list__text"><span>14.00 Uhr | Freunde-Foyer (Eingang Nord, Alfons-Goppel-Straße)</span><span class="h3">Führung</span><input class="activity-list--toggle" type="checkbox" value="16516" id="toggle-16516-fe5edd6985" aria-label="Weitere Informationen zu Führung anzeigen"><div class="activity-list--toggle__content"><p class="activity-list-price-info"><span>
+            
+                    
+                            
+                                    
+                                            Preise
+                                            PG15/7
+                                                    
+                                                            , €
+                                                            15
+                                                        
+                                                
+                                        
+                                
+                        
+                
+        </span>
+        
+                                Führung<br></p></div><label class="activity-list--toggle__button" for="toggle-16516-fe5edd6985"><span class="show-more">mehr anzeigen</span><span class="show-less">weniger anzeigen</span><svg class="icon"><use xlink:href="#icon-arrow-down"></use></svg></label></div><div class="activity-list__channel hide-on-md">
+        
+                Extra
+            
+    </div></a></div><div class="activity-list__col activity-list__col--genre">
+                                
+                                        Extra
+                                    
+                            </div><div class="activity-list__col activity-list__col--tickets"><div><a class="button button--ticket" href="https://tickets.staatstheater.bayern/bso.webshop/webticket/shop?language=de&amp;event=42168" target="_blank"><span>Tickets</span></a></div></div><div class="activity-list__col activity-list__col--actions"><a class="button-save-date" href="/stuecke/fuehrung/26-04-2026-1400-16516/calendar.ics"><svg class="icon icon-stroke"><use xlink:href="#icon-calendar"></use></svg><span>Termin merken</span></a></div></div><div data-date="2026-04-26" class="activity-list__row activity-list__row--is-same-date" data-schedule-filter="{&quot;date&quot;:&quot;2026-04-26&quot;,&quot;filter&quot;:{&quot;type&quot;:[{&quot;name&quot;:&quot;Extra&quot;,&quot;sort&quot;:-1}],&quot;availability&quot;:[],&quot;category&quot;:[],&quot;festival&quot;:[]}}" data-additional-info="[]" data-filtered="false"><div class="activity-list__col activity-list__col--content"><a class="activity-list__content" href="/stuecke/kinderfuehrung-durch-das-nationaltheater-abenteuer-oper/26-04-2026-1400-16525"><div class="activity-list__date"><time datetime="2026-04-26" class=""><span>
+                
+                26<span class="activity-list__date--month">. April 2026</span><span class="activity-list__date--month-short">.4.26</span></span><em class="activity-list__date-day-long">Sonntag</em><em class="activity-list__date-day-short">So</em></time></div><div class="activity-list__text"><span>14.00 Uhr | Freunde-Foyer (Eingang Nord, Alfons-Goppel-Straße)</span><span class="h3">Kinderführung „Abenteuer Oper"</span><input class="activity-list--toggle" type="checkbox" value="16525" id="toggle-16525-efdc5796e6" aria-label="Weitere Informationen zu Kinderführung „Abenteuer Oper&quot; anzeigen"><div class="activity-list--toggle__content"><p class="activity-list-price-info"><span>
+            
+                    
+                        Preise PG5
+                    
+                
+        </span>
+        
+                                Führung<br></p></div><label class="activity-list--toggle__button" for="toggle-16525-efdc5796e6"><span class="show-more">mehr anzeigen</span><span class="show-less">weniger anzeigen</span><svg class="icon"><use xlink:href="#icon-arrow-down"></use></svg></label></div><div class="activity-list__channel hide-on-md">
+        
+                Extra
+            
+    </div></a></div><div class="activity-list__col activity-list__col--genre">
+                                
+                                        Extra
+                                    
+                            </div><div class="activity-list__col activity-list__col--tickets"><div><span class="hide-on-xs">ausverkauft</span><span class="hide-from-xs">ausverk.</span></div></div><!-- sold out --></div><div data-date="2026-04-26" class="activity-list__row activity-list__row--is-same-date" data-schedule-filter="{&quot;date&quot;:&quot;2026-04-26&quot;,&quot;filter&quot;:{&quot;type&quot;:[{&quot;name&quot;:&quot;Oper&quot;,&quot;sort&quot;:-1}],&quot;availability&quot;:[{&quot;name&quot;:&quot;verf\u00fcgbar&quot;,&quot;sort&quot;:-1}],&quot;category&quot;:[{&quot;name&quot;:&quot;&lt;30&quot;,&quot;sort&quot;:-1}],&quot;festival&quot;:[]}}" data-additional-info="{&quot;premiere&quot;:{&quot;state&quot;:false,&quot;color&quot;:&quot;&quot;,&quot;colorSecondary&quot;:&quot;&quot;,&quot;date&quot;:&quot;2026-04-26&quot;}}" data-filtered="false"><div class="activity-list__col activity-list__col--content"><a class="activity-list__content" href="/stuecke/il-trovatore/2026-04-26-1800-15614"><div class="activity-list__date"><time datetime="2026-04-26" class=""><span>
+                
+                26<span class="activity-list__date--month">. April 2026</span><span class="activity-list__date--month-short">.4.26</span></span><em class="activity-list__date-day-long">Sonntag</em><em class="activity-list__date-day-short">So</em></time></div><div class="activity-list__text"><span>18.00 Uhr | Nationaltheater</span><span class="h3">IL TROVATORE</span><input class="activity-list--toggle" type="checkbox" value="15614" id="toggle-15614-bab7be0410" aria-label="Weitere Informationen zu IL TROVATORE anzeigen"><div class="activity-list--toggle__content"><p>Giuseppe Verdi<br></p><p class="activity-list-price-info"><span>
+            
+                    
+                            
+                                    
+                                            Preise
+                                            L
+                                                    
+                                                            , €
+                                                            163 /142 /117 /91 /- /39 /15 /11
+                                                        
+                                                
+                                        
+                                
+                        
+                
+        </span>
+        
+                                Abo-Serie 23, &lt;30<br></p></div><label class="activity-list--toggle__button" for="toggle-15614-bab7be0410"><span class="show-more">mehr anzeigen</span><span class="show-less">weniger anzeigen</span><svg class="icon"><use xlink:href="#icon-arrow-down"></use></svg></label></div><div class="activity-list__channel hide-on-md">
+        
+                Oper
+            
+    </div></a></div><div class="activity-list__col activity-list__col--genre">
+                                
+                                        Oper
+                                    
+                            </div><div class="activity-list__col activity-list__col--tickets"><div><a class="button button--ticket" href="https://tickets.staatstheater.bayern/bso.webshop/webticket/shop?language=de&amp;event=40229" target="_blank"><span>Tickets</span></a></div></div><div class="activity-list__col activity-list__col--actions"><a class="button-save-date" href="/stuecke/il-trovatore/2026-04-26-1800-15614/calendar.ics"><svg class="icon icon-stroke"><use xlink:href="#icon-calendar"></use></svg><span>Termin merken</span></a></div></div></div><div class="activity-group"><div data-date="2026-04-30" class="activity-list__row" data-schedule-filter="{&quot;date&quot;:&quot;2026-04-30&quot;,&quot;filter&quot;:{&quot;type&quot;:[{&quot;name&quot;:&quot;Extra&quot;,&quot;sort&quot;:-1}],&quot;availability&quot;:[{&quot;name&quot;:&quot;verf\u00fcgbar&quot;,&quot;sort&quot;:-1}],&quot;category&quot;:[],&quot;festival&quot;:[]}}" data-additional-info="[]" data-filtered="false"><div class="activity-list__col activity-list__col--content"><a class="activity-list__content" href="/stuecke/fuehrung/30-04-2026-1400-16517"><div class="activity-list__date"><time datetime="2026-04-30" class=""><span>
+                
+                30<span class="activity-list__date--month">. April 2026</span><span class="activity-list__date--month-short">.4.26</span></span><em class="activity-list__date-day-long">Donnerstag</em><em class="activity-list__date-day-short">Do</em></time></div><div class="activity-list__text"><span>14.00 Uhr | Freunde-Foyer (Eingang Nord, Alfons-Goppel-Straße)</span><span class="h3">Führung</span><input class="activity-list--toggle" type="checkbox" value="16517" id="toggle-16517-80794c4fe6" aria-label="Weitere Informationen zu Führung anzeigen"><div class="activity-list--toggle__content"><p class="activity-list-price-info"><span>
+            
+                    
+                            
+                                    
+                                            Preise
+                                            PG15/7
+                                                    
+                                                            , €
+                                                            15
+                                                        
+                                                
+                                        
+                                
+                        
+                
+        </span>
+        
+                                Führung<br></p></div><label class="activity-list--toggle__button" for="toggle-16517-80794c4fe6"><span class="show-more">mehr anzeigen</span><span class="show-less">weniger anzeigen</span><svg class="icon"><use xlink:href="#icon-arrow-down"></use></svg></label></div><div class="activity-list__channel hide-on-md">
+        
+                Extra
+            
+    </div></a></div><div class="activity-list__col activity-list__col--genre">
+                                
+                                        Extra
+                                    
+                            </div><div class="activity-list__col activity-list__col--tickets"><div><a class="button button--ticket" href="https://tickets.staatstheater.bayern/bso.webshop/webticket/shop?language=de&amp;event=42169" target="_blank"><span>Tickets</span></a></div></div><div class="activity-list__col activity-list__col--actions"><a class="button-save-date" href="/stuecke/fuehrung/30-04-2026-1400-16517/calendar.ics"><svg class="icon icon-stroke"><use xlink:href="#icon-calendar"></use></svg><span>Termin merken</span></a></div></div><div data-date="2026-04-30" class="activity-list__row activity-list__row--is-same-date" data-schedule-filter="{&quot;date&quot;:&quot;2026-04-30&quot;,&quot;filter&quot;:{&quot;type&quot;:[{&quot;name&quot;:&quot;Extra&quot;,&quot;sort&quot;:-1}],&quot;availability&quot;:[{&quot;name&quot;:&quot;verf\u00fcgbar&quot;,&quot;sort&quot;:-1}],&quot;category&quot;:[],&quot;festival&quot;:[]}}" data-additional-info="[]" data-filtered="false"><div class="activity-list__col activity-list__col--content"><a class="activity-list__content" href="/stuecke/guided-tour-of-the-national-theatre/30-04-2026-1400-16528"><div class="activity-list__date"><time datetime="2026-04-30" class=""><span>
+                
+                30<span class="activity-list__date--month">. April 2026</span><span class="activity-list__date--month-short">.4.26</span></span><em class="activity-list__date-day-long">Donnerstag</em><em class="activity-list__date-day-short">Do</em></time></div><div class="activity-list__text"><span>14.00 Uhr | Freunde-Foyer (Eingang Nord, Alfons-Goppel-Straße)</span><span class="h3">Guided tour of the Nationaltheater</span><input class="activity-list--toggle" type="checkbox" value="16528" id="toggle-16528-159ab5fd06" aria-label="Weitere Informationen zu Guided tour of the Nationaltheater anzeigen"><div class="activity-list--toggle__content"><p class="activity-list-price-info"><span>
+            
+                    
+                            
+                                    
+                                            Preise
+                                            PG15/7
+                                                    
+                                                            , €
+                                                            15
+                                                        
+                                                
+                                        
+                                
+                        
+                
+        </span>
+        
+                                Führung<br></p></div><label class="activity-list--toggle__button" for="toggle-16528-159ab5fd06"><span class="show-more">mehr anzeigen</span><span class="show-less">weniger anzeigen</span><svg class="icon"><use xlink:href="#icon-arrow-down"></use></svg></label></div><div class="activity-list__channel hide-on-md">
+        
+                Extra
+            
+    </div></a></div><div class="activity-list__col activity-list__col--genre">
+                                
+                                        Extra
+                                    
+                            </div><div class="activity-list__col activity-list__col--tickets"><div><a class="button button--ticket" href="https://tickets.staatstheater.bayern/bso.webshop/webticket/shop?language=de&amp;event=42172" target="_blank"><span>Tickets</span></a></div></div><div class="activity-list__col activity-list__col--actions"><a class="button-save-date" href="/stuecke/guided-tour-of-the-national-theatre/30-04-2026-1400-16528/calendar.ics"><svg class="icon icon-stroke"><use xlink:href="#icon-calendar"></use></svg><span>Termin merken</span></a></div></div><div data-date="2026-04-30" class="activity-list__row activity-list__row--is-same-date" data-schedule-filter="{&quot;date&quot;:&quot;2026-04-30&quot;,&quot;filter&quot;:{&quot;type&quot;:[{&quot;name&quot;:&quot;Oper&quot;,&quot;sort&quot;:-1}],&quot;availability&quot;:[{&quot;name&quot;:&quot;verf\u00fcgbar&quot;,&quot;sort&quot;:-1}],&quot;category&quot;:[],&quot;festival&quot;:[]}}" data-additional-info="{&quot;premiere&quot;:{&quot;state&quot;:false,&quot;color&quot;:&quot;&quot;,&quot;colorSecondary&quot;:&quot;&quot;,&quot;date&quot;:&quot;2026-04-30&quot;}}" data-filtered="false"><div class="activity-list__col activity-list__col--content"><a class="activity-list__content" href="/stuecke/il-trovatore/2026-04-30-1900-15615"><div class="activity-list__date"><time datetime="2026-04-30" class=""><span>
+                
+                30<span class="activity-list__date--month">. April 2026</span><span class="activity-list__date--month-short">.4.26</span></span><em class="activity-list__date-day-long">Donnerstag</em><em class="activity-list__date-day-short">Do</em></time></div><div class="activity-list__text"><span>19.00 Uhr | Nationaltheater</span><span class="h3">IL TROVATORE</span><input class="activity-list--toggle" type="checkbox" value="15615" id="toggle-15615-7c346915ed" aria-label="Weitere Informationen zu IL TROVATORE anzeigen"><div class="activity-list--toggle__content"><p>Giuseppe Verdi<br></p><p class="activity-list-price-info"><span>
+            
+                    
+                            
+                                    
+                                            Preise
+                                            L
+                                                    
+                                                            , €
+                                                            163 /142 /- /91 /64 /- /15 /11
+                                                        
+                                                
+                                        
+                                
+                        
+                
+        </span>
+        
+                                Abo-Serie 13<br></p></div><label class="activity-list--toggle__button" for="toggle-15615-7c346915ed"><span class="show-more">mehr anzeigen</span><span class="show-less">weniger anzeigen</span><svg class="icon"><use xlink:href="#icon-arrow-down"></use></svg></label></div><div class="activity-list__channel hide-on-md">
+        
+                Oper
+            
+    </div></a></div><div class="activity-list__col activity-list__col--genre">
+                                
+                                        Oper
+                                    
+                            </div><div class="activity-list__col activity-list__col--tickets"><div><a class="button button--ticket" href="https://tickets.staatstheater.bayern/bso.webshop/webticket/shop?language=de&amp;event=40236" target="_blank"><span>Tickets</span></a></div></div><div class="activity-list__col activity-list__col--actions"><a class="button-save-date" href="/stuecke/il-trovatore/2026-04-30-1900-15615/calendar.ics"><svg class="icon icon-stroke"><use xlink:href="#icon-calendar"></use></svg><span>Termin merken</span></a></div></div></div></div></div></div></div>
+
+
+    </main>
+    <!--TYPO3SEARCH_end-->
+
+
+            
+    <footer id="footer" class="footer">
+        <nav>
+            
+            
+    
+    <div class="footer__sponsor-logo">
+        
+            
+                
+                    
+                            
+                                <img src="/fileadmin/user_upload/2021/05/bmw_logo_gray.png" width="340" height="78" alt="BMW GLOBAL Partner">
+                            
+                        
+                
+            
+        
+
+    </div>
+
+
+            
+            
+    
+        <ul class="footer__link-wrapper footer__link-wrapper--stacked">
+            <li class="footer__site-end-navigation-item">
+                <a href="#" onclick="UC_UI.showSecondLayer();">Cookie-Einstellungen</a>
+            </li>
+            
+                <li class="footer__site-end-navigation-item">
+                    <a href="/erklaerung-zur-barrierefreiheit" target="_self">
+                        Erklärung zur Barrierefreiheit
+                    </a>
+                </li>
+            
+                <li class="footer__site-end-navigation-item">
+                    <a href="/ausschreibungen" target="https://vst.deutsche-evergabe.de/portal/verfahren/6165">
+                        Ausschreibungen
+                    </a>
+                </li>
+            
+                <li class="footer__site-end-navigation-item">
+                    <a href="/agb" target="_self">
+                        AGB
+                    </a>
+                </li>
+            
+                <li class="footer__site-end-navigation-item">
+                    <a href="/impressum" target="_self">
+                        Impressum
+                    </a>
+                </li>
+            
+                <li class="footer__site-end-navigation-item">
+                    <a href="/datenschutz" target="_self">
+                        Datenschutz
+                    </a>
+                </li>
+            
+                <li class="footer__site-end-navigation-item">
+                    <a href="/presse" target="_self">
+                        Presse
+                    </a>
+                </li>
+            
+                <li class="footer__site-end-navigation-item">
+                    <a href="/login" target="_self">
+                        Login
+                    </a>
+                </li>
+            
+                <li class="footer__site-end-navigation-item">
+                    <a href="/kontakt" target="_self">
+                        Kontakt
+                    </a>
+                </li>
+            
+                <li class="footer__site-end-navigation-item">
+                    <a href="/jobs-1" target="_self">
+                        Jobs
+                    </a>
+                </li>
+            
+                <li class="footer__site-end-navigation-item">
+                    <a href="/newsletter/anmeldung" target="_self">
+                        Newsletter
+                    </a>
+                </li>
+            
+        </ul>
+    
+
+
+            
+            
+    
+        <ul class="footer__link-wrapper">
+            
+                <li class="footer__social-links-item">
+                    <a data-tracking-event="UAEvent-Klick" data-tracking-eventlabel="facebook" data-tracking-eventaction="SocialMedia" data-tracking-eventcategory="Element" data-tracking-trigger="click" rel="noopener" target="_blank" href="https://www.facebook.com/baystaatsoper">
+                        Facebook
+                    </a>
+                </li>
+            
+            
+                <li class="footer__social-links-item">
+                    <a data-tracking-event="UAEvent-Klick" data-tracking-eventlabel="instagram" data-tracking-eventaction="SocialMedia" data-tracking-eventcategory="Element" data-tracking-trigger="click" rel="noopener" target="_blank" href="https://www.instagram.com/bayerischestaatsoper">
+                        Instagram
+                    </a>
+                </li>
+            
+            
+                <li class="footer__social-links-item">
+                    <a data-tracking-event="UAEvent-Klick" data-tracking-eventlabel="youtube" data-tracking-eventaction="SocialMedia" data-tracking-eventcategory="Element" data-tracking-trigger="click" rel="noopener" target="_blank" href="https://www.youtube.com/user/BayerischeStaatsoper">
+                        Youtube
+                    </a>
+                </li>
+            
+            
+        </ul>
+    
+
+        </nav>
+    </footer>
+
+
+        </div>
+
+        <div class="page__main-aside page__main-aside--sticky">
+            
+
+    
+
+    <aside class="schedule-aside">
+        
+                <div class="schedule-aside__calendar">
+                    
+    
+            
+        
+    <div data-component="03_molecules/Calendar" data-range-mode="1" data-can-pick="1" data-start="" data-endpoint="/spielplan/{month}/activities.ajax" data-next="Nächster Monat" data-prev="Vorheriger Monat" data-history-url="/spielplan" data-archive="0" data-language="de-DE">
+    <div class="litepicker" data-plugins="customevents|startmonth" style="display: inline-block; position: relative;"><div class="container__main"><div class="container__months"><div class="month-item no-previous-month"><div class="month-item-header"><button type="button" class="button-previous-month" aria-label="Nächster Monat"><svg class="icon"><use xlink:href="#icon-arrow-left"></use></svg></button><div><strong class="month-item-name">April</strong><span class="month-item-year">2026</span></div><button type="button" class="button-next-month" aria-label="Vorheriger Monat"><svg class="icon"><use xlink:href="#icon-arrow-right"></use></svg></button></div><div class="month-item-weekdays-row"><div title="Montag">Mo</div><div title="Dienstag">Di</div><div title="Mittwoch">Mi</div><div title="Donnerstag">Do</div><div title="Freitag">Fr</div><div title="Samstag">Sa</div><div title="Sonntag">So</div></div><div class="container__days"><div></div><div></div><div class="day-item is-locked" data-time="1774994400000" tabindex="-1" data-no="1">1</div><div class="day-item is-today" data-time="1775080800000" tabindex="0" data-no="2">2</div><div class="day-item" data-time="1775167200000" tabindex="0" data-no="3">3</div><div class="day-item" data-time="1775253600000" tabindex="0" data-no="4">4</div><div class="day-item last-in-row" data-time="1775340000000" tabindex="0" data-no="5">5</div><div class="day-item first-in-row" data-time="1775426400000" tabindex="0" data-no="6">6</div><div class="day-item" data-time="1775512800000" tabindex="0" data-no="7">7</div><div class="day-item" data-time="1775599200000" tabindex="0" data-no="8">8</div><div class="day-item" data-time="1775685600000" tabindex="0" data-no="9">9</div><div class="day-item" data-time="1775772000000" tabindex="0" data-no="10">10</div><div class="day-item" data-time="1775858400000" tabindex="0" data-no="11">11</div><div class="day-item last-in-row" data-time="1775944800000" tabindex="0" data-no="12">12</div><div class="day-item first-in-row" data-time="1776031200000" tabindex="0" data-no="13">13</div><div class="day-item" data-time="1776117600000" tabindex="0" data-no="14">14</div><div class="day-item" data-time="1776204000000" tabindex="0" data-no="15">15</div><div class="day-item" data-time="1776290400000" tabindex="0" data-no="16">16</div><div class="day-item" data-time="1776376800000" tabindex="0" data-no="17">17</div><div class="day-item" data-time="1776463200000" tabindex="0" data-no="18">18</div><div class="day-item last-in-row" data-time="1776549600000" tabindex="0" data-no="19">19</div><div class="day-item first-in-row" data-time="1776636000000" tabindex="0" data-no="20">20</div><div class="day-item" data-time="1776722400000" tabindex="0" data-no="21">21</div><div class="day-item" data-time="1776808800000" tabindex="0" data-no="22">22</div><div class="day-item" data-time="1776895200000" tabindex="0" data-no="23">23</div><div class="day-item" data-time="1776981600000" tabindex="0" data-no="24">24</div><div class="day-item" data-time="1777068000000" tabindex="0" data-no="25">25</div><div class="day-item last-in-row" data-time="1777154400000" tabindex="0" data-no="26">26</div><div class="day-item first-in-row" data-time="1777240800000" tabindex="0" data-no="27">27</div><div class="day-item" data-time="1777327200000" tabindex="0" data-no="28">28</div><div class="day-item" data-time="1777413600000" tabindex="0" data-no="29">29</div><div class="day-item" data-time="1777500000000" tabindex="0" data-no="30">30</div></div></div></div></div></div></div>
+    <div class="calendar-reset">
+        <a data-component="02_atoms/CalendarReset" href="#reset">heute</a>
+    </div>
+
+                </div>
+                <div class="schedule-aside__schedule-filter">
+                    
+    <div class="schedule-month-filter" data-component="03_molecules/ScheduleMonthFilter" data-label-select="Monatsauswahl">
+            <div class="hide-on-sm"></div>
+            <label class="hide-from-sm schedule-month-filter__select">
+                <select class="form__control form__field-select" data-select="">
+                    <option selected="">Monatsauswahl</option>
+                    
+                </select>
+                <svg class="icon"><use xlink:href="#icon-arrow-down"></use></svg>
+            </label>
+        </div>
+
+                </div>
+            
+
+        
+                <div class="schedule-aside__filter-header" data-component="03_molecules/FilterLightbox" data-selectors=".schedule-aside__section, .schedule-aside__action">
+                    <span>Filter</span>
+                    <svg class="icon icon-filter"><use xlink:href="#icon-filter"></use></svg>
+                    <svg class="icon hide icon-close"><use xlink:href="#icon-close"></use></svg>
+                </div>
+            
+
+        
+                <div class="schedule-aside__section">
+                    <div class="schedule-aside__filter-list">
+                        
+    <div class="schedule-filter" data-component="03_molecules/ScheduleFilter">
+        <div class="schedule-filter__inner">
+            <ul id="schedule-filter" class="list list--style-none">
+
+                
+                <li>
+                    <input id="schedule-filter-0" type="checkbox" aria-labelledby="schedule-filter-heading-0" role="button" aria-pressed="false" class="visuallyhidden" aria-controls="schedule-filter-panel-0">
+
+                    <div class="schedule-filter__section-content">
+                        <label for="schedule-filter-0" id="schedule-filter-heading-0">
+                            Art der Vorstellung
+                            <svg class="icon">
+                                <use xlink:href="#icon-arrow-down"></use>
+                            </svg>
+                        </label>
+
+                        <ul id="schedule-filter-panel-0" class="list list--style-none" role="region" aria-labelledby="schedule-filter-heading-0" data-parent="#schedule-filter" data-filter-category="type"><li>
+                <label>
+                    <input class="visuallyhidden" type="checkbox" name="Ballett" data-category="type">
+                    <span>Ballett</span>
+                </label>
+            </li><li>
+                <label>
+                    <input class="visuallyhidden" type="checkbox" name="Community" data-category="type">
+                    <span>Community</span>
+                </label>
+            </li><li>
+                <label>
+                    <input class="visuallyhidden" type="checkbox" name="Extra" data-category="type">
+                    <span>Extra</span>
+                </label>
+            </li><li>
+                <label>
+                    <input class="visuallyhidden" type="checkbox" name="Kind&amp;Co" data-category="type">
+                    <span>Kind&amp;Co</span>
+                </label>
+            </li><li>
+                <label>
+                    <input class="visuallyhidden" type="checkbox" name="Konzert" data-category="type">
+                    <span>Konzert</span>
+                </label>
+            </li><li>
+                <label>
+                    <input class="visuallyhidden" type="checkbox" name="Liederabend" data-category="type">
+                    <span>Liederabend</span>
+                </label>
+            </li><li>
+                <label>
+                    <input class="visuallyhidden" type="checkbox" name="Offstage 360" data-category="type">
+                    <span>Offstage 360</span>
+                </label>
+            </li><li>
+                <label>
+                    <input class="visuallyhidden" type="checkbox" name="Oper" data-category="type">
+                    <span>Oper</span>
+                </label>
+            </li></ul>
+                    </div>
+                </li>
+                <li>
+                    <input id="schedule-filter-1" type="checkbox" aria-labelledby="schedule-filter-heading-1" role="button" aria-pressed="false" class="visuallyhidden" aria-controls="schedule-filter-panel-1">
+
+                    <div class="schedule-filter__section-content">
+                        <label for="schedule-filter-1" id="schedule-filter-heading-1">
+                            Kartenstatus
+                            <svg class="icon">
+                                <use xlink:href="#icon-arrow-down"></use>
+                            </svg>
+                        </label>
+
+                        <ul id="schedule-filter-panel-1" class="list list--style-none" role="region" aria-labelledby="schedule-filter-heading-1" data-parent="#schedule-filter" data-filter-category="availability"><li>
+                <label>
+                    <input class="visuallyhidden" type="checkbox" name="verfügbar" data-category="availability">
+                    <span>verfügbar</span>
+                </label>
+            </li></ul>
+                    </div>
+                </li>
+                <li>
+                    <input id="schedule-filter-2" type="checkbox" aria-labelledby="schedule-filter-heading-2" role="button" aria-pressed="false" class="visuallyhidden" aria-controls="schedule-filter-panel-2">
+
+                    <div class="schedule-filter__section-content">
+                        <label for="schedule-filter-2" id="schedule-filter-heading-2">
+                            Kategorie
+                            <svg class="icon">
+                                <use xlink:href="#icon-arrow-down"></use>
+                            </svg>
+                        </label>
+
+                        <ul id="schedule-filter-panel-2" role="region" aria-labelledby="schedule-filter-heading-2" data-parent="#schedule-filter" data-filter-category="category"><li>
+                <label>
+                    <input class="visuallyhidden" type="checkbox" name="&lt;30" data-category="category">
+                    <span>&lt;30</span>
+                </label>
+            </li></ul>
+                    </div>
+                </li>
+                <li>
+                    <input id="schedule-filter-3" type="checkbox" aria-labelledby="schedule-filter-heading-3" role="button" aria-pressed="false" class="visuallyhidden" aria-controls="schedule-filter-panel-3">
+
+                    <div class="schedule-filter__section-content is-empty">
+                        <label for="schedule-filter-3" id="schedule-filter-heading-3">
+                            Festival
+                            <svg class="icon">
+                                <use xlink:href="#icon-arrow-down"></use>
+                            </svg>
+                        </label>
+
+                        <ul id="schedule-filter-panel-3" role="region" aria-labelledby="schedule-filter-heading-3" data-parent="#schedule-filter" data-filter-category="festival"></ul>
+                    </div>
+                </li>
+                
+            </ul>
+        </div>
+
+    </div>
+
+                    </div>
+                </div>
+            
+
+        
+            <div class="schedule-aside__info hide-from-sm" data-component="02_atoms/ScheduleFilterInfo"></div>
+            <div class="schedule-aside__action">
+                <button class="button button--dark mr-auto hide-from-sm" data-component="02_atoms/ScheduleFilterClose">
+                    Bestätigen
+                </button>
+                <button class="button schedule-filter-reset" data-component="02_atoms/ScheduleFilterReset">
+                    <svg class="icon icon--fill-current" aria-hidden="true"><use xlink:href="#icon-arrow-rotate-left"></use></svg>
+                    Zurücksetzen
+                </button>
+            </div>
+        
+    </aside>
+
+        </div>
+
+    </div>
+
+</div>
+
+<script src="/typo3conf/ext/sfsitepackage/Resources/Public/JavaScript/main.js?1774004424"></script>
+<script src="/assets/forms/powermail/jquery.validate.min.js?1773737857"></script>
+<script src="/assets/forms/powermail/powermailvalidierung.js?1773737857"></script>
+<script src="/assets/forms/powermail/powermail-payment.js?1773737857"></script>
+<script src="/assets/forms/powermail/localization/messages_de.min.js?1773737857"></script>
+
+
+
+<div id="usercentrics-root" data-created-at="1775162135096" style=""></div><iframe id="uc-cross-domain-bridge" src="https://app.usercentrics.eu/browser-sdk/4.61.0/cross-domain-bridge.html" style="display: none;"></iframe><style id="uc-overflow-style">.overflowHidden {overflow: hidden !important;}</style></body></html>

--- a/src/scrapers/__tests__/bayerische-staatsoper.test.ts
+++ b/src/scrapers/__tests__/bayerische-staatsoper.test.ts
@@ -1,0 +1,50 @@
+import { readFileSync } from 'node:fs';
+import { describe, it, expect } from 'vitest';
+import { BayerischeStaatsoperScraper } from '../bayerische-staatsoper.js';
+
+const fixture = readFileSync(new URL('../__fixtures__/bayerische-staatsoper.html', import.meta.url), 'utf8');
+const scraper = new BayerischeStaatsoperScraper({ fetchHtml: async () => fixture });
+
+describe('BayerischeStaatsoperScraper', () => {
+  it('parses events from fixture', async () => {
+    const events = await scraper.scrape();
+    expect(events.length).toBeGreaterThan(0);
+  });
+
+  it('parses date in YYYY-MM-DD format', async () => {
+    const events = await scraper.scrape();
+    for (const e of events) {
+      expect(e.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    }
+  });
+
+  it('parses time in HH:MM format', async () => {
+    const events = await scraper.scrape();
+    const withTime = events.filter(e => e.time);
+    expect(withTime.length).toBeGreaterThan(0);
+    for (const e of withTime) {
+      expect(e.time).toMatch(/^\d{2}:\d{2}$/);
+    }
+  });
+
+  it('generates URLs under staatsoper.de', async () => {
+    const events = await scraper.scrape();
+    const withUrl = events.filter(e => e.url);
+    expect(withUrl.length).toBeGreaterThan(0);
+    for (const e of withUrl) {
+      expect(e.url).toMatch(/^https:\/\/www\.staatsoper\.de\/stuecke\//);
+    }
+  });
+
+  it('includes composer in title when available', async () => {
+    const events = await scraper.scrape();
+    const withComposer = events.filter(e => e.title.includes('('));
+    expect(withComposer.length).toBeGreaterThan(0);
+  });
+
+  it('parses location from time/location string', async () => {
+    const events = await scraper.scrape();
+    const withLocation = events.filter(e => e.location);
+    expect(withLocation.length).toBeGreaterThan(0);
+  });
+});

--- a/src/scrapers/bayerische-staatsoper.ts
+++ b/src/scrapers/bayerische-staatsoper.ts
@@ -1,0 +1,106 @@
+import { load } from 'cheerio';
+import type { Event } from '../types.js';
+import { generateEventId, USER_AGENT, type Scraper, type VenueMeta } from './base.js';
+
+type FetchHtml = () => Promise<string>;
+
+const BASE_URL = 'https://www.staatsoper.de';
+
+export class BayerischeStaatsoperScraper implements Scraper {
+  readonly venue: VenueMeta = {
+    venueId: 'bayerische-staatsoper',
+    venueName: 'Bayerische Staatsoper',
+    cityId: 'muenchen',
+    cityName: 'München',
+    country: 'DE',
+    scheduleUrl: 'https://www.staatsoper.de/spielplan',
+  };
+
+  get venueId(): string { return this.venue.venueId; }
+
+  constructor(private readonly opts: { fetchHtml?: FetchHtml } = {}) {}
+
+  async scrape(): Promise<Event[]> {
+    const html = this.opts.fetchHtml
+      ? await this.opts.fetchHtml()
+      : await fetch(this.venue.scheduleUrl, {
+          headers: { 'User-Agent': USER_AGENT },
+        }).then((r) => {
+          if (!r.ok) throw new Error(`HTTP ${r.status} from ${this.venue.scheduleUrl}`);
+          return r.text();
+        });
+    return this.parse(html);
+  }
+
+  parse(html: string): Event[] {
+    const $ = load(html);
+    const events: Event[] = [];
+    const now = new Date().toISOString();
+
+    $('div.activity-list__row').each((_, el) => {
+      try {
+        const $row = $(el);
+        const date = $row.attr('data-date') ?? '';
+        if (!date || !/^\d{4}-\d{2}-\d{2}$/.test(date)) return;
+
+        const $content = $row.find('a.activity-list__content');
+        if (!$content.length) return;
+
+        const title = $content.find('span.h3').text().trim();
+        if (!title) return;
+
+        // Time and location from the first span in activity-list__text
+        // Format: "19.30 Uhr | Nationaltheater"
+        const timeLocationText = $content.find('div.activity-list__text > span').first().text().trim();
+        let time: string | null = null;
+        let location: string | null = null;
+
+        const tlMatch = timeLocationText.match(/^(\d{1,2})\.(\d{2})\s*Uhr\s*\|\s*(.+)$/);
+        if (tlMatch) {
+          time = `${tlMatch[1].padStart(2, '0')}:${tlMatch[2]}`;
+          location = tlMatch[3].trim() || null;
+        } else {
+          // Try to extract just the time
+          const timeOnly = timeLocationText.match(/(\d{1,2})\.(\d{2})\s*Uhr/);
+          if (timeOnly) {
+            time = `${timeOnly[1].padStart(2, '0')}:${timeOnly[2]}`;
+          }
+        }
+
+        // Composer from toggle content (first <p> that is NOT price info)
+        const toggleContent = $content.find('div.activity-list--toggle__content');
+        let composer: string | null = null;
+        if (toggleContent.length) {
+          const firstP = toggleContent.find('p').first();
+          if (firstP.length && !firstP.hasClass('activity-list-price-info')) {
+            composer = firstP.text().replace(/<br\s*\/?>/g, '').trim() || null;
+          }
+        }
+
+        // Build title with composer
+        const fullTitle = composer ? `${title} (${composer})` : title;
+
+        // Event detail URL
+        const href = $content.attr('href') ?? '';
+        const url = href ? new URL(href, BASE_URL + '/').href : null;
+
+        events.push({
+          id: generateEventId(this.venueId, date, time, title),
+          venue_id: this.venueId,
+          title: fullTitle,
+          date,
+          time,
+          conductor: null,
+          cast: null,
+          location,
+          url,
+          scraped_at: now,
+        });
+      } catch {
+        // skip malformed entries silently
+      }
+    });
+
+    return events;
+  }
+}


### PR DESCRIPTION
## Summary
- Add scraper for **Bayerische Staatsoper** (München, DE) — Closes #3
- **Schedule URL:** https://www.staatsoper.de/spielplan
- Parses event title, date, time, location, composer, and detail URL from the Spielplan HTML
- Conductor and cast are not available on the schedule listing page (set to `null`)
- Fixture fetched via Playwright since the site uses aggressive WAF bot protection (curl returns 403)

## Test plan
- [x] All 8 test files pass (25 tests total, including 6 new ones)
- [x] `bayerische-staatsoper.test.ts` validates: event count > 0, YYYY-MM-DD dates, HH:MM times, staatsoper.de URLs, composer in title, location parsing
- [ ] Verify live scrape with `npm run scrape` (may require browser-like headers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)