### PR TITLE
scraper: Arena di Verona (Verona)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Missing your favorite venue? PRs welcome! Read **[CONTRIBUTING.md](CONTRIBUTING.
 | San Francisco Opera | San Francisco |
 | Gran Teatre del Liceu | Barcelona |
 | Semperoper | Dresden |
+| Arena di Verona | Verona |
 
 ## How it works
 

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -14,6 +14,7 @@ import { OperFrankfurtScraper } from './scrapers/oper-frankfurt.js';
 import { SanFranciscoOperaScraper } from './scrapers/san-francisco-opera.js';
 import { LiceuBarcelonaScraper } from './scrapers/liceu-barcelona.js';
 import { SemperoperDresdenScraper } from './scrapers/semperoper-dresden.js';
+import { ArenaDiVeronaScraper } from './scrapers/arena-di-verona.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -44,6 +45,7 @@ export const scrapers: Scraper[] = [
   new SanFranciscoOperaScraper(),
   new LiceuBarcelonaScraper(),
   new SemperoperDresdenScraper(),
+  new ArenaDiVeronaScraper(),
 ];
 
 export async function runScrapers(list: Scraper[]): Promise<void> {

--- a/src/scrapers/__fixtures__/arena-di-verona.html
+++ b/src/scrapers/__fixtures__/arena-di-verona.html
@@ -1,0 +1,10016 @@
+<!doctype html>
+<html lang="it">
+	<head>
+		<meta charset="utf-8">
+		<meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+		<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+		<meta name="format-detection" content="telephone=no">
+
+		
+		<!-- OneTrust Cookies Consent Notice start for arena.it -->
+		<script src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js"  
+                type="text/javascript" 
+                charset="UTF-8" 
+                data-domain-script="019ada40-28d6-79e0-a63b-88849e50f109"
+                data-document-language="true"></script>
+		<script type="text/javascript">
+		    function OptanonWrapper() { }
+		</script>
+		<!-- OneTrust Cookies Consent Notice end for arena.it -->
+
+
+		<script>
+            // Define dataLayer and the gtag function.
+            window.dataLayer = window.dataLayer || [];
+            function gtag() { dataLayer.push(arguments); }
+            gtag('set', 'ads_data_redaction', false);
+            // Default consent to 'denied'
+            gtag('consent', 'default', {
+                'ad_storage': 'denied',
+                'ad_user_data': 'denied',
+                'ad_personalization': 'denied',
+                'analytics_storage': 'denied',
+                'functionality_storage': "denied", // optional
+                'personalization_storage': "denied", // optional
+                'security_storage': "denied", // optional
+                'wait_for_update': 500 // milliseconds
+            });
+            // Improve ad click measurement quality (optional)
+            //gtag('set', 'url_passthrough', true);
+        </script>
+
+		<!-- start SEO -->
+		<title>Calendario Arena Opera Festival e Teatro Filarmonico</title>
+<meta name="description" content="Sfoglia il calendario degli spettacoli all&apos;Arena di Verona Opera Festival e al Teatro Filarmonico di Verona. Prenota ora un&apos;esperienza indimenticabile!">
+<link rel="canonical" href="https://www.arena.it/calendario/">
+<meta property="og:title" content="Calendario Arena Opera Festival e Teatro Filarmonico">
+<meta property="og:description" content="Sfoglia il calendario degli spettacoli all&apos;Arena di Verona Opera Festival e al Teatro Filarmonico di Verona. Prenota ora un&apos;esperienza indimenticabile!">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://www.arena.it/calendario/">
+<meta name="twitter:card" content="summary">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+  {
+    "@type": "ListItem",
+    "position": 1,
+    "name": "Calendario",
+    "item": "https://www.arena.it/calendario/"
+  }
+  ]
+}
+</script>
+<meta name="generator" content="ProcessWire">
+<link rel="alternate" href="https://www.arena.it/calendario/" hreflang="it">
+<link rel="alternate" href="https://www.arena.it/calendario/" hreflang="x-default">
+<link rel="alternate" href="https://www.arena.it/en/calendar/" hreflang="en">
+<link rel="alternate" href="https://www.arena.it/de/kalender/" hreflang="de">
+		<!-- end SEO -->
+
+		<!-- SEO DATA -->
+
+
+
+
+
+
+
+
+
+
+<!-- END SEO DATA -->
+
+
+<!-- START SORJEN DATA -->
+
+    
+
+<!-- END SORJEN DATA -->
+
+
+		<link href="/site/templates/res/css/arena-di-verona.css?v=20260129" rel="stylesheet"/> 
+        <link href="/site/templates/res/override/arena-di-verona.css?v=20260129" rel="stylesheet"/> 
+        <link rel="icon" type="image/png" href="/site/templates/res/favicons/favicon-32x32.png" sizes="32x32">
+		<link rel="icon" type="image/png" href="/site/templates/res/favicons/favicon-194x194.png" sizes="194x194">
+		<link rel="icon" type="image/png" href="/site/templates/res/favicons/android-chrome-192x192.png" sizes="192x192">
+		<link rel="icon" type="image/png" href="/site/templates/res/favicons/favicon-16x16.png" sizes="16x16">
+		<link rel="apple-touch-icon" sizes="180x180" href="/site/templates/res/favicons/apple-touch-icon.png">
+		<meta name="msapplication-TileImage" content="/site/templates/res/favicons/favicon-270x270.png"/>
+
+	    <!-- Google Tag Manager -->
+		 <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+		        new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+		        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+		        'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+		        })(window,document,'script','dataLayer','GTM-PSSKRPF');</script>
+		<!-- End Google Tag Manager -->
+
+		 <script async src="https://cdn.eye-able.com/configs/www.arena.it.js"></script>
+		 <script async src="https://cdn.eye-able.com/public/js/eyeAble.js"></script>
+
+	</head>
+	<body>
+		<a href="#maincontent" class="visually-hidden" title="Salta al contenuto principale">Salta al contenuto principale</a>
+		<h1 class="visually-hidden">Calendario</h1>
+
+		
+
+
+
+
+<header class="header bh-header">
+	<div class="bh-menuDisappear">
+		<div class="toggle-menu">
+			<div class="open-menu bh-open-menu" style="display: block;">
+				<a href="javascript:void(8);" title="Apri Menu" class="cta">
+					<span class="label">Menu</span>
+				</a>
+			</div>
+			<div class="close-menu bh-close-menu" style="display: none;">
+				<a href="javascript:void(9);" title="Chiudi menu" class="cta">
+					<span class="label">Menu</span>
+				</a>
+			</div>
+		</div>
+		<div class="menu-disappear bh-megaMenu" style="left: -100%;">
+			<nav aria-labelledby="headermenufull" class="megamenu">
+				<h3 class="visually-hidden" id="headermenufull">Menu Principale completo</h3>
+
+												<ul>
+					
+						<li>
+							<a href="/arena-opera-festival/" title="Arena Opera Festival" class="cta opera  bh-linkMenuDeepening children" aria-label="Arena Opera Festival">Arena Opera Festival</a>
+																						<div class="menu-deepening bh-menuDeepening" style="display: none;">
+									<a href="/arena-opera-festival/" title="Torna al menu principale" class="back-menu bh-backMenuDeepening children" aria-label="Arena Opera Festival">Arena Opera Festival</a>
+									<ul>
+																					<li>
+																								<a href="/arena-opera-festival/" title="Home Opera Festival" aria-label="Home Opera Festival" class="">Home Opera Festival</a>
+																							</li>
+																					<li>
+																								<a href="/arena-opera-festival/spettacoli/" title="Programma" aria-label="Programma" class="">Programma</a>
+																							</li>
+																					<li>
+																								<a href="/arena-opera-festival/artisti/" title="Cast" aria-label="Cast" class="">Cast</a>
+																							</li>
+																					<li>
+																								<a href="/arena-opera-festival/calendario/" title="Calendario" aria-label="Calendario" class="">Calendario</a>
+																							</li>
+																					<li>
+																								<a href="/arena-opera-festival/biglietti/" title="Biglietti" aria-label="Biglietti" class="children">Biglietti</a>
+																									<ul style="display: none;">
+																													<li>
+																<a href="/arena-opera-festival/biglietti/" title="Tutti i biglietti" aria-label="Tutti i biglietti">Tutti i biglietti</a>
+															</li>
+																													<li>
+																<a href="/arena-opera-festival/biglietti/regala-un-biglietto/" title="Regala un biglietto" aria-label="Regala un biglietto">Regala un biglietto</a>
+															</li>
+																													<li>
+																<a href="/arena-opera-festival/biglietti/tariffe-e-settori/" title="Tariffe e settori" aria-label="Tariffe e settori">Tariffe e settori</a>
+															</li>
+																													<li>
+																<a href="/arena-opera-festival/biglietti/come-acquistare/" title="Come acquistare" aria-label="Come acquistare">Come acquistare</a>
+															</li>
+																													<li>
+																<a href="/arena-opera-festival/biglietti/persone-con-disabilita/" title="Persone con disabilità" aria-label="Persone con disabilità">Persone con disabilità</a>
+															</li>
+																													<li>
+																<a href="/arena-opera-festival/regolamento/" title="Regolamento" aria-label="Regolamento">Regolamento</a>
+															</li>
+																											</ul>
+																							</li>
+																					<li>
+																								<a href="/arena-opera-festival/biglietti/star-roof/" title="Star Roof" aria-label="Star Roof" class="">Star Roof</a>
+																							</li>
+																					<li>
+																								<a href="/arena-opera-festival/biglietti/aziende/" title="Per le aziende" aria-label="Per le aziende" class="children">Per le aziende</a>
+																									<ul style="display: none;">
+																													<li>
+																<a href="/arena-opera-festival/biglietti/aziende/" title="Aziende" aria-label="Aziende">Aziende</a>
+															</li>
+																													<li>
+																<a href="/arena-opera-festival/biglietti/esperienze/" title="Arena Experience" aria-label="Arena Experience">Arena Experience</a>
+															</li>
+																													<li>
+																<a href="/sostienici/67-colonne/" title="67 Colonne per l'Arena di Verona" aria-label="67 Colonne per l'Arena di Verona">67 Colonne per l'Arena di Verona</a>
+															</li>
+																													<li>
+																<a href="/sostienici/sponsor-partners/" title="Sponsor & Partners" aria-label="Sponsor & Partners">Sponsor & Partners</a>
+															</li>
+																											</ul>
+																							</li>
+																					<li>
+																								<a href="/arena-opera-festival/arena-per-tutti/" title="Arena per tutti" aria-label="Arena per tutti" class="">Arena per tutti</a>
+																							</li>
+																					<li>
+																								<a href="/arena-opera-festival/preparati-allopera/" title="Preparati all'opera" aria-label="Preparati all'opera" class="children">Preparati all'opera</a>
+																									<ul style="display: none;">
+																													<li>
+																<a href="/arena-opera-festival/preparati-allopera/dove-siamo/" title="Dove siamo" aria-label="Dove siamo">Dove siamo</a>
+															</li>
+																													<li>
+																<a href="/arena-opera-festival/preparati-allopera/come-arrivare/" title="Come arrivare" aria-label="Come arrivare">Come arrivare</a>
+															</li>
+																													<li>
+																<a href="/arena-opera-festival/preparati-allopera/dove-parcheggiare/" title="Dove parcheggiare" aria-label="Dove parcheggiare">Dove parcheggiare</a>
+															</li>
+																											</ul>
+																							</li>
+																					<li>
+																								<a href="/arena-opera-festival/domande-frequenti/" title="FAQs" aria-label="FAQs" class="">FAQs</a>
+																							</li>
+																			</ul>
+								</div>
+													</li>
+					
+						<li>
+							<a href="/teatro-filarmonico-verona/" title="Teatro Filarmonico" class="cta theater  bh-linkMenuDeepening children" aria-label="Teatro Filarmonico">Teatro Filarmonico</a>
+																						<div class="menu-deepening bh-menuDeepening" style="display: none;">
+									<a href="/teatro-filarmonico-verona/" title="Torna al menu principale" class="back-menu bh-backMenuDeepening children" aria-label="Teatro Filarmonico">Teatro Filarmonico</a>
+									<ul>
+																					<li>
+																								<a href="/teatro-filarmonico-verona/" title="Teatro Filarmonico" aria-label="Teatro Filarmonico" class="">Teatro Filarmonico</a>
+																							</li>
+																					<li>
+																								<a href="/teatro-filarmonico-verona/spettacoli/" title="Programma" aria-label="Programma" class="">Programma</a>
+																							</li>
+																					<li>
+																								<a href="/teatro-filarmonico-verona/biglietti/" title="Biglietti" aria-label="Biglietti" class="children">Biglietti</a>
+																									<ul style="display: none;">
+																													<li>
+																<a href="/teatro-filarmonico-verona/biglietti/" title="Tutti i biglietti" aria-label="Tutti i biglietti">Tutti i biglietti</a>
+															</li>
+																													<li>
+																<a href="/teatro-filarmonico-verona/biglietti/" title="Biglietti" aria-label="Biglietti">Biglietti</a>
+															</li>
+																													<li>
+																<a href="/teatro-filarmonico-verona/biglietti/prezzi-e-convenzioni/" title="Prezzi e Convenzioni" aria-label="Prezzi e Convenzioni">Prezzi e Convenzioni</a>
+															</li>
+																													<li>
+																<a href="/teatro-filarmonico-verona/biglietti/abbonamenti-e-carnet/" title="Abbonamenti e Carnet" aria-label="Abbonamenti e Carnet">Abbonamenti e Carnet</a>
+															</li>
+																													<li>
+																<a href="/teatro-filarmonico-verona/biglietti/regolamento/" title="Regolamento" aria-label="Regolamento">Regolamento</a>
+															</li>
+																													<li>
+																<a href="/teatro-filarmonico-verona/biglietti/persone-con-disabilita/" title="Persone con disabilità" aria-label="Persone con disabilità">Persone con disabilità</a>
+															</li>
+																											</ul>
+																							</li>
+																					<li>
+																								<a href="/teatro-filarmonico-verona/prepara-la-tua-visita/" title="Prepara la tua visita" aria-label="Prepara la tua visita" class="children">Prepara la tua visita</a>
+																									<ul style="display: none;">
+																													<li>
+																<a href="/teatro-filarmonico-verona/prepara-la-tua-visita/come-arrivare/" title="Come arrivare" aria-label="Come arrivare">Come arrivare</a>
+															</li>
+																													<li>
+																<a href="/teatro-filarmonico-verona/prepara-la-tua-visita/dove-parcheggiare/" title="Dove parcheggiare" aria-label="Dove parcheggiare">Dove parcheggiare</a>
+															</li>
+																													<li>
+																<a href="/teatro-filarmonico-verona/prepara-la-tua-visita/dove-siamo/" title="Dove siamo" aria-label="Dove siamo">Dove siamo</a>
+															</li>
+																											</ul>
+																							</li>
+																					<li>
+																								<a href="/teatro-filarmonico-verona/domande-frequenti/" title="Domande frequenti" aria-label="Domande frequenti" class="">Domande frequenti</a>
+																							</li>
+																			</ul>
+								</div>
+													</li>
+					
+						<li>
+							<a href="/fondazione-arena/" title="Fondazione Arena" class="cta  bh-linkMenuDeepening children" aria-label="Fondazione Arena">Fondazione Arena</a>
+																						<div class="menu-deepening bh-menuDeepening" style="display: none;">
+									<a href="/fondazione-arena/" title="Torna al menu principale" class="back-menu bh-backMenuDeepening children" aria-label="Fondazione Arena">Fondazione Arena</a>
+									<ul>
+																					<li>
+																								<a href="/fondazione-arena/" title="La Fondazione" aria-label="La Fondazione" class="">La Fondazione</a>
+																							</li>
+																					<li>
+																								<a href="/fondazione-arena/chi-siamo/" title="Chi siamo" aria-label="Chi siamo" class="">Chi siamo</a>
+																							</li>
+																					<li>
+																								<a href="/lavora-con-noi/" title="Lavora con noi" aria-label="Lavora con noi" class="children">Lavora con noi</a>
+																									<ul style="display: none;">
+																													<li>
+																<a href="/lavora-con-noi/ricerca-personale/" title="Ricerca personale" aria-label="Ricerca personale">Ricerca personale</a>
+															</li>
+																													<li>
+																<a href="/lavora-con-noi/gare-e-appalti/" title="Gare e appalti" aria-label="Gare e appalti">Gare e appalti</a>
+															</li>
+																											</ul>
+																							</li>
+																					<li>
+																								<a href="/sostienici/" title="Sostienici" aria-label="Sostienici" class="">Sostienici</a>
+																							</li>
+																					<li>
+																								<a href="/contattaci/" title="Contattaci" aria-label="Contattaci" class="">Contattaci</a>
+																							</li>
+																			</ul>
+								</div>
+													</li>
+					
+						<li>
+							<a href="/arena-young/" title="Passione Arena" class="cta  bh-linkMenuDeepening children" aria-label="Passione Arena">Passione Arena</a>
+																						<div class="menu-deepening bh-menuDeepening" style="display: none;">
+									<a href="/arena-young/" title="Torna al menu principale" class="back-menu bh-backMenuDeepening children" aria-label="Passione Arena">Passione Arena</a>
+									<ul>
+																					<li>
+																								<a href="/arena-young/" title="Arena Young" aria-label="Arena Young" class="">Arena Young</a>
+																							</li>
+																					<li>
+																								<a href="/teatro-filarmonico-verona/musei-in-musica/" title="Musei in musica" aria-label="Musei in musica" class="">Musei in musica</a>
+																							</li>
+																					<li>
+																								<a href="/teatro-filarmonico-verona/musica-e-cinema/" title="Musica e cinema" aria-label="Musica e cinema" class="">Musica e cinema</a>
+																							</li>
+																					<li>
+																								<a href="/teatro-filarmonico-verona/aspettando-beethoven/" title="Aspettando Beethoven" aria-label="Aspettando Beethoven" class="">Aspettando Beethoven</a>
+																							</li>
+																			</ul>
+								</div>
+													</li>
+					
+						<li>
+							<a href="/magazine/news/" title="News" class="cta  bh-linkMenuDeepening children" aria-label="News">News</a>
+																				</li>
+									</ul>
+			</nav>
+
+													<nav aria-label="headermenuservices" class="menu-link-services">
+					<h3 class="visually-hidden" id="headermenuservices">Menu Servizi</h3>
+					<ul>
+													<li>
+								<a href="/contattaci/" title="Contattaci">Contattaci</a>
+							</li>
+													<li>
+								<a href="/area-stampa/" title="Area stampa">Area stampa</a>
+							</li>
+													<li>
+								<a href="/arena-opera-festival/regolamento/" title="Regolamento">Regolamento</a>
+							</li>
+											</ul>
+				</nav>
+			
+													<nav aria-labelledby="headermenusocial" class="menu-social">
+					<h3 id="headermenusocial" title="Menu Social">Seguici su</h3>
+					<ul>
+													<li>
+								<a href="https://www.instagram.com/arenadiverona/" class="icon instagram-light " title="Instagram">Instagram</a>
+							</li>
+													<li>
+								<a href="https://www.facebook.com/arenaverona" class="icon facebook-light " title="Facebook">Facebook</a>
+							</li>
+													<li>
+								<a href="https://www.youtube.com/arenaverona" class="icon youtube-light " title="Youtube">Youtube</a>
+							</li>
+											</ul>
+				</nav>
+			
+			<nav aria-labelledby="headermenulanguagemobile" class="menu-lang">
+				<h3 class="visually-hidden" id="headermenulanguagemobile">Menu Lingua</h3>
+				<ul>
+					<li><a data-x="0"href="/calendario/"title="Italiano"aria-label="Italiano" class="it active">Italiano</a></li>
+					<li><a data-x="0"href="/de/kalender/"title="Deutsch"aria-label="Deutsch" class="de">Deutsch</a></li>
+					<li><a data-x="0"href="/en/calendar/"title="English"aria-label="English" class="en">English</a></li>
+				</ul>
+			</nav>
+		</div>
+	</div>
+
+	<div class="logo">
+													<a href="/" title="Fondazione - Arena di Verona"></a>
+	</div>
+
+
+
+			<nav aria-labelledby="headermenu" class="menu opera-teatro">
+			<h3 class="visually-hidden" id="headermenu">Menu Principale</h3>
+			<ul class="bh-menu">
+									<li>
+						<a href="/arena-opera-festival/" title="Arena Opera Festival" class="cta-opera " aria-label="Arena Opera Festival">
+							<span class="label">Arena Opera Festival</span>
+						</a>
+					</li>
+									<li>
+						<a href="/teatro-filarmonico-verona/" title="Teatro Filarmonico" class="cta-theater " aria-label="Teatro Filarmonico">
+							<span class="label">Teatro Filarmonico</span>
+						</a>
+					</li>
+							</ul>
+		</nav>
+		<nav aria-labelledby="headermenulanguage" class="menu-language bh-language">
+			<h3 class="visually-hidden" id="headermenulanguage">Menu Lingua</h3>
+			<a href="javascript:void(5);" title="Lingua it" class="link bh-sel-language" aria-label="Lingua selezionata it">it</a>
+			<div class="submenu">
+				<ul>
+					<li><a data-x="0"href="/calendario/"title="Italiano"aria-label="Italiano" class="it active">Italiano</a></li>
+					<li><a data-x="0"href="/de/kalender/"title="Deutsch"aria-label="Deutsch" class="de ">Deutsch</a></li>
+					<li><a data-x="0"href="/en/calendar/"title="English"aria-label="English" class="en ">English</a></li>
+				</ul>
+			</div>
+		</nav>
+	
+	
+									<div class="action-shop">
+			<a href="https://shop.fondazionearena.it/" title="Acquista" class="cta" target="_blank">
+				<span class="label">Acquista</span>
+							</a>
+		</div>
+				<div class="action-calendar">
+			<a href="/calendario/" title="Calendario" class="cta">
+				<span class="label">Calendario</span>
+			</a>
+		</div>
+	
+</header>
+
+		<div class="main" id="maincontent" role="main">
+			
+    
+
+
+            
+    
+	
+
+
+    <div class="panel-intro spacer-none ">
+
+	<div class="content">
+		<div class="container">
+			<div class="row gy-4">
+				<div class="col-lg-6">
+                    
+                    
+	<nav aria-label="Breadcrumb" class="breadcrumb">
+		<ol>
+							<li>
+																	Fondazione Arena di Verona
+																				</li>
+					</ol>
+	</nav>
+					<section class="title-page">
+						<header class="heading by">
+							<h2 class="title">Calendario</h2>
+						</header>
+                                                                        					</section>
+				</div>
+                			</div>
+		</div>
+	</div>
+</div>
+    
+            
+    
+	
+
+
+				        
+
+
+
+
+<div class="calendar-events bh-calendarEvents" data-start-view="CALENDAR" data-pagination-count="25">
+	<div class="bh-toolbarSticky">
+
+		<div class="toolbar bg bh-toolbar">
+			<div class="content"> 
+				<div class="container">
+					<div class="row g-0">
+						<div class="col">
+							<form action="/" method="post" class="frm">
+								<div class="toolbar filters">
+									
+										<div class="left">
+											<ul class="tabs">
+																									<li>
+														<a href="javascript:void(0);" class="cta tab icon bh-switchViewBtn" data-view="CALENDAR" title="Calendario">
+															<span class="icon calendar"></span>
+															<span class="label">Calendario</span>
+														</a>
+													</li>
+												
+																									<li>
+														<a href="javascript:void(0);" class="cta tab icon bh-switchViewBtn" data-view="LIST" title="Lista">
+															<span class="icon list"></span>
+															<span class="label">Lista</span>
+														</a>
+													</li>
+												
+												
+											</ul>
+										</div>
+									
+									<div class="right">
+										<div class="bh-filters">
+											<a href="javascript:void(0);" class="cta action-filter d-block d-xl-none bh-linkOpen" title="Filtra">
+												<span class="icon filter">Filtra</span>
+											</a>
+											<div class="ctn-filters bh-ctnFilters ">
+												<div class="txt big bold primary spacer-bottom-3">
+													<p>Filtra</p>
+												</div>
+												<a href="javascript:void(0);" class="icon close bh-linkClose">Chiudi</a>
+
+												<fieldset class="search w-max bh-filter-form">
+													<legend class="visually-hidden">Cerca un artista</legend>
+													<label for="search2" class="visually-hidden">Cerca un artista</label>
+													<div class="icon search"></div>
+													<input type="text" class="bh-inputArtist" name="search2" id="search2" placeholder="Cerca un artista"/>
+													<button type="submit" class="btn secondary small visually-hidden">
+														Invia
+													</button>
+													<div class="suggestions-list bh-suggestionPanel" style="display:none">
+														<ul>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="27966" data-chip-value="Vasilisa Berzhanskaya">Vasilisa Berzhanskaya</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="124096" data-chip-value="Anna Werle">Anna Werle</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="4160" data-chip-value="Michele Pertusi">Michele Pertusi</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="67571" data-chip-value="Matteo Forla">Matteo Forla</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="67775" data-chip-value="Federico Brunello">Federico Brunello</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="26605" data-chip-value="Sara Airoldi">Sara Airoldi</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="67291" data-chip-value="Marco Venturini">Marco Venturini</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="64120" data-chip-value="Francesca Rodomonti">Francesca Rodomonti</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="67503" data-chip-value="Fabrizio Baldon">Fabrizio Baldon</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="67639" data-chip-value="Lanfranco Martinelli">Lanfranco Martinelli</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="64077" data-chip-value="Michele Spotti">Michele Spotti</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="4845" data-chip-value="Francesca Maionchi">Francesca Maionchi</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="1823" data-chip-value="Yusif Eyvazov">Yusif Eyvazov</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="4445" data-chip-value="Amartuvshin Enkhbat">Amartuvshin Enkhbat</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="4788" data-chip-value="Carlo Bosi">Carlo Bosi</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="28468" data-chip-value="Nicolò Ceriani">Nicolò Ceriani</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="27554" data-chip-value="Gëzim Myshketa">Gëzim Myshketa</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="28538" data-chip-value="Gilda Fiume">Gilda Fiume</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="84072" data-chip-value="Galeano Salas">Galeano Salas</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="27654" data-chip-value="Francesco Meli">Francesco Meli</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="4502" data-chip-value="Youngjun Park">Youngjun Park</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="64691" data-chip-value="Jan Antem">Jan Antem</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="3415" data-chip-value="Ludovic Tézier">Ludovic Tézier</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="27117" data-chip-value="Gabriele Sagona">Gabriele Sagona</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="63922" data-chip-value="René Barbera">René Barbera</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="172559" data-chip-value="Antonio Poli">Antonio Poli</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="3243" data-chip-value="Luca Salsi">Luca Salsi</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="28568" data-chip-value="Rosa Feola">Rosa Feola</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="66411" data-chip-value="Enea Scala">Enea Scala</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="28588" data-chip-value="Francesco Ivan Ciampa">Francesco Ivan Ciampa</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="39401" data-chip-value="Abramo Rosalen">Abramo Rosalen</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="3758" data-chip-value="Maria José Siri">Maria José Siri</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="64441" data-chip-value="Simon Lim">Simon Lim</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="63780" data-chip-value="Agnieszka Rehlis">Agnieszka Rehlis</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="4731" data-chip-value="Riccardo Rados">Riccardo Rados</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="4102" data-chip-value="Gregory Kunde">Gregory Kunde</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="3701" data-chip-value="Clémentine Margaine">Clémentine Margaine</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="4217" data-chip-value="Alexander Vinogradov">Alexander Vinogradov</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="27872" data-chip-value="Matteo Macchioni">Matteo Macchioni</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="26795" data-chip-value="Annalisa Stroppa">Annalisa Stroppa</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="39537" data-chip-value="Roberto Tagliavini">Roberto Tagliavini</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="144951" data-chip-value="Elisabetta Zizzo">Elisabetta Zizzo</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="149940" data-chip-value="Elena Borin">Elena Borin</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="64130" data-chip-value="Olga Maslova">Olga Maslova</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="63846" data-chip-value="Marta Torbidoni">Marta Torbidoni</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="91387" data-chip-value="Paolo Lardizzone">Paolo Lardizzone</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="28268" data-chip-value="Eleonora Buratto">Eleonora Buratto</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="39129" data-chip-value="Gianfranco Montresor">Gianfranco Montresor</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="28128" data-chip-value="Enkeleda Kamani">Enkeleda Kamani</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="28046" data-chip-value="Aleksandra Kurzak">Aleksandra Kurzak</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="26635" data-chip-value="Roberto Alagna">Roberto Alagna</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="151967" data-chip-value="Gianluca Buratto">Gianluca Buratto</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="1824" data-chip-value="Anna Netrebko">Anna Netrebko</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="27664" data-chip-value="Andrea Battistoni">Andrea Battistoni</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="3872" data-chip-value="Anna Pirozzi">Anna Pirozzi</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="28148" data-chip-value="Brian Jagde">Brian Jagde</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="5133" data-chip-value="Mariangela Sicilia">Mariangela Sicilia</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="28548" data-chip-value="Saverio Fiore">Saverio Fiore</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="27474" data-chip-value="Lisette Oropesa">Lisette Oropesa</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="123366" data-chip-value="Lise Lindström">Lise Lindström</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="64135" data-chip-value="Maria Agresta">Maria Agresta</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="64062" data-chip-value="Erin Morley">Erin Morley</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="153503" data-chip-value="Carlo Vistoli">Carlo Vistoli</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="39605" data-chip-value="Giovanni Andrea Zanon">Giovanni Andrea Zanon</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="66675" data-chip-value="Lorenzo Paini">Lorenzo Paini</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="27792" data-chip-value="Eleonora Bellocci">Eleonora Bellocci</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="28768" data-chip-value="Leonardo Cortellazzi">Leonardo Cortellazzi</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="123286" data-chip-value="Nicolò Donini">Nicolò Donini</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="26755" data-chip-value="Bianca Tognocchi">Bianca Tognocchi</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="123856" data-chip-value="Stefano Rinaldi Miliani">Stefano Rinaldi Miliani</a>
+																</li>
+																															<li>
+																	<a class="bh-filterItem" href="javascript:void(0);" data-input-type="SUGGESTION" data-type="ARTIST" data-value="67707" data-chip-value="Riccardo Mazzoni">Riccardo Mazzoni</a>
+																</li>
+																													</ul>
+													</div>
+												</fieldset>
+
+												<div class="dropdown bh-toggle bh-filter-form">
+													<a href="javascript:void(0);" class="cta action bh-linkToggle" title="Scegli il tipo di evento">
+														Tutti i tipi di evento
+													</a>
+													<div class="int">
+														<fieldset>
+															<legend class="visually-hidden">Tipo di evento</legend>
+																															<div class="wrapper-checkbox">
+																	<input class="bh-filterItemData" id="filter-gender-1" name="filter-gender-1" type="checkbox" value="2940" data-type="GENRE" data-value="2940" data-chip-value="Concerto">
+																	<label for="filter-gender-1">Concerto</label>
+																</div>
+																															<div class="wrapper-checkbox">
+																	<input class="bh-filterItemData" id="filter-gender-2" name="filter-gender-2" type="checkbox" value="173430" data-type="GENRE" data-value="173430" data-chip-value="Visita guidata">
+																	<label for="filter-gender-2">Visita guidata</label>
+																</div>
+																															<div class="wrapper-checkbox">
+																	<input class="bh-filterItemData" id="filter-gender-3" name="filter-gender-3" type="checkbox" value="31899" data-type="GENRE" data-value="31899" data-chip-value="Evento per famiglie">
+																	<label for="filter-gender-3">Evento per famiglie</label>
+																</div>
+																															<div class="wrapper-checkbox">
+																	<input class="bh-filterItemData" id="filter-gender-4" name="filter-gender-4" type="checkbox" value="31940" data-type="GENRE" data-value="31940" data-chip-value="Musica da camera">
+																	<label for="filter-gender-4">Musica da camera</label>
+																</div>
+																															<div class="wrapper-checkbox">
+																	<input class="bh-filterItemData" id="filter-gender-5" name="filter-gender-5" type="checkbox" value="1133" data-type="GENRE" data-value="1133" data-chip-value="Opera">
+																	<label for="filter-gender-5">Opera</label>
+																</div>
+																															<div class="wrapper-checkbox">
+																	<input class="bh-filterItemData" id="filter-gender-6" name="filter-gender-6" type="checkbox" value="2941" data-type="GENRE" data-value="2941" data-chip-value="Balletto">
+																	<label for="filter-gender-6">Balletto</label>
+																</div>
+																															<div class="wrapper-checkbox">
+																	<input class="bh-filterItemData" id="filter-gender-7" name="filter-gender-7" type="checkbox" value="169222" data-type="GENRE" data-value="169222" data-chip-value="Proiezione">
+																	<label for="filter-gender-7">Proiezione</label>
+																</div>
+																													</fieldset>
+														<fieldset class="d-none d-xl-block">
+															<div class="buttons-bar variant">
+																<button type="button" class="btn small secondary bh-filterItemReset" data-input-type="MULTIPLECHOISE" title="Reset">Reset</button>
+																<button type="button" class="btn small primary bh-filterItem" data-input-type="MULTIPLECHOISE" title="Applica">Applica</button>
+															</div>
+														</fieldset>
+													</div>
+												</div>
+
+																									<div class="dropdown bh-toggle bh-filter-form">
+														<a href="javascript:void(0);" class="cta action bh-linkToggle" title="Stagione">
+															Tutte le stagioni
+														</a>
+														<div class="int">
+															<fieldset>
+																<legend class="visually-hidden">Stagione</legend>
+                                                                                                                                    <div class="wrapper-checkbox">
+																		<input class="bh-filterItemData" id="filter-season-1" name="filter-season-1" type="checkbox" value="156866|129831" data-type="SEASON" data-value="156866|129831" data-chip-value="2026">
+																		<label for="filter-season-1">2026</label>
+																	</div>
+																															</fieldset>
+															<fieldset class="d-none d-xl-block">
+																<div class="buttons-bar variant">
+																	<button type="button" class="btn small secondary bh-filterItemReset" data-input-type="MULTIPLECHOISE" title="Reset">Reset</button>
+																	<button type="button" class="btn small primary bh-filterItem" data-input-type="MULTIPLECHOISE" title="Applica">Applica</button>
+																</div>
+															</fieldset>
+														</div>
+													</div>
+												
+																									<div class="dropdown bh-toggle bh-filter-form">
+														<a href="javascript:void(0);" class="cta action bh-linkToggle" title="Spettacoli">
+															Tutti gli spettacoli
+														</a>
+														<div class="int">
+															<fieldset>
+																<legend class="visually-hidden">Spettacoli</legend>
+																<div class="wrapper-checkbox">
+																	<input class="bh-filterItemData" id="filter-section-01" name="filter-section-01" type="checkbox" value="OPERA" data-type="TYPE" data-value="OPERA" data-chip-value="Arena Opera Festival">
+																	<label for="filter-section-01">Arena Opera Festival</label>
+																</div>
+																<div class="wrapper-checkbox">
+																	<input class="bh-filterItemData" id="filter-section-02" name="filter-section-02" type="checkbox" value="TEATRO" data-type="TYPE" data-value="TEATRO" data-chip-value="Teatro Filarmonico di Verona">
+																	<label for="filter-section-02">Teatro Filarmonico di Verona</label>
+																</div>
+                                                                <div class="wrapper-checkbox">
+																	<input class="bh-filterItemData" id="filter-section-03" name="filter-section-03" type="checkbox" value="PASSIONE" data-type="TYPE" data-value="PASSIONE" data-chip-value="Passione Arena">
+																	<label for="filter-section-03">Passione Arena</label>
+																</div>
+
+															</fieldset>
+															<fieldset class="d-none d-xl-block">
+																<div class="buttons-bar variant">
+																	<button type="button" class="btn small secondary bh-filterItemReset" data-input-type="MULTIPLECHOISE" title="Reset">Reset</button>
+																	<button type="button" class="btn small primary bh-filterItem" data-input-type="MULTIPLECHOISE" title="Applica">Applica</button>
+																</div>
+															</fieldset>
+														</div>
+													</div>
+												
+
+												<div class="toolbar spacer-bottom-2 d-block d-xl-none bh-chipContainer"></div>
+												<fieldset class="d-block d-xl-none">
+													<div class="buttons-bar variant">
+														<button type="button" class="btn small secondary bh-mobResetFilter" title="Reset">Reset</button>
+														<button type="button" class="btn small primary bh-mobApplyFilter" title="Applica">Applica</button>
+													</div>
+												</fieldset>
+											</div>
+										</div>
+									</div>
+									<div class="toolbar spacer-top-3 d-none d-xl-block bh-chipContainer"></div>
+								</div>
+							</form>
+						</div>
+					</div>
+				</div>
+			</div>
+
+							<div class="container full bh-view" data-view="CALENDAR" style="display:none">
+					<div class="row g-0">
+						<div class="col-xl d-none d-xl-block">
+							<header class="heading">
+								<h2 class="subtitle xsmall bh-monthCurrent">marzo 2026</h2>
+							</header>
+						</div>
+					</div>
+					<div class="row g-0">
+																									<div class="col-xl d-none d-xl-block">
+								<div class="day th">
+									<div class="number">
+										<span class="label">
+																						lunedì
+										</span>
+									</div>
+								</div>
+							</div>
+													<div class="col-xl d-none d-xl-block">
+								<div class="day th">
+									<div class="number">
+										<span class="label">
+																						martedì
+										</span>
+									</div>
+								</div>
+							</div>
+													<div class="col-xl d-none d-xl-block">
+								<div class="day th">
+									<div class="number">
+										<span class="label">
+																						mercoledì
+										</span>
+									</div>
+								</div>
+							</div>
+													<div class="col-xl d-none d-xl-block">
+								<div class="day th">
+									<div class="number">
+										<span class="label">
+																						giovedì
+										</span>
+									</div>
+								</div>
+							</div>
+													<div class="col-xl d-none d-xl-block">
+								<div class="day th">
+									<div class="number">
+										<span class="label">
+																						venerdì
+										</span>
+									</div>
+								</div>
+							</div>
+													<div class="col-xl d-none d-xl-block">
+								<div class="day th">
+									<div class="number">
+										<span class="label">
+																						sabato
+										</span>
+									</div>
+								</div>
+							</div>
+													<div class="col-xl d-none d-xl-block">
+								<div class="day th">
+									<div class="number">
+										<span class="label">
+																						domenica
+										</span>
+									</div>
+								</div>
+							</div>
+											</div>
+				</div>
+			
+		</div>
+	</div>
+
+			<div class="bh-view" data-view="CALENDAR" style="display:none">
+			<div class="container full">
+				<ul class="calendar-listing">
+																							<li>
+								<a href="javascript:void(more);" class="cta-item bh-linkControl  active" title="Cta More">
+									marzo 2026
+								</a>
+                                								<div class="int-item bh-itemContent" style="display:block">
+																																																<div class="row g-0">
+										                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-03-30">
+																											<div class="number">
+															<span class="label">lunedì</span>
+															30
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-03-31">
+																											<div class="number">
+															<span class="label">martedì</span>
+															31
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-03---">
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-03---">
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-03---">
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-03---">
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-03---">
+																									</div>
+											</div>
+																						</div>
+																																					</div>
+							</li>
+													<li>
+								<a href="javascript:void(more);" class="cta-item bh-linkControl " title="Cta More">
+									aprile 2026
+								</a>
+                                								<div class="int-item bh-itemContent">
+																																																<div class="row g-0">
+										                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-04---">
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-04---">
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-04-01">
+																											<div class="number">
+															<span class="label">mercoledì</span>
+															01
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-04-02">
+																											<div class="number">
+															<span class="label">giovedì</span>
+															02
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-04-03">
+																											<div class="number">
+															<span class="label">venerdì</span>
+															03
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="27966|124096|4160" data-filter-type="TEATRO" data-filter-genre="2940" data-filter-season="156866">
+																			                                                                                                                                                        <div class="event theater">
+																																									<div class="tag">Concerto</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/teatro-filarmonico-verona/rossini-petite-messe-solennelle/" title="Rossini Petite Messe Solennelle">
+																							Rossini Petite Messe Solennelle
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Teatro Filarmonico</span>
+																					</div>
+																																																																																			<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">19:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=13134399&amp;tcode=vt0020008" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-04-04">
+																											<div class="number">
+															<span class="label">sabato</span>
+															04
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="27966|124096|4160" data-filter-type="TEATRO" data-filter-genre="2940" data-filter-season="156866">
+																			                                                                                                                                                        <div class="event theater">
+																																									<div class="tag">Concerto</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/teatro-filarmonico-verona/rossini-petite-messe-solennelle/" title="Rossini Petite Messe Solennelle">
+																							Rossini Petite Messe Solennelle
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Teatro Filarmonico</span>
+																					</div>
+																																																																																																																												<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">17:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=13134400&amp;tcode=vt0020008" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																							</div>
+																		</li>
+																																																																																					<li class="bh-calendarShow" data-filter-artist="" data-filter-type="TEATRO" data-filter-genre="173430" data-filter-season="156866">
+																			                                                                                                                                                        <div class="event theater">
+																																									<div class="tag">Visita guidata</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/teatro-filarmonico-verona/visita-guidata-a-teatro-le-sale-della-musica/" title="Visita guidata a teatro | Le Sale della Musica">
+																							Visita guidata a teatro | Le Sale della Musica
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Teatro Filarmonico</span>
+																					</div>
+																																																																																			<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">10:30</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=prices&amp;pcode=13540410&amp;tcode=vt0020008" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																															<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">12:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=prices&amp;pcode=13563171&amp;tcode=vt0020008" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																					</div>
+																		</li>
+																																																																																					<li class="bh-calendarShow" data-filter-artist="" data-filter-type="TEATRO" data-filter-genre="173430" data-filter-season="156866">
+																			                                                                                                                                                        <div class="event theater">
+																																									<div class="tag">Visita guidata</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/teatro-filarmonico-verona/visita-guidata-a-teatro-le-sale-della-musica/" title="Visita guidata a teatro | Le Sale della Musica">
+																							Visita guidata a teatro | Le Sale della Musica
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Teatro Filarmonico</span>
+																					</div>
+																																																																																			<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">10:30</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=prices&amp;pcode=13540410&amp;tcode=vt0020008" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																															<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">12:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=prices&amp;pcode=13563171&amp;tcode=vt0020008" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																					</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-04-05">
+																											<div class="number">
+															<span class="label">domenica</span>
+															05
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																						</div>
+																																																		<div class="row g-0">
+										                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-04-06">
+																											<div class="number">
+															<span class="label">lunedì</span>
+															06
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-04-07">
+																											<div class="number">
+															<span class="label">martedì</span>
+															07
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-04-08">
+																											<div class="number">
+															<span class="label">mercoledì</span>
+															08
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-04-09">
+																											<div class="number">
+															<span class="label">giovedì</span>
+															09
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-04-10">
+																											<div class="number">
+															<span class="label">venerdì</span>
+															10
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="" data-filter-type="TEATRO" data-filter-genre="2940" data-filter-season="156866">
+																			                                                                                                                                                        <div class="event theater">
+																																									<div class="tag">Concerto</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/teatro-filarmonico-verona/berlioz-fantastique/" title="Berlioz Fantastique">
+																							Berlioz Fantastique
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Teatro Filarmonico</span>
+																					</div>
+																																																																																			<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">20:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=13134401&amp;tcode=vt0020008" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-04-11">
+																											<div class="number">
+															<span class="label">sabato</span>
+															11
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-04-12">
+																											<div class="number">
+															<span class="label">domenica</span>
+															12
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="" data-filter-type="TEATRO" data-filter-genre="2940" data-filter-season="156866">
+																			                                                                                                                                                        <div class="event theater">
+																																									<div class="tag">Concerto</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/teatro-filarmonico-verona/berlioz-fantastique/" title="Berlioz Fantastique">
+																							Berlioz Fantastique
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Teatro Filarmonico</span>
+																					</div>
+																																																																																																																												<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">17:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=13134402&amp;tcode=vt0020008" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																							</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																						</div>
+																																																		<div class="row g-0">
+										                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-04-13">
+																											<div class="number">
+															<span class="label">lunedì</span>
+															13
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-04-14">
+																											<div class="number">
+															<span class="label">martedì</span>
+															14
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-04-15">
+																											<div class="number">
+															<span class="label">mercoledì</span>
+															15
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-04-16">
+																											<div class="number">
+															<span class="label">giovedì</span>
+															16
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-04-17">
+																											<div class="number">
+															<span class="label">venerdì</span>
+															17
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="" data-filter-type="TEATRO" data-filter-genre="2940" data-filter-season="156866">
+																			                                                                                                                                                        <div class="event theater">
+																																									<div class="tag">Concerto</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/teatro-filarmonico-verona/musorgskij-quadri/" title="Musorgskij Quadri">
+																							Musorgskij Quadri
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Teatro Filarmonico</span>
+																					</div>
+																																																																																			<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">20:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=13134403&amp;tcode=vt0020008" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-04-18">
+																											<div class="number">
+															<span class="label">sabato</span>
+															18
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="" data-filter-type="TEATRO" data-filter-genre="173430" data-filter-season="156866">
+																			                                                                                                                                                        <div class="event theater">
+																																									<div class="tag">Visita guidata</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/teatro-filarmonico-verona/visita-guidata-a-teatro-le-sale-della-musica/" title="Visita guidata a teatro | Le Sale della Musica">
+																							Visita guidata a teatro | Le Sale della Musica
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Teatro Filarmonico</span>
+																					</div>
+																																																																																																																																																																					<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">10:30</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=prices&amp;pcode=13540411&amp;tcode=vt0020008" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																															<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">12:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=prices&amp;pcode=13563172&amp;tcode=vt0020008" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																			</div>
+																		</li>
+																																																																																					<li class="bh-calendarShow" data-filter-artist="" data-filter-type="TEATRO" data-filter-genre="173430" data-filter-season="156866">
+																			                                                                                                                                                        <div class="event theater">
+																																									<div class="tag">Visita guidata</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/teatro-filarmonico-verona/visita-guidata-a-teatro-le-sale-della-musica/" title="Visita guidata a teatro | Le Sale della Musica">
+																							Visita guidata a teatro | Le Sale della Musica
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Teatro Filarmonico</span>
+																					</div>
+																																																																																																																																																																					<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">10:30</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=prices&amp;pcode=13540411&amp;tcode=vt0020008" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																															<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">12:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=prices&amp;pcode=13563172&amp;tcode=vt0020008" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																			</div>
+																		</li>
+																																																																																					<li class="bh-calendarShow" data-filter-artist="" data-filter-type="TEATRO" data-filter-genre="2940" data-filter-season="156866">
+																			                                                                                                                                                        <div class="event theater">
+																																									<div class="tag">Concerto</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/teatro-filarmonico-verona/musorgskij-quadri/" title="Musorgskij Quadri">
+																							Musorgskij Quadri
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Teatro Filarmonico</span>
+																					</div>
+																																																																																																																												<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">17:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=13134404&amp;tcode=vt0020008" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																							</div>
+																		</li>
+																																																																																					<li class="bh-calendarShow" data-filter-artist="" data-filter-type="TEATRO" data-filter-genre="31899" data-filter-season="156866">
+																			                                                                                                                                                        <div class="event theater">
+																																									<div class="tag">Arena Young</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/teatro-filarmonico-verona/opera-in-giallo-pagliacci/" title="Opera in giallo | Pagliacci | Arena Young">
+																							Opera in giallo | Pagliacci | Arena Young
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Sala Filarmonica</span>
+																					</div>
+																																																																																			<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">15:30</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=13134472&amp;tcode=vt0020006" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																							</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-04-19">
+																											<div class="number">
+															<span class="label">domenica</span>
+															19
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="" data-filter-type="TEATRO" data-filter-genre="31940" data-filter-season="156866">
+																			                                                                                                                                                        <div class="event theater">
+																																									<div class="tag">Musica da camera</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/teatro-filarmonico-verona/rossini-trascrizioni-per-quartetto-di-fiati/" title="Rossini | Trascrizioni per quartetto di fiati">
+																							Rossini | Trascrizioni per quartetto di fiati
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Palazzo Maffei</span>
+																					</div>
+																																																																																			<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">11:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/it/event/rossini-trascrizioni-per-quartetto-di-fiati/291087" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																							</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																						</div>
+																																																		<div class="row g-0">
+										                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-04-20">
+																											<div class="number">
+															<span class="label">lunedì</span>
+															20
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-04-21">
+																											<div class="number">
+															<span class="label">martedì</span>
+															21
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-04-22">
+																											<div class="number">
+															<span class="label">mercoledì</span>
+															22
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-04-23">
+																											<div class="number">
+															<span class="label">giovedì</span>
+															23
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-04-24">
+																											<div class="number">
+															<span class="label">venerdì</span>
+															24
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="" data-filter-type="TEATRO" data-filter-genre="2940" data-filter-season="156866">
+																			                                                                                                                                                        <div class="event theater">
+																																									<div class="tag">Concerto</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/teatro-filarmonico-verona/mahler-9/" title="Mahler 9">
+																							Mahler 9
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Teatro Filarmonico</span>
+																					</div>
+																																																																																			<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">20:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=13134405&amp;tcode=vt0020008" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-04-25">
+																											<div class="number">
+															<span class="label">sabato</span>
+															25
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="" data-filter-type="TEATRO" data-filter-genre="2940" data-filter-season="156866">
+																			                                                                                                                                                        <div class="event theater">
+																																									<div class="tag">Concerto</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/teatro-filarmonico-verona/mahler-9/" title="Mahler 9">
+																							Mahler 9
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Teatro Filarmonico</span>
+																					</div>
+																																																																																																																												<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">17:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=13134406&amp;tcode=vt0020008" class="btn primary small full-down-sm" title="" target="_blank">
+                        <span class="label"></span>
+        </a>
+                                                                                                                                                                                																																							</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-04-26">
+																											<div class="number">
+															<span class="label">domenica</span>
+															26
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="67571|67775" data-filter-type="TEATRO" data-filter-genre="31940" data-filter-season="156866">
+																			                                                                                                                                                        <div class="event theater">
+																																									<div class="tag">Musica da camera</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/teatro-filarmonico-verona/bach-couperin-carter-sonate-e-concerti/" title="Bach, Couperin, Carter | Sonate e concerti">
+																							Bach, Couperin, Carter | Sonate e concerti
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Palazzo Maffei</span>
+																					</div>
+																																																																																			<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">11:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/it/event/bach-couperin-carter-sonate-e-concerti/291085" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																							</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																						</div>
+																																																		<div class="row g-0">
+										                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-04-27">
+																											<div class="number">
+															<span class="label">lunedì</span>
+															27
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-04-28">
+																											<div class="number">
+															<span class="label">martedì</span>
+															28
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-04-29">
+																											<div class="number">
+															<span class="label">mercoledì</span>
+															29
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-04-30">
+																											<div class="number">
+															<span class="label">giovedì</span>
+															30
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-04---">
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-04---">
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-04---">
+																									</div>
+											</div>
+																						</div>
+																																					</div>
+							</li>
+													<li>
+								<a href="javascript:void(more);" class="cta-item bh-linkControl " title="Cta More">
+									maggio 2026
+								</a>
+                                								<div class="int-item bh-itemContent">
+																																																<div class="row g-0">
+										                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-05---">
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-05---">
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-05---">
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-05---">
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-05-01">
+																											<div class="number">
+															<span class="label">venerdì</span>
+															01
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-05-02">
+																											<div class="number">
+															<span class="label">sabato</span>
+															02
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-05-03">
+																											<div class="number">
+															<span class="label">domenica</span>
+															03
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="26605" data-filter-type="TEATRO" data-filter-genre="31940" data-filter-season="156866">
+																			                                                                                                                                                        <div class="event theater">
+																																									<div class="tag">Musica da camera</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/teatro-filarmonico-verona/brahms-sestetti/" title="Brahms | Sestetti">
+																							Brahms | Sestetti
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Biblioteca Capitolare</span>
+																					</div>
+																																																																																			<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">11:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/it/event/brahms-sestetti/291082" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																							</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																						</div>
+																																																		<div class="row g-0">
+										                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-05-04">
+																											<div class="number">
+															<span class="label">lunedì</span>
+															04
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-05-05">
+																											<div class="number">
+															<span class="label">martedì</span>
+															05
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-05-06">
+																											<div class="number">
+															<span class="label">mercoledì</span>
+															06
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-05-07">
+																											<div class="number">
+															<span class="label">giovedì</span>
+															07
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-05-08">
+																											<div class="number">
+															<span class="label">venerdì</span>
+															08
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="" data-filter-type="TEATRO" data-filter-genre="2940" data-filter-season="156866">
+																			                                                                                                                                                        <div class="event theater">
+																																									<div class="tag">Concerto</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/teatro-filarmonico-verona/beethoven-missa-solemnis/" title="Beethoven Missa Solemnis">
+																							Beethoven Missa Solemnis
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Teatro Filarmonico</span>
+																					</div>
+																																																																																			<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">20:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=13134407&amp;tcode=vt0020008" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-05-09">
+																											<div class="number">
+															<span class="label">sabato</span>
+															09
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="" data-filter-type="TEATRO" data-filter-genre="2940" data-filter-season="156866">
+																			                                                                                                                                                        <div class="event theater">
+																																									<div class="tag">Concerto</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/teatro-filarmonico-verona/beethoven-missa-solemnis/" title="Beethoven Missa Solemnis">
+																							Beethoven Missa Solemnis
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Teatro Filarmonico</span>
+																					</div>
+																																																																																																																												<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">17:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=13134408&amp;tcode=vt0020008" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																							</div>
+																		</li>
+																																																																																					<li class="bh-calendarShow" data-filter-artist="" data-filter-type="OPERA" data-filter-genre="1133" data-filter-season="129831">
+																			                                                                                                                                                        <div class="event opera">
+																																									<div class="tag">Opera</div>
+																																									<div class="tag">2026</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/arena-opera-festival/turandot-enigmi-al-museo/" title="Turandot | Enigmi al museo">
+																							Turandot | Enigmi al museo
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Arena di Verona</span>
+																					</div>
+																																																																																			<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">17:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.arena.it/it/event/turandot-enigmi-al-museo/292749" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																							</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-05-10">
+																											<div class="number">
+															<span class="label">domenica</span>
+															10
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="67291" data-filter-type="TEATRO" data-filter-genre="31940" data-filter-season="156866">
+																			                                                                                                                                                        <div class="event theater">
+																																									<div class="tag">Musica da camera</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/teatro-filarmonico-verona/haydn-schubert-beethoven-trii-per-archi/" title="Haydn, Schubert, Beethoven | Trii per archi">
+																							Haydn, Schubert, Beethoven | Trii per archi
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Palazzo Maffei</span>
+																					</div>
+																																																																																			<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">11:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/it/event/haydn-schubert-beethoven-trii-per-archi/291086" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																							</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																						</div>
+																																																		<div class="row g-0">
+										                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-05-11">
+																											<div class="number">
+															<span class="label">lunedì</span>
+															11
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-05-12">
+																											<div class="number">
+															<span class="label">martedì</span>
+															12
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-05-13">
+																											<div class="number">
+															<span class="label">mercoledì</span>
+															13
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-05-14">
+																											<div class="number">
+															<span class="label">giovedì</span>
+															14
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-05-15">
+																											<div class="number">
+															<span class="label">venerdì</span>
+															15
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="" data-filter-type="TEATRO" data-filter-genre="2940" data-filter-season="156866">
+																			                                                                                                                                                        <div class="event theater">
+																																									<div class="tag">Concerto</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/teatro-filarmonico-verona/dvorak-nuovo-mondo/" title="Dvořák Nuovo Mondo">
+																							Dvořák Nuovo Mondo
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Teatro Filarmonico</span>
+																					</div>
+																																																																																			<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">20:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=13134409&amp;tcode=vt0020008" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-05-16">
+																											<div class="number">
+															<span class="label">sabato</span>
+															16
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="" data-filter-type="TEATRO" data-filter-genre="173430" data-filter-season="156866">
+																			                                                                                                                                                        <div class="event theater">
+																																									<div class="tag">Visita guidata</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/teatro-filarmonico-verona/visita-guidata-a-teatro-le-sale-della-musica/" title="Visita guidata a teatro | Le Sale della Musica">
+																							Visita guidata a teatro | Le Sale della Musica
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Teatro Filarmonico</span>
+																					</div>
+																																																																																																																																																																																																																																																							<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">10:30</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=prices&amp;pcode=13540413&amp;tcode=vt0020008" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																															<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">12:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=prices&amp;pcode=13540412&amp;tcode=vt0020008" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																																																																																																																																																																																																																																																																																																																																																																																																	</div>
+																		</li>
+																																																																																					<li class="bh-calendarShow" data-filter-artist="" data-filter-type="TEATRO" data-filter-genre="173430" data-filter-season="156866">
+																			                                                                                                                                                        <div class="event theater">
+																																									<div class="tag">Visita guidata</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/teatro-filarmonico-verona/visita-guidata-a-teatro-le-sale-della-musica/" title="Visita guidata a teatro | Le Sale della Musica">
+																							Visita guidata a teatro | Le Sale della Musica
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Teatro Filarmonico</span>
+																					</div>
+																																																																																																																																																																																																																																																							<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">10:30</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=prices&amp;pcode=13540413&amp;tcode=vt0020008" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																															<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">12:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=prices&amp;pcode=13540412&amp;tcode=vt0020008" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																																																																																																																																																																																																																																																																																																																																																																																																	</div>
+																		</li>
+																																																																																					<li class="bh-calendarShow" data-filter-artist="" data-filter-type="TEATRO" data-filter-genre="2940" data-filter-season="156866">
+																			                                                                                                                                                        <div class="event theater">
+																																									<div class="tag">Concerto</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/teatro-filarmonico-verona/dvorak-nuovo-mondo/" title="Dvořák Nuovo Mondo">
+																							Dvořák Nuovo Mondo
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Teatro Filarmonico</span>
+																					</div>
+																																																																																																																												<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">17:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=13134410&amp;tcode=vt0020008" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																							</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-05-17">
+																											<div class="number">
+															<span class="label">domenica</span>
+															17
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="64120|67503|67639" data-filter-type="TEATRO" data-filter-genre="31940" data-filter-season="156866">
+																			                                                                                                                                                        <div class="event theater">
+																																									<div class="tag">Musica da camera</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/teatro-filarmonico-verona/mozart-beethoven-brani-per-ottetto-di-fiati/" title="Mozart, Beethoven | Brani per ottetto di fiati">
+																							Mozart, Beethoven | Brani per ottetto di fiati
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Circolo Unificato dell’Esercito</span>
+																					</div>
+																																																																																			<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">11:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/it/event/mozart-rossini-beethoven-brani-per-ottetto-di-fiati/291090" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																							</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																						</div>
+																																																		<div class="row g-0">
+										                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-05-18">
+																											<div class="number">
+															<span class="label">lunedì</span>
+															18
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-05-19">
+																											<div class="number">
+															<span class="label">martedì</span>
+															19
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-05-20">
+																											<div class="number">
+															<span class="label">mercoledì</span>
+															20
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-05-21">
+																											<div class="number">
+															<span class="label">giovedì</span>
+															21
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-05-22">
+																											<div class="number">
+															<span class="label">venerdì</span>
+															22
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="" data-filter-type="TEATRO" data-filter-genre="2940" data-filter-season="156866">
+																			                                                                                                                                                        <div class="event theater">
+																																									<div class="tag">Concerto</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/teatro-filarmonico-verona/grieg-concerto/" title="Grieg Concerto">
+																							Grieg Concerto
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Teatro Filarmonico</span>
+																					</div>
+																																																																																			<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">20:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=13134411&amp;tcode=vt0020008" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-05-23">
+																											<div class="number">
+															<span class="label">sabato</span>
+															23
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="" data-filter-type="TEATRO" data-filter-genre="2940" data-filter-season="156866">
+																			                                                                                                                                                        <div class="event theater">
+																																									<div class="tag">Concerto</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/teatro-filarmonico-verona/grieg-concerto/" title="Grieg Concerto">
+																							Grieg Concerto
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Teatro Filarmonico</span>
+																					</div>
+																																																																																																																												<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">17:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=13134412&amp;tcode=vt0020008" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																							</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-05-24">
+																											<div class="number">
+															<span class="label">domenica</span>
+															24
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																						</div>
+																																																		<div class="row g-0">
+										                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-05-25">
+																											<div class="number">
+															<span class="label">lunedì</span>
+															25
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-05-26">
+																											<div class="number">
+															<span class="label">martedì</span>
+															26
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-05-27">
+																											<div class="number">
+															<span class="label">mercoledì</span>
+															27
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-05-28">
+																											<div class="number">
+															<span class="label">giovedì</span>
+															28
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-05-29">
+																											<div class="number">
+															<span class="label">venerdì</span>
+															29
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-05-30">
+																											<div class="number">
+															<span class="label">sabato</span>
+															30
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-05-31">
+																											<div class="number">
+															<span class="label">domenica</span>
+															31
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																						</div>
+																																					</div>
+							</li>
+													<li>
+								<a href="javascript:void(more);" class="cta-item bh-linkControl " title="Cta More">
+									giugno 2026
+								</a>
+                                								<div class="int-item bh-itemContent">
+																																																<div class="row g-0">
+										                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-06-01">
+																											<div class="number">
+															<span class="label">lunedì</span>
+															01
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-06-02">
+																											<div class="number">
+															<span class="label">martedì</span>
+															02
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-06-03">
+																											<div class="number">
+															<span class="label">mercoledì</span>
+															03
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-06-04">
+																											<div class="number">
+															<span class="label">giovedì</span>
+															04
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-06-05">
+																											<div class="number">
+															<span class="label">venerdì</span>
+															05
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-06-06">
+																											<div class="number">
+															<span class="label">sabato</span>
+															06
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-06-07">
+																											<div class="number">
+															<span class="label">domenica</span>
+															07
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																						</div>
+																																																		<div class="row g-0">
+										                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-06-08">
+																											<div class="number">
+															<span class="label">lunedì</span>
+															08
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-06-09">
+																											<div class="number">
+															<span class="label">martedì</span>
+															09
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-06-10">
+																											<div class="number">
+															<span class="label">mercoledì</span>
+															10
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-06-11">
+																											<div class="number">
+															<span class="label">giovedì</span>
+															11
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-06-12">
+																											<div class="number">
+															<span class="label">venerdì</span>
+															12
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="64077|124096|4845|1823|4445|4788|28468|27554" data-filter-type="OPERA" data-filter-genre="1133" data-filter-season="129831">
+																			                                                                                                                                                        <div class="event opera">
+																																									<div class="tag">Opera</div>
+																																									<div class="tag">2026</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/arena-opera-festival/la-traviata/" title="La Traviata">
+																							La Traviata
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Arena di Verona</span>
+																					</div>
+																																																																																			<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">21:30</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=12730651&amp;tcode=vt0017687" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																			</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-06-13">
+																											<div class="number">
+															<span class="label">sabato</span>
+															13
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="64077|28538|124096|4845|84072|4445|4788|28468|27554" data-filter-type="OPERA" data-filter-genre="1133" data-filter-season="129831">
+																			                                                                                                                                                        <div class="event opera">
+																																									<div class="tag">Opera</div>
+																																									<div class="tag">2026</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/arena-opera-festival/la-traviata/" title="La Traviata">
+																							La Traviata
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Arena di Verona</span>
+																					</div>
+																																																																																																																												<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">21:30</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=12730652&amp;tcode=vt0017687" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																										</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-06-14">
+																											<div class="number">
+															<span class="label">domenica</span>
+															14
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																						</div>
+																																																		<div class="row g-0">
+										                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-06-15">
+																											<div class="number">
+															<span class="label">lunedì</span>
+															15
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-06-16">
+																											<div class="number">
+															<span class="label">martedì</span>
+															16
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-06-17">
+																											<div class="number">
+															<span class="label">mercoledì</span>
+															17
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-06-18">
+																											<div class="number">
+															<span class="label">giovedì</span>
+															18
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-06-19">
+																											<div class="number">
+															<span class="label">venerdì</span>
+															19
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="39401|3758|1823|4445|64441|4788|4845" data-filter-type="OPERA" data-filter-genre="1133" data-filter-season="129831">
+																			                                                                                                                                                        <div class="event opera">
+																																									<div class="tag">Opera</div>
+																																									<div class="tag">2026</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/arena-opera-festival/aida-2023/" title="Aida Ed. Stefano Poda">
+																							Aida Ed. Stefano Poda
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Arena di Verona</span>
+																					</div>
+																																																																																			<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">21:15</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=12730633&amp;tcode=vt0017687" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																																																																																																																																																																																				</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-06-20">
+																											<div class="number">
+															<span class="label">sabato</span>
+															20
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="64077|124096|4845|1823|4788|28468|27554" data-filter-type="OPERA" data-filter-genre="1133" data-filter-season="129831">
+																			                                                                                                                                                        <div class="event opera">
+																																									<div class="tag">Opera</div>
+																																									<div class="tag">2026</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/arena-opera-festival/la-traviata/" title="La Traviata">
+																							La Traviata
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Arena di Verona</span>
+																					</div>
+																																																																																																																																																																					<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">21:15</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=12730653&amp;tcode=vt0017687" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																																																																																																																																																																																																																																																																																																																																																																																																	</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-06-21">
+																											<div class="number">
+															<span class="label">domenica</span>
+															21
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																						</div>
+																																																		<div class="row g-0">
+										                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-06-22">
+																											<div class="number">
+															<span class="label">lunedì</span>
+															22
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-06-23">
+																											<div class="number">
+															<span class="label">martedì</span>
+															23
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-06-24">
+																											<div class="number">
+															<span class="label">mercoledì</span>
+															24
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-06-25">
+																											<div class="number">
+															<span class="label">giovedì</span>
+															25
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="39401|63780|1823|4502|64441|4731|4845" data-filter-type="OPERA" data-filter-genre="1133" data-filter-season="129831">
+																			                                                                                                                                                        <div class="event opera">
+																																									<div class="tag">Opera</div>
+																																									<div class="tag">2026</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/arena-opera-festival/aida-2023/" title="Aida Ed. Stefano Poda">
+																							Aida Ed. Stefano Poda
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Arena di Verona</span>
+																					</div>
+																																																																																																																												<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">21:15</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=12730634&amp;tcode=vt0017687" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																																																																																																																																											</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-06-26">
+																											<div class="number">
+															<span class="label">venerdì</span>
+															26
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="64077|4445|3758|26795|39537|84072|28468|4788|144951" data-filter-type="OPERA" data-filter-genre="1133" data-filter-season="129831">
+																			                                                                                                                                                        <div class="event opera">
+																																									<div class="tag">Opera</div>
+																																									<div class="tag">2026</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/arena-opera-festival/nabucco/" title="Nabucco">
+																							Nabucco
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Arena di Verona</span>
+																					</div>
+																																																																																			<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">21:15</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=12730664&amp;tcode=vt0017687" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																																																																																																																																																																																																																																																																																																																																																								</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-06-27">
+																											<div class="number">
+															<span class="label">sabato</span>
+															27
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="64077|28538|124096|4845|84072|4788|28468|27554" data-filter-type="OPERA" data-filter-genre="1133" data-filter-season="129831">
+																			                                                                                                                                                        <div class="event opera">
+																																									<div class="tag">Opera</div>
+																																									<div class="tag">2026</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/arena-opera-festival/la-traviata/" title="La Traviata">
+																							La Traviata
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Arena di Verona</span>
+																					</div>
+																																																																																																																																																																																																														<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">21:15</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=12730654&amp;tcode=vt0017687" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																																																																																																																																																																																																																																																																																																																																																								</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-06-28">
+																											<div class="number">
+															<span class="label">domenica</span>
+															28
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																						</div>
+																																																		<div class="row g-0">
+										                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-06-29">
+																											<div class="number">
+															<span class="label">lunedì</span>
+															29
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-06-30">
+																											<div class="number">
+															<span class="label">martedì</span>
+															30
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-06---">
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-06---">
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-06---">
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-06---">
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-06---">
+																									</div>
+											</div>
+																						</div>
+																																					</div>
+							</li>
+													<li>
+								<a href="javascript:void(more);" class="cta-item bh-linkControl " title="Cta More">
+									luglio 2026
+								</a>
+                                								<div class="int-item bh-itemContent">
+																																																<div class="row g-0">
+										                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-07---">
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-07---">
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-07-01">
+																											<div class="number">
+															<span class="label">mercoledì</span>
+															01
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-07-02">
+																											<div class="number">
+															<span class="label">giovedì</span>
+															02
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="39401|63780|3758|4102|4445|64441|4788|4845" data-filter-type="OPERA" data-filter-genre="1133" data-filter-season="129831">
+																			                                                                                                                                                        <div class="event opera">
+																																									<div class="tag">Opera</div>
+																																									<div class="tag">2026</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/arena-opera-festival/aida-2023/" title="Aida Ed. Stefano Poda">
+																							Aida Ed. Stefano Poda
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Arena di Verona</span>
+																					</div>
+																																																																																																																																																																					<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">21:15</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=12730635&amp;tcode=vt0017687" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																																																																																																		</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-07-03">
+																											<div class="number">
+															<span class="label">venerdì</span>
+															03
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="28268|1823|64691|28468|39129|4788" data-filter-type="OPERA" data-filter-genre="1133" data-filter-season="129831">
+																			                                                                                                                                                        <div class="event opera">
+																																									<div class="tag">Opera</div>
+																																									<div class="tag">2026</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/arena-opera-festival/la-boheme/" title="La Bohème">
+																							La Bohème
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Arena di Verona</span>
+																					</div>
+																																																																																			<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">21:15</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=12730647&amp;tcode=vt0017687" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																																																																																																		</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-07-04">
+																											<div class="number">
+															<span class="label">sabato</span>
+															04
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="64077|4445|3758|26795|64441|84072|28468|4731|144951" data-filter-type="OPERA" data-filter-genre="1133" data-filter-season="129831">
+																			                                                                                                                                                        <div class="event opera">
+																																									<div class="tag">Opera</div>
+																																									<div class="tag">2026</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/arena-opera-festival/nabucco/" title="Nabucco">
+																							Nabucco
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Arena di Verona</span>
+																					</div>
+																																																																																																																												<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">21:15</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=12730665&amp;tcode=vt0017687" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																																																																																																																																																																																																																																																																																																															</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-07-05">
+																											<div class="number">
+															<span class="label">domenica</span>
+															05
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="64077|4845|27654|4502|4788|28468|64691" data-filter-type="OPERA" data-filter-genre="1133" data-filter-season="129831">
+																			                                                                                                                                                        <div class="event opera">
+																																									<div class="tag">Opera</div>
+																																									<div class="tag">2026</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/arena-opera-festival/la-traviata/" title="La Traviata">
+																							La Traviata
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Arena di Verona</span>
+																					</div>
+																																																																																																																																																																																																																																																							<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">21:15</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=12730655&amp;tcode=vt0017687" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																																																																																																																																																																																																																																																																																																															</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																						</div>
+																																																		<div class="row g-0">
+										                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-07-06">
+																											<div class="number">
+															<span class="label">lunedì</span>
+															06
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-07-07">
+																											<div class="number">
+															<span class="label">martedì</span>
+															07
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-07-08">
+																											<div class="number">
+															<span class="label">mercoledì</span>
+															08
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-07-09">
+																											<div class="number">
+															<span class="label">giovedì</span>
+															09
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="64077|4845|27654|3415|4788|28468|64691|27117" data-filter-type="OPERA" data-filter-genre="1133" data-filter-season="129831">
+																			                                                                                                                                                        <div class="event opera">
+																																									<div class="tag">Opera</div>
+																																									<div class="tag">2026</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/arena-opera-festival/la-traviata/" title="La Traviata">
+																							La Traviata
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Arena di Verona</span>
+																					</div>
+																																																																																																																																																																																																																																																																																																<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">21:15</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=12730656&amp;tcode=vt0017687" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																																																																																																																																																																																																																																																																						</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-07-10">
+																											<div class="number">
+															<span class="label">venerdì</span>
+															10
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="39401|3758|4102|4445|64441|4731|4845" data-filter-type="OPERA" data-filter-genre="1133" data-filter-season="129831">
+																			                                                                                                                                                        <div class="event opera">
+																																									<div class="tag">Opera</div>
+																																									<div class="tag">2026</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/arena-opera-festival/aida-2023/" title="Aida Ed. Stefano Poda">
+																							Aida Ed. Stefano Poda
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Arena di Verona</span>
+																					</div>
+																																																																																																																																																																																																														<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">21:15</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=12730636&amp;tcode=vt0017687" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																																																									</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-07-11">
+																											<div class="number">
+															<span class="label">sabato</span>
+															11
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="28268|1823|64691|28468|39129|4788" data-filter-type="OPERA" data-filter-genre="1133" data-filter-season="129831">
+																			                                                                                                                                                        <div class="event opera">
+																																									<div class="tag">Opera</div>
+																																									<div class="tag">2026</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/arena-opera-festival/la-boheme/" title="La Bohème">
+																							La Bohème
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Arena di Verona</span>
+																					</div>
+																																																																																																																												<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">21:15</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=12730648&amp;tcode=vt0017687" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																																																									</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-07-12">
+																											<div class="number">
+															<span class="label">domenica</span>
+															12
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="64077|3415|3758|124096|64441|84072|28468|4731|149940" data-filter-type="OPERA" data-filter-genre="1133" data-filter-season="129831">
+																			                                                                                                                                                        <div class="event opera">
+																																									<div class="tag">Opera</div>
+																																									<div class="tag">2026</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/arena-opera-festival/nabucco/" title="Nabucco">
+																							Nabucco
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Arena di Verona</span>
+																					</div>
+																																																																																																																																																																					<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">21:15</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=12730666&amp;tcode=vt0017687" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																																																																																																																																																																																																																																																																						</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																						</div>
+																																																		<div class="row g-0">
+										                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-07-13">
+																											<div class="number">
+															<span class="label">lunedì</span>
+															13
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-07-14">
+																											<div class="number">
+															<span class="label">martedì</span>
+															14
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-07-15">
+																											<div class="number">
+															<span class="label">mercoledì</span>
+															15
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-07-16">
+																											<div class="number">
+															<span class="label">giovedì</span>
+															16
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="64077|27966|4845|63922|4502|4788|28468|64691|27117" data-filter-type="OPERA" data-filter-genre="1133" data-filter-season="129831">
+																			                                                                                                                                                        <div class="event opera">
+																																									<div class="tag">Opera</div>
+																																									<div class="tag">2026</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/arena-opera-festival/la-traviata/" title="La Traviata">
+																							La Traviata
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Arena di Verona</span>
+																					</div>
+																																																																																																																																																																																																																																																																																																																																									<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">21:15</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=12730657&amp;tcode=vt0017687" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																																																																																																																																																																																																																													</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-07-17">
+																											<div class="number">
+															<span class="label">venerdì</span>
+															17
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="28128|1823|64691|28468|39129|27872" data-filter-type="OPERA" data-filter-genre="1133" data-filter-season="129831">
+																			                                                                                                                                                        <div class="event opera">
+																																									<div class="tag">Opera</div>
+																																									<div class="tag">2026</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/arena-opera-festival/la-boheme/" title="La Bohème">
+																							La Bohème
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Arena di Verona</span>
+																					</div>
+																																																																																																																																																																					<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">21:15</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=12730649&amp;tcode=vt0017687" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-07-18">
+																											<div class="number">
+															<span class="label">sabato</span>
+															18
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="64077|4502|3758|26795|4217|27654|27117|4731|144951" data-filter-type="OPERA" data-filter-genre="1133" data-filter-season="129831">
+																			                                                                                                                                                        <div class="event opera">
+																																									<div class="tag">Opera</div>
+																																									<div class="tag">2026</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/arena-opera-festival/nabucco/" title="Nabucco">
+																							Nabucco
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Arena di Verona</span>
+																					</div>
+																																																																																																																																																																																																														<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">21:15</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=12730667&amp;tcode=vt0017687" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																																																																																																																																																																																																																													</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-07-19">
+																											<div class="number">
+															<span class="label">domenica</span>
+															19
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="64441|3701|1823|4502|4217|27872|4845" data-filter-type="OPERA" data-filter-genre="1133" data-filter-season="129831">
+																			                                                                                                                                                        <div class="event opera">
+																																									<div class="tag">Opera</div>
+																																									<div class="tag">2026</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/arena-opera-festival/aida-2023/" title="Aida Ed. Stefano Poda">
+																							Aida Ed. Stefano Poda
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Arena di Verona</span>
+																					</div>
+																																																																																																																																																																																																																																																							<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">21:15</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=12730637&amp;tcode=vt0017687" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																						</div>
+																																																		<div class="row g-0">
+										                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-07-20">
+																											<div class="number">
+															<span class="label">lunedì</span>
+															20
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-07-21">
+																											<div class="number">
+															<span class="label">martedì</span>
+															21
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="" data-filter-type="OPERA" data-filter-genre="2941" data-filter-season="129831">
+																			                                                                                                                                                        <div class="event opera">
+																																									<div class="tag">Balletto</div>
+																																									<div class="tag">2026</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/arena-opera-festival/roberto-bolle-and-friends/" title="Roberto Bolle and Friends">
+																							Roberto Bolle and Friends
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Arena di Verona</span>
+																					</div>
+																																																																																			<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">21:30</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=12730674&amp;tcode=vt0017687" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																							</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-07-22">
+																											<div class="number">
+															<span class="label">mercoledì</span>
+															22
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-07-23">
+																											<div class="number">
+															<span class="label">giovedì</span>
+															23
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="64077|4502|64130|124096|27654|27117|4788|149940" data-filter-type="OPERA" data-filter-genre="1133" data-filter-season="129831">
+																			                                                                                                                                                        <div class="event opera">
+																																									<div class="tag">Opera</div>
+																																									<div class="tag">2026</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/arena-opera-festival/nabucco/" title="Nabucco">
+																							Nabucco
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Arena di Verona</span>
+																					</div>
+																																																																																																																																																																																																																																																							<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">21:15</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=12730668&amp;tcode=vt0017687" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																																																																																																																																																																																				</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-07-24">
+																											<div class="number">
+															<span class="label">venerdì</span>
+															24
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="64441|3701|3758|1823|4502|4217|27872|4845" data-filter-type="OPERA" data-filter-genre="1133" data-filter-season="129831">
+																			                                                                                                                                                        <div class="event opera">
+																																									<div class="tag">Opera</div>
+																																									<div class="tag">2026</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/arena-opera-festival/aida-2023/" title="Aida Ed. Stefano Poda">
+																							Aida Ed. Stefano Poda
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Arena di Verona</span>
+																					</div>
+																																																																																																																																																																																																																																																																																																<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">21:15</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=12730638&amp;tcode=vt0017687" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																							</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-07-25">
+																											<div class="number">
+															<span class="label">sabato</span>
+															25
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="28128|64691|28468|39129|27872" data-filter-type="OPERA" data-filter-genre="1133" data-filter-season="129831">
+																			                                                                                                                                                        <div class="event opera">
+																																									<div class="tag">Opera</div>
+																																									<div class="tag">2026</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/arena-opera-festival/la-boheme/" title="La Bohème">
+																							La Bohème
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Arena di Verona</span>
+																					</div>
+																																																																																																																																																																																																														<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">21:15</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=12730650&amp;tcode=vt0017687" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																							</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-07-26">
+																											<div class="number">
+															<span class="label">domenica</span>
+															26
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																						</div>
+																																																		<div class="row g-0">
+										                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-07-27">
+																											<div class="number">
+															<span class="label">lunedì</span>
+															27
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-07-28">
+																											<div class="number">
+															<span class="label">martedì</span>
+															28
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-07-29">
+																											<div class="number">
+															<span class="label">mercoledì</span>
+															29
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-07-30">
+																											<div class="number">
+															<span class="label">giovedì</span>
+															30
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="39401|3701|28046|4502|4217|4788|4845" data-filter-type="OPERA" data-filter-genre="1133" data-filter-season="129831">
+																			                                                                                                                                                        <div class="event opera">
+																																									<div class="tag">Opera</div>
+																																									<div class="tag">2026</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/arena-opera-festival/aida/" title="Aida Ed. Franco Zeffirelli">
+																							Aida Ed. Franco Zeffirelli
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Arena di Verona</span>
+																					</div>
+																																																																																			<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">21:15</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=12730639&amp;tcode=vt0017687" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																																																																																																																																																																																																																													</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-07-31">
+																											<div class="number">
+															<span class="label">venerdì</span>
+															31
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="64077|27966|124096|4845|172559|3243|4788|28468|64691|27117" data-filter-type="OPERA" data-filter-genre="1133" data-filter-season="129831">
+																			                                                                                                                                                        <div class="event opera">
+																																									<div class="tag">Opera</div>
+																																									<div class="tag">2026</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/arena-opera-festival/la-traviata/" title="La Traviata">
+																							La Traviata
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Arena di Verona</span>
+																					</div>
+																																																																																																																																																																																																																																																																																																																																																																																		<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">21:15</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=12730658&amp;tcode=vt0017687" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																																																																																																																																																																																				</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-07---">
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-07---">
+																									</div>
+											</div>
+																						</div>
+																																					</div>
+							</li>
+													<li>
+								<a href="javascript:void(more);" class="cta-item bh-linkControl " title="Cta More">
+									agosto 2026
+								</a>
+                                								<div class="int-item bh-itemContent">
+																																																<div class="row g-0">
+										                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-08---">
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-08---">
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-08---">
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-08---">
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-08---">
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-08-01">
+																											<div class="number">
+															<span class="label">sabato</span>
+															01
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="64077|3243|3758|124096|39537|27654|27117|27872|144951" data-filter-type="OPERA" data-filter-genre="1133" data-filter-season="129831">
+																			                                                                                                                                                        <div class="event opera">
+																																									<div class="tag">Opera</div>
+																																									<div class="tag">2026</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/arena-opera-festival/nabucco/" title="Nabucco">
+																							Nabucco
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Arena di Verona</span>
+																					</div>
+																																																																																																																																																																																																																																																																																																<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">21:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=12730669&amp;tcode=vt0017687" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																																																																																																																																											</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-08-02">
+																											<div class="number">
+															<span class="label">domenica</span>
+															02
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																						</div>
+																																																		<div class="row g-0">
+										                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-08-03">
+																											<div class="number">
+															<span class="label">lunedì</span>
+															03
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-08-04">
+																											<div class="number">
+															<span class="label">martedì</span>
+															04
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-08-05">
+																											<div class="number">
+															<span class="label">mercoledì</span>
+															05
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-08-06">
+																											<div class="number">
+															<span class="label">giovedì</span>
+															06
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="64077|28568|124096|4845|66411|3243|4788|28468|64691" data-filter-type="OPERA" data-filter-genre="1133" data-filter-season="129831">
+																			                                                                                                                                                        <div class="event opera">
+																																									<div class="tag">Opera</div>
+																																									<div class="tag">2026</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/arena-opera-festival/la-traviata/" title="La Traviata">
+																							La Traviata
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Arena di Verona</span>
+																					</div>
+																																																																																																																																																																																																																																																																																																																																																																																																																											<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">21:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=12730659&amp;tcode=vt0017687" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																																																																																																																																											</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-08-07">
+																											<div class="number">
+															<span class="label">venerdì</span>
+															07
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="27664|4788|3872|39537|28148|5133|27554|27872|28548" data-filter-type="OPERA" data-filter-genre="1133" data-filter-season="129831">
+																			                                                                                                                                                        <div class="event opera">
+																																									<div class="tag">Opera</div>
+																																									<div class="tag">2026</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/arena-opera-festival/turandot/" title="Turandot">
+																							Turandot
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Arena di Verona</span>
+																					</div>
+																																																																																			<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">21:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=12730675&amp;tcode=vt0017687" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																																																																																																																																																																																				</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-08-08">
+																											<div class="number">
+															<span class="label">sabato</span>
+															08
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="4502|63846|124096|4217|27654|27117|27872|144951" data-filter-type="OPERA" data-filter-genre="1133" data-filter-season="129831">
+																			                                                                                                                                                        <div class="event opera">
+																																									<div class="tag">Opera</div>
+																																									<div class="tag">2026</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/arena-opera-festival/nabucco/" title="Nabucco">
+																							Nabucco
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Arena di Verona</span>
+																					</div>
+																																																																																																																																																																																																																																																																																																																																									<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">21:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=12730670&amp;tcode=vt0017687" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																																																																																																		</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-08-09">
+																											<div class="number">
+															<span class="label">domenica</span>
+															09
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="64441|3701|28046|26635|4502|4217|4731|4845" data-filter-type="OPERA" data-filter-genre="1133" data-filter-season="129831">
+																			                                                                                                                                                        <div class="event opera">
+																																									<div class="tag">Opera</div>
+																																									<div class="tag">2026</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/arena-opera-festival/aida/" title="Aida Ed. Franco Zeffirelli">
+																							Aida Ed. Franco Zeffirelli
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Arena di Verona</span>
+																					</div>
+																																																																																																																												<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">21:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=12730640&amp;tcode=vt0017687" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																																																																																																																																																																																				</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																						</div>
+																																																		<div class="row g-0">
+										                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-08-10">
+																											<div class="number">
+															<span class="label">lunedì</span>
+															10
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-08-11">
+																											<div class="number">
+															<span class="label">martedì</span>
+															11
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-08-12">
+																											<div class="number">
+															<span class="label">mercoledì</span>
+															12
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-08-13">
+																											<div class="number">
+															<span class="label">giovedì</span>
+															13
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="64062|153503" data-filter-type="OPERA" data-filter-genre="2940" data-filter-season="129831">
+																			                                                                                                                                                        <div class="event opera">
+																																									<div class="tag">Concerto</div>
+																																									<div class="tag">2026</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/arena-opera-festival/carmina-burana/" title="Carmina Burana">
+																							Carmina Burana
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Arena di Verona</span>
+																					</div>
+																																																																																			<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">21:30</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=12730646&amp;tcode=vt0017687" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																							</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-08-14">
+																											<div class="number">
+															<span class="label">venerdì</span>
+															14
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="27664|4788|3872|39537|28148|27474|27554|27872|28548" data-filter-type="OPERA" data-filter-genre="1133" data-filter-season="129831">
+																			                                                                                                                                                        <div class="event opera">
+																																									<div class="tag">Opera</div>
+																																									<div class="tag">2026</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/arena-opera-festival/turandot/" title="Turandot">
+																							Turandot
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Arena di Verona</span>
+																					</div>
+																																																																																																																												<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">21:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=12730676&amp;tcode=vt0017687" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																																																																																																																																											</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-08-15">
+																											<div class="number">
+															<span class="label">sabato</span>
+															15
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="39401|3701|3758|1823|4502|151967|4788|4845" data-filter-type="OPERA" data-filter-genre="1133" data-filter-season="129831">
+																			                                                                                                                                                        <div class="event opera">
+																																									<div class="tag">Opera</div>
+																																									<div class="tag">2026</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/arena-opera-festival/aida/" title="Aida Ed. Franco Zeffirelli">
+																							Aida Ed. Franco Zeffirelli
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Arena di Verona</span>
+																					</div>
+																																																																																																																																																																					<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">21:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=12730641&amp;tcode=vt0017687" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																																																																																																																																											</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-08-16">
+																											<div class="number">
+															<span class="label">domenica</span>
+															16
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																						</div>
+																																																		<div class="row g-0">
+										                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-08-17">
+																											<div class="number">
+															<span class="label">lunedì</span>
+															17
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-08-18">
+																											<div class="number">
+															<span class="label">martedì</span>
+															18
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="" data-filter-type="OPERA" data-filter-genre="2940" data-filter-season="129831">
+																			                                                                                                                                                        <div class="event opera">
+																																									<div class="tag">Concerto</div>
+																																									<div class="tag">2026</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/arena-opera-festival/paganini-paradise/" title="Paganini Paradise. Superlive Immersive Concert">
+																							Paganini Paradise. Superlive Immersive Concert
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Arena di Verona</span>
+																					</div>
+																																																																																			<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">21:30</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/it/event/paganini-paradise/291849" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																							</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-08-19">
+																											<div class="number">
+															<span class="label">mercoledì</span>
+															19
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="39605" data-filter-type="OPERA" data-filter-genre="2940" data-filter-season="129831">
+																			                                                                                                                                                        <div class="event opera">
+																																									<div class="tag">Concerto</div>
+																																									<div class="tag">2026</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/arena-opera-festival/viva-vivaldi/" title="Viva Vivaldi. The Four Seasons Immersive Concert">
+																							Viva Vivaldi. The Four Seasons Immersive Concert
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Arena di Verona</span>
+																					</div>
+																																																																																			<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">21:30</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=12730681&amp;tcode=vt0017687" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																							</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-08-20">
+																											<div class="number">
+															<span class="label">giovedì</span>
+															20
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="3243|63846|124096|4217|91387|27117|27872|149940" data-filter-type="OPERA" data-filter-genre="1133" data-filter-season="129831">
+																			                                                                                                                                                        <div class="event opera">
+																																									<div class="tag">Opera</div>
+																																									<div class="tag">2026</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/arena-opera-festival/nabucco/" title="Nabucco">
+																							Nabucco
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Arena di Verona</span>
+																					</div>
+																																																																																																																																																																																																																																																																																																																																																																																		<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">21:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=12730671&amp;tcode=vt0017687" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																																																									</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-08-21">
+																											<div class="number">
+															<span class="label">venerdì</span>
+															21
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="27664|4788|123366|4160|28148|27474|27554|27872|28548" data-filter-type="OPERA" data-filter-genre="1133" data-filter-season="129831">
+																			                                                                                                                                                        <div class="event opera">
+																																									<div class="tag">Opera</div>
+																																									<div class="tag">2026</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/arena-opera-festival/turandot/" title="Turandot">
+																							Turandot
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Arena di Verona</span>
+																					</div>
+																																																																																																																																																																					<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">21:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=12730677&amp;tcode=vt0017687" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																																																																																																		</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-08-22">
+																											<div class="number">
+															<span class="label">sabato</span>
+															22
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="64077|28568|124096|4845|3243|4788|28468|64691|27117" data-filter-type="OPERA" data-filter-genre="1133" data-filter-season="129831">
+																			                                                                                                                                                        <div class="event opera">
+																																									<div class="tag">Opera</div>
+																																									<div class="tag">2026</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/arena-opera-festival/la-traviata/" title="La Traviata">
+																							La Traviata
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Arena di Verona</span>
+																					</div>
+																																																																																																																																																																																																																																																																																																																																																																																																																																																																				<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">21:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=12730660&amp;tcode=vt0017687" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																																																																																																		</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-08-23">
+																											<div class="number">
+															<span class="label">domenica</span>
+															23
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="3701|28046|26635|4502|64441|4731|4845" data-filter-type="OPERA" data-filter-genre="1133" data-filter-season="129831">
+																			                                                                                                                                                        <div class="event opera">
+																																									<div class="tag">Opera</div>
+																																									<div class="tag">2026</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/arena-opera-festival/aida/" title="Aida Ed. Franco Zeffirelli">
+																							Aida Ed. Franco Zeffirelli
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Arena di Verona</span>
+																					</div>
+																																																																																																																																																																																																														<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">21:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=12730642&amp;tcode=vt0017687" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																																																																																																		</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																						</div>
+																																																		<div class="row g-0">
+										                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-08-24">
+																											<div class="number">
+															<span class="label">lunedì</span>
+															24
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-08-25">
+																											<div class="number">
+															<span class="label">martedì</span>
+															25
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="" data-filter-type="OPERA" data-filter-genre="2941" data-filter-season="129831">
+																			                                                                                                                                                        <div class="event opera">
+																																									<div class="tag">Balletto</div>
+																																									<div class="tag">2026</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/arena-opera-festival/balletto/" title="Zorba il greco">
+																							Zorba il greco
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Teatro Romano di Verona</span>
+																					</div>
+																																																																																			<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">21:30</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/it/event/zorba-il-greco/291493" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-08-26">
+																											<div class="number">
+															<span class="label">mercoledì</span>
+															26
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="" data-filter-type="OPERA" data-filter-genre="2941" data-filter-season="129831">
+																			                                                                                                                                                        <div class="event opera">
+																																									<div class="tag">Balletto</div>
+																																									<div class="tag">2026</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/arena-opera-festival/balletto/" title="Zorba il greco">
+																							Zorba il greco
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Teatro Romano di Verona</span>
+																					</div>
+																																																																																																																												<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">21:30</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/it/event/zorba-il-greco/291636" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																							</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-08-27">
+																											<div class="number">
+															<span class="label">giovedì</span>
+															27
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="28588|4788|123366|4160|1823|27474|27554|27872|28548" data-filter-type="OPERA" data-filter-genre="1133" data-filter-season="129831">
+																			                                                                                                                                                        <div class="event opera">
+																																									<div class="tag">Opera</div>
+																																									<div class="tag">2026</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/arena-opera-festival/turandot/" title="Turandot">
+																							Turandot
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Arena di Verona</span>
+																					</div>
+																																																																																																																																																																																																														<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">21:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=12730678&amp;tcode=vt0017687" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																																																									</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-08-28">
+																											<div class="number">
+															<span class="label">venerdì</span>
+															28
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="3243|64130|124096|4217|91387|27117|27872|144951" data-filter-type="OPERA" data-filter-genre="1133" data-filter-season="129831">
+																			                                                                                                                                                        <div class="event opera">
+																																									<div class="tag">Opera</div>
+																																									<div class="tag">2026</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/arena-opera-festival/nabucco/" title="Nabucco">
+																							Nabucco
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Arena di Verona</span>
+																					</div>
+																																																																																																																																																																																																																																																																																																																																																																																																																											<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">21:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=12730672&amp;tcode=vt0017687" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-08-29">
+																											<div class="number">
+															<span class="label">sabato</span>
+															29
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="28588|28568|124096|4845|3415|4788|28468|64691|27117" data-filter-type="OPERA" data-filter-genre="1133" data-filter-season="129831">
+																			                                                                                                                                                        <div class="event opera">
+																																									<div class="tag">Opera</div>
+																																									<div class="tag">2026</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/arena-opera-festival/la-traviata/" title="La Traviata">
+																							La Traviata
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Arena di Verona</span>
+																					</div>
+																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																													<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">21:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=12730661&amp;tcode=vt0017687" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																																																									</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-08-30">
+																											<div class="number">
+															<span class="label">domenica</span>
+															30
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="3701|1824|1823|3415|151967|4788|4845" data-filter-type="OPERA" data-filter-genre="1133" data-filter-season="129831">
+																			                                                                                                                                                        <div class="event opera">
+																																									<div class="tag">Opera</div>
+																																									<div class="tag">2026</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/arena-opera-festival/aida/" title="Aida Ed. Franco Zeffirelli">
+																							Aida Ed. Franco Zeffirelli
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Arena di Verona</span>
+																					</div>
+																																																																																																																																																																																																																																																							<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">21:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=12730643&amp;tcode=vt0017687" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																																																									</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																						</div>
+																																																		<div class="row g-0">
+										                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-08-31">
+																											<div class="number">
+															<span class="label">lunedì</span>
+															31
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-08---">
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-08---">
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-08---">
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-08---">
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-08---">
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-08---">
+																									</div>
+											</div>
+																						</div>
+																																					</div>
+							</li>
+													<li>
+								<a href="javascript:void(more);" class="cta-item bh-linkControl " title="Cta More">
+									settembre 2026
+								</a>
+                                								<div class="int-item bh-itemContent">
+																																																<div class="row g-0">
+										                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-09---">
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-09-01">
+																											<div class="number">
+															<span class="label">martedì</span>
+															01
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-09-02">
+																											<div class="number">
+															<span class="label">mercoledì</span>
+															02
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-09-03">
+																											<div class="number">
+															<span class="label">giovedì</span>
+															03
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="27664|4788|3872|4160|1823|64135|27554|27872|28548" data-filter-type="OPERA" data-filter-genre="1133" data-filter-season="129831">
+																			                                                                                                                                                        <div class="event opera">
+																																									<div class="tag">Opera</div>
+																																									<div class="tag">2026</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/arena-opera-festival/turandot/" title="Turandot">
+																							Turandot
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Arena di Verona</span>
+																					</div>
+																																																																																																																																																																																																																																																							<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">21:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=12730679&amp;tcode=vt0017687" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-09-04">
+																											<div class="number">
+															<span class="label">venerdì</span>
+															04
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="3701|3758|91387|4502|64441|4731|4845" data-filter-type="OPERA" data-filter-genre="1133" data-filter-season="129831">
+																			                                                                                                                                                        <div class="event opera">
+																																									<div class="tag">Opera</div>
+																																									<div class="tag">2026</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/arena-opera-festival/aida/" title="Aida Ed. Franco Zeffirelli">
+																							Aida Ed. Franco Zeffirelli
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Arena di Verona</span>
+																					</div>
+																																																																																																																																																																																																																																																																																																<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">21:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=12730644&amp;tcode=vt0017687" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-09-05">
+																											<div class="number">
+															<span class="label">sabato</span>
+															05
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="28588|28568|124096|4845|63922|3243|4788|28468|64691|27117" data-filter-type="OPERA" data-filter-genre="1133" data-filter-season="129831">
+																			                                                                                                                                                        <div class="event opera">
+																																									<div class="tag">Opera</div>
+																																									<div class="tag">2026</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/arena-opera-festival/la-traviata/" title="La Traviata">
+																							La Traviata
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Arena di Verona</span>
+																					</div>
+																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																						<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">21:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=12730662&amp;tcode=vt0017687" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-09-06">
+																											<div class="number">
+															<span class="label">domenica</span>
+															06
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																						</div>
+																																																		<div class="row g-0">
+										                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-09-07">
+																											<div class="number">
+															<span class="label">lunedì</span>
+															07
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-09-08">
+																											<div class="number">
+															<span class="label">martedì</span>
+															08
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-09-09">
+																											<div class="number">
+															<span class="label">mercoledì</span>
+															09
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="3243|3758|26795|4160|84072|27117|4788|144951" data-filter-type="OPERA" data-filter-genre="1133" data-filter-season="129831">
+																			                                                                                                                                                        <div class="event opera">
+																																									<div class="tag">Opera</div>
+																																									<div class="tag">2026</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/arena-opera-festival/nabucco/" title="Nabucco">
+																							Nabucco
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Arena di Verona</span>
+																					</div>
+																																																																																																																																																																																																																																																																																																																																																																																																																																																																				<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">21:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=12730673&amp;tcode=vt0017687" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																							</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-09-10">
+																											<div class="number">
+															<span class="label">giovedì</span>
+															10
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="64441|3701|3758|4502|4217|4731|4845" data-filter-type="OPERA" data-filter-genre="1133" data-filter-season="129831">
+																			                                                                                                                                                        <div class="event opera">
+																																									<div class="tag">Opera</div>
+																																									<div class="tag">2026</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/arena-opera-festival/aida/" title="Aida Ed. Franco Zeffirelli">
+																							Aida Ed. Franco Zeffirelli
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Arena di Verona</span>
+																					</div>
+																																																																																																																																																																																																																																																																																																																																									<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">21:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=12730645&amp;tcode=vt0017687" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																							</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-09-11">
+																											<div class="number">
+															<span class="label">venerdì</span>
+															11
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="28588|4788|3872|4160|28148|64135|27554|27872|28548" data-filter-type="OPERA" data-filter-genre="1133" data-filter-season="129831">
+																			                                                                                                                                                        <div class="event opera">
+																																									<div class="tag">Opera</div>
+																																									<div class="tag">2026</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/arena-opera-festival/turandot/" title="Turandot">
+																							Turandot
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Arena di Verona</span>
+																					</div>
+																																																																																																																																																																																																																																																																																																<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">21:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=12730680&amp;tcode=vt0017687" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																							</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-09-12">
+																											<div class="number">
+															<span class="label">sabato</span>
+															12
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="28588|124096|4845|1823|3243|4788|28468|64691|27117" data-filter-type="OPERA" data-filter-genre="1133" data-filter-season="129831">
+																			                                                                                                                                                        <div class="event opera">
+																																									<div class="tag">Opera</div>
+																																									<div class="tag">2026</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/arena-opera-festival/la-traviata/" title="La Traviata">
+																							La Traviata
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Arena di Verona</span>
+																					</div>
+																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																															<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">21:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=12730663&amp;tcode=vt0017687" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																							</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-09-13">
+																											<div class="number">
+															<span class="label">domenica</span>
+															13
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																						</div>
+																																																		<div class="row g-0">
+										                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-09-14">
+																											<div class="number">
+															<span class="label">lunedì</span>
+															14
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-09-15">
+																											<div class="number">
+															<span class="label">martedì</span>
+															15
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-09-16">
+																											<div class="number">
+															<span class="label">mercoledì</span>
+															16
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-09-17">
+																											<div class="number">
+															<span class="label">giovedì</span>
+															17
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-09-18">
+																											<div class="number">
+															<span class="label">venerdì</span>
+															18
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-09-19">
+																											<div class="number">
+															<span class="label">sabato</span>
+															19
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-09-20">
+																											<div class="number">
+															<span class="label">domenica</span>
+															20
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																						</div>
+																																																		<div class="row g-0">
+										                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-09-21">
+																											<div class="number">
+															<span class="label">lunedì</span>
+															21
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-09-22">
+																											<div class="number">
+															<span class="label">martedì</span>
+															22
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-09-23">
+																											<div class="number">
+															<span class="label">mercoledì</span>
+															23
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-09-24">
+																											<div class="number">
+															<span class="label">giovedì</span>
+															24
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-09-25">
+																											<div class="number">
+															<span class="label">venerdì</span>
+															25
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-09-26">
+																											<div class="number">
+															<span class="label">sabato</span>
+															26
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-09-27">
+																											<div class="number">
+															<span class="label">domenica</span>
+															27
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																						</div>
+																																																		<div class="row g-0">
+										                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-09-28">
+																											<div class="number">
+															<span class="label">lunedì</span>
+															28
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-09-29">
+																											<div class="number">
+															<span class="label">martedì</span>
+															29
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-09-30">
+																											<div class="number">
+															<span class="label">mercoledì</span>
+															30
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-09---">
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-09---">
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-09---">
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-09---">
+																									</div>
+											</div>
+																						</div>
+																																					</div>
+							</li>
+													<li>
+								<a href="javascript:void(more);" class="cta-item bh-linkControl " title="Cta More">
+									ottobre 2026
+								</a>
+                                								<div class="int-item bh-itemContent">
+																																																<div class="row g-0">
+										                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-10---">
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-10---">
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-10---">
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-10-01">
+																											<div class="number">
+															<span class="label">giovedì</span>
+															01
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-10-02">
+																											<div class="number">
+															<span class="label">venerdì</span>
+															02
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-10-03">
+																											<div class="number">
+															<span class="label">sabato</span>
+															03
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-10-04">
+																											<div class="number">
+															<span class="label">domenica</span>
+															04
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																						</div>
+																																																		<div class="row g-0">
+										                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-10-05">
+																											<div class="number">
+															<span class="label">lunedì</span>
+															05
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-10-06">
+																											<div class="number">
+															<span class="label">martedì</span>
+															06
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-10-07">
+																											<div class="number">
+															<span class="label">mercoledì</span>
+															07
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-10-08">
+																											<div class="number">
+															<span class="label">giovedì</span>
+															08
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-10-09">
+																											<div class="number">
+															<span class="label">venerdì</span>
+															09
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-10-10">
+																											<div class="number">
+															<span class="label">sabato</span>
+															10
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-10-11">
+																											<div class="number">
+															<span class="label">domenica</span>
+															11
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																						</div>
+																																																		<div class="row g-0">
+										                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-10-12">
+																											<div class="number">
+															<span class="label">lunedì</span>
+															12
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-10-13">
+																											<div class="number">
+															<span class="label">martedì</span>
+															13
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-10-14">
+																											<div class="number">
+															<span class="label">mercoledì</span>
+															14
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-10-15">
+																											<div class="number">
+															<span class="label">giovedì</span>
+															15
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-10-16">
+																											<div class="number">
+															<span class="label">venerdì</span>
+															16
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-10-17">
+																											<div class="number">
+															<span class="label">sabato</span>
+															17
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-10-18">
+																											<div class="number">
+															<span class="label">domenica</span>
+															18
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="67571|67503|66675" data-filter-type="TEATRO" data-filter-genre="31940" data-filter-season="156866">
+																			                                                                                                                                                        <div class="event theater">
+																																									<div class="tag">Musica da camera</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/teatro-filarmonico-verona/gounod-nielsen-dvorak-serenate-e-sinfonie-per-fiati/" title="Gounod, Nielsen, Dvořák | Serenate e sinfonie per fiati">
+																							Gounod, Nielsen, Dvořák | Serenate e sinfonie per fiati
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Accademia di Agricoltura Scienze e Lettere</span>
+																					</div>
+																																																																																			<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">11:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/it/event/gounod-nielsen-dvorak-serenate-e-sinfonie-per-fiati/291081" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																							</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																						</div>
+																																																		<div class="row g-0">
+										                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-10-19">
+																											<div class="number">
+															<span class="label">lunedì</span>
+															19
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-10-20">
+																											<div class="number">
+															<span class="label">martedì</span>
+															20
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-10-21">
+																											<div class="number">
+															<span class="label">mercoledì</span>
+															21
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-10-22">
+																											<div class="number">
+															<span class="label">giovedì</span>
+															22
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-10-23">
+																											<div class="number">
+															<span class="label">venerdì</span>
+															23
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-10-24">
+																											<div class="number">
+															<span class="label">sabato</span>
+															24
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="" data-filter-type="TEATRO" data-filter-genre="173430" data-filter-season="156866">
+																			                                                                                                                                                        <div class="event theater">
+																																									<div class="tag">Visita guidata</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/teatro-filarmonico-verona/visita-guidata-a-teatro-le-sale-della-musica/" title="Visita guidata a teatro | Le Sale della Musica">
+																							Visita guidata a teatro | Le Sale della Musica
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Teatro Filarmonico</span>
+																					</div>
+																																																																																																																																																																																																																																																																																																																																									<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">10:30</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=prices&amp;pcode=13540414&amp;tcode=vt0020008" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																															<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">12:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=prices&amp;pcode=13563173&amp;tcode=vt0020008" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																																																																																																																																																																																																																																																																																																															</div>
+																		</li>
+																																																																																					<li class="bh-calendarShow" data-filter-artist="" data-filter-type="TEATRO" data-filter-genre="173430" data-filter-season="156866">
+																			                                                                                                                                                        <div class="event theater">
+																																									<div class="tag">Visita guidata</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/teatro-filarmonico-verona/visita-guidata-a-teatro-le-sale-della-musica/" title="Visita guidata a teatro | Le Sale della Musica">
+																							Visita guidata a teatro | Le Sale della Musica
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Teatro Filarmonico</span>
+																					</div>
+																																																																																																																																																																																																																																																																																																																																									<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">10:30</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=prices&amp;pcode=13540414&amp;tcode=vt0020008" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																															<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">12:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=prices&amp;pcode=13563173&amp;tcode=vt0020008" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																																																																																																																																																																																																																																																																																																															</div>
+																		</li>
+																																																																																					<li class="bh-calendarShow" data-filter-artist="" data-filter-type="TEATRO" data-filter-genre="169222" data-filter-season="156866">
+																			                                                                                                                                                        <div class="event theater">
+																																									<div class="tag">Proiezione</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/teatro-filarmonico-verona/strictly-ballroom-proiezione/" title="Strictly Ballroom | Proiezione">
+																							Strictly Ballroom | Proiezione
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Teatro Filarmonico</span>
+																					</div>
+																																																																																			<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">18:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/it/event/strictly-ballroom-di-b-luhrmann/288970" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																							</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-10-25">
+																											<div class="number">
+															<span class="label">domenica</span>
+															25
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="27792|27554|28768|123286" data-filter-type="TEATRO" data-filter-genre="1133" data-filter-season="156866">
+																			                                                                                                                                                        <div class="event theater">
+																																									<div class="tag">Opera</div>
+																																									<div class="tag">Balletto</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/teatro-filarmonico-verona/amelia-al-ballo-jeu-de-cartes/" title="Jeu de Cartes | Amelia al ballo">
+																							Jeu de Cartes | Amelia al ballo
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Teatro Filarmonico</span>
+																					</div>
+																																																																																			<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">15:30</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=13134415&amp;tcode=vt0020008" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																																																																																																		</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																						</div>
+																																																		<div class="row g-0">
+										                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-10-26">
+																											<div class="number">
+															<span class="label">lunedì</span>
+															26
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-10-27">
+																											<div class="number">
+															<span class="label">martedì</span>
+															27
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-10-28">
+																											<div class="number">
+															<span class="label">mercoledì</span>
+															28
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="27792|27554|28768|123286" data-filter-type="TEATRO" data-filter-genre="1133" data-filter-season="156866">
+																			                                                                                                                                                        <div class="event theater">
+																																									<div class="tag">Opera</div>
+																																									<div class="tag">Balletto</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/teatro-filarmonico-verona/amelia-al-ballo-jeu-de-cartes/" title="Jeu de Cartes | Amelia al ballo">
+																							Jeu de Cartes | Amelia al ballo
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Teatro Filarmonico</span>
+																					</div>
+																																																																																																																												<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">19:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=13134417&amp;tcode=vt0020008" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																																																									</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-10-29">
+																											<div class="number">
+															<span class="label">giovedì</span>
+															29
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-10-30">
+																											<div class="number">
+															<span class="label">venerdì</span>
+															30
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="27792|27554|28768|123286" data-filter-type="TEATRO" data-filter-genre="1133" data-filter-season="156866">
+																			                                                                                                                                                        <div class="event theater">
+																																									<div class="tag">Opera</div>
+																																									<div class="tag">Balletto</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/teatro-filarmonico-verona/amelia-al-ballo-jeu-de-cartes/" title="Jeu de Cartes | Amelia al ballo">
+																							Jeu de Cartes | Amelia al ballo
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Teatro Filarmonico</span>
+																					</div>
+																																																																																																																																																																					<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">20:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=13134418&amp;tcode=vt0020008" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-10-31">
+																											<div class="number">
+															<span class="label">sabato</span>
+															31
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="" data-filter-type="TEATRO" data-filter-genre="173430" data-filter-season="156866">
+																			                                                                                                                                                        <div class="event theater">
+																																									<div class="tag">Visita guidata</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/teatro-filarmonico-verona/visita-guidata-a-teatro-le-sale-della-musica/" title="Visita guidata a teatro | Le Sale della Musica">
+																							Visita guidata a teatro | Le Sale della Musica
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Teatro Filarmonico</span>
+																					</div>
+																																																																																																																																																																																																																																																																																																																																																																																																																											<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">10:30</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=prices&amp;pcode=13540415&amp;tcode=vt0020008" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																															<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">12:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=prices&amp;pcode=13563174&amp;tcode=vt0020008" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																																																																																																																																																																																																																													</div>
+																		</li>
+																																																																																					<li class="bh-calendarShow" data-filter-artist="" data-filter-type="TEATRO" data-filter-genre="173430" data-filter-season="156866">
+																			                                                                                                                                                        <div class="event theater">
+																																									<div class="tag">Visita guidata</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/teatro-filarmonico-verona/visita-guidata-a-teatro-le-sale-della-musica/" title="Visita guidata a teatro | Le Sale della Musica">
+																							Visita guidata a teatro | Le Sale della Musica
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Teatro Filarmonico</span>
+																					</div>
+																																																																																																																																																																																																																																																																																																																																																																																																																											<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">10:30</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=prices&amp;pcode=13540415&amp;tcode=vt0020008" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																															<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">12:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=prices&amp;pcode=13563174&amp;tcode=vt0020008" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																																																																																																																																																																																																																													</div>
+																		</li>
+																																																																																					<li class="bh-calendarShow" data-filter-artist="" data-filter-type="TEATRO" data-filter-genre="2940" data-filter-season="156866">
+																			                                                                                                                                                        <div class="event theater">
+																																									<div class="tag">Concerto</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/teatro-filarmonico-verona/sinfonie-4-6-aspettando-beethoven/" title="Sinfonie n. 4, 6 | Aspettando Beethoven">
+																							Sinfonie n. 4, 6 | Aspettando Beethoven
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Sala Filarmonica</span>
+																					</div>
+																																																																																			<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">18:30</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/it/event/aspettando-beethoven-sinfonie-n-4-6/293077" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																							</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-10---">
+																									</div>
+											</div>
+																						</div>
+																																					</div>
+							</li>
+													<li>
+								<a href="javascript:void(more);" class="cta-item bh-linkControl " title="Cta More">
+									novembre 2026
+								</a>
+                                								<div class="int-item bh-itemContent">
+																																																<div class="row g-0">
+										                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-11---">
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-11---">
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-11---">
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-11---">
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-11---">
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-11---">
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-11-01">
+																											<div class="number">
+															<span class="label">domenica</span>
+															01
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="27792|27554|28768|123286" data-filter-type="TEATRO" data-filter-genre="1133" data-filter-season="156866">
+																			                                                                                                                                                        <div class="event theater">
+																																									<div class="tag">Opera</div>
+																																									<div class="tag">Balletto</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/teatro-filarmonico-verona/amelia-al-ballo-jeu-de-cartes/" title="Jeu de Cartes | Amelia al ballo">
+																							Jeu de Cartes | Amelia al ballo
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Teatro Filarmonico</span>
+																					</div>
+																																																																																																																																																																																																														<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">15:30</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=13134416&amp;tcode=vt0020008" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																							</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																						</div>
+																																																		<div class="row g-0">
+										                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-11-02">
+																											<div class="number">
+															<span class="label">lunedì</span>
+															02
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-11-03">
+																											<div class="number">
+															<span class="label">martedì</span>
+															03
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-11-04">
+																											<div class="number">
+															<span class="label">mercoledì</span>
+															04
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-11-05">
+																											<div class="number">
+															<span class="label">giovedì</span>
+															05
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-11-06">
+																											<div class="number">
+															<span class="label">venerdì</span>
+															06
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="" data-filter-type="TEATRO" data-filter-genre="2940" data-filter-season="156866">
+																			                                                                                                                                                        <div class="event theater">
+																																									<div class="tag">Concerto</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/teatro-filarmonico-verona/brahms-serenata/" title="Brahms Serenata">
+																							Brahms Serenata
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Teatro Filarmonico</span>
+																					</div>
+																																																																																			<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">20:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=13134413&amp;tcode=vt0020008" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-11-07">
+																											<div class="number">
+															<span class="label">sabato</span>
+															07
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="" data-filter-type="TEATRO" data-filter-genre="2940" data-filter-season="156866">
+																			                                                                                                                                                        <div class="event theater">
+																																									<div class="tag">Concerto</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/teatro-filarmonico-verona/brahms-serenata/" title="Brahms Serenata">
+																							Brahms Serenata
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Teatro Filarmonico</span>
+																					</div>
+																																																																																																																												<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">17:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=13134414&amp;tcode=vt0020008" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																							</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-11-08">
+																											<div class="number">
+															<span class="label">domenica</span>
+															08
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="" data-filter-type="TEATRO" data-filter-genre="31940" data-filter-season="156866">
+																			                                                                                                                                                        <div class="event theater">
+																																									<div class="tag">Musica da camera</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/teatro-filarmonico-verona/beethoven-schubert-quartetti-per-archi/" title="Beethoven, Schubert | Quartetti per archi">
+																							Beethoven, Schubert | Quartetti per archi
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Museo Nicolis</span>
+																					</div>
+																																																																																			<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">11:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/it/event/beethoven-schubert-quartetti-per-archi/291084" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																							</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																						</div>
+																																																		<div class="row g-0">
+										                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-11-09">
+																											<div class="number">
+															<span class="label">lunedì</span>
+															09
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-11-10">
+																											<div class="number">
+															<span class="label">martedì</span>
+															10
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-11-11">
+																											<div class="number">
+															<span class="label">mercoledì</span>
+															11
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-11-12">
+																											<div class="number">
+															<span class="label">giovedì</span>
+															12
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-11-13">
+																											<div class="number">
+															<span class="label">venerdì</span>
+															13
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-11-14">
+																											<div class="number">
+															<span class="label">sabato</span>
+															14
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-11-15">
+																											<div class="number">
+															<span class="label">domenica</span>
+															15
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																						</div>
+																																																		<div class="row g-0">
+										                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-11-16">
+																											<div class="number">
+															<span class="label">lunedì</span>
+															16
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-11-17">
+																											<div class="number">
+															<span class="label">martedì</span>
+															17
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-11-18">
+																											<div class="number">
+															<span class="label">mercoledì</span>
+															18
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-11-19">
+																											<div class="number">
+															<span class="label">giovedì</span>
+															19
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-11-20">
+																											<div class="number">
+															<span class="label">venerdì</span>
+															20
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-11-21">
+																											<div class="number">
+															<span class="label">sabato</span>
+															21
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="" data-filter-type="TEATRO" data-filter-genre="173430" data-filter-season="156866">
+																			                                                                                                                                                        <div class="event theater">
+																																									<div class="tag">Visita guidata</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/teatro-filarmonico-verona/visita-guidata-a-teatro-le-sale-della-musica/" title="Visita guidata a teatro | Le Sale della Musica">
+																							Visita guidata a teatro | Le Sale della Musica
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Teatro Filarmonico</span>
+																					</div>
+																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																													<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">10:30</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=prices&amp;pcode=13540416&amp;tcode=vt0020008" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																															<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">12:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=prices&amp;pcode=13563175&amp;tcode=vt0020008" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																																																																																																																																											</div>
+																		</li>
+																																																																																					<li class="bh-calendarShow" data-filter-artist="" data-filter-type="TEATRO" data-filter-genre="173430" data-filter-season="156866">
+																			                                                                                                                                                        <div class="event theater">
+																																									<div class="tag">Visita guidata</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/teatro-filarmonico-verona/visita-guidata-a-teatro-le-sale-della-musica/" title="Visita guidata a teatro | Le Sale della Musica">
+																							Visita guidata a teatro | Le Sale della Musica
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Teatro Filarmonico</span>
+																					</div>
+																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																													<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">10:30</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=prices&amp;pcode=13540416&amp;tcode=vt0020008" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																															<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">12:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=prices&amp;pcode=13563175&amp;tcode=vt0020008" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																																																																																																																																											</div>
+																		</li>
+																																																																																					<li class="bh-calendarShow" data-filter-artist="" data-filter-type="TEATRO" data-filter-genre="169222" data-filter-season="156866">
+																			                                                                                                                                                        <div class="event theater">
+																																									<div class="tag">Proiezione</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/teatro-filarmonico-verona/the-dreamers-proiezione/" title="The Dreamers | Proiezione">
+																							The Dreamers | Proiezione
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Teatro Filarmonico</span>
+																					</div>
+																																																																																			<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">18:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/it/event/the-dreamers-di-b-bertolucci/288971" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																							</div>
+																		</li>
+																																																																																					<li class="bh-calendarShow" data-filter-artist="" data-filter-type="TEATRO" data-filter-genre="2940" data-filter-season="156866">
+																			                                                                                                                                                        <div class="event theater">
+																																									<div class="tag">Concerto</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/teatro-filarmonico-verona/sinfonie-7-8-aspettando-beethoven/" title="Sinfonie n. 7, 8 | Aspettando Beethoven">
+																							Sinfonie n. 7, 8 | Aspettando Beethoven
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Sala Filarmonica</span>
+																					</div>
+																																																																																			<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">18:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/it/event/aspettando-beethoven-sinfonie-n-7-8/293078" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																							</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-11-22">
+																											<div class="number">
+															<span class="label">domenica</span>
+															22
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="26755|84072|64691|123856" data-filter-type="TEATRO" data-filter-genre="1133" data-filter-season="156866">
+																			                                                                                                                                                        <div class="event theater">
+																																									<div class="tag">Opera</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/teatro-filarmonico-verona/la-boheme/" title="La Bohème">
+																							La Bohème
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Teatro Filarmonico</span>
+																					</div>
+																																																																																			<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">15:30</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=13134438&amp;tcode=vt0020008" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																																																																																																		</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																						</div>
+																																																		<div class="row g-0">
+										                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-11-23">
+																											<div class="number">
+															<span class="label">lunedì</span>
+															23
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-11-24">
+																											<div class="number">
+															<span class="label">martedì</span>
+															24
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-11-25">
+																											<div class="number">
+															<span class="label">mercoledì</span>
+															25
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="26755|84072|64691|123856" data-filter-type="TEATRO" data-filter-genre="1133" data-filter-season="156866">
+																			                                                                                                                                                        <div class="event theater">
+																																									<div class="tag">Opera</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/teatro-filarmonico-verona/la-boheme/" title="La Bohème">
+																							La Bohème
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Teatro Filarmonico</span>
+																					</div>
+																																																																																																																												<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">19:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=13134440&amp;tcode=vt0020008" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																																																									</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-11-26">
+																											<div class="number">
+															<span class="label">giovedì</span>
+															26
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-11-27">
+																											<div class="number">
+															<span class="label">venerdì</span>
+															27
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="26755|84072|64691|123856" data-filter-type="TEATRO" data-filter-genre="1133" data-filter-season="156866">
+																			                                                                                                                                                        <div class="event theater">
+																																									<div class="tag">Opera</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/teatro-filarmonico-verona/la-boheme/" title="La Bohème">
+																							La Bohème
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Teatro Filarmonico</span>
+																					</div>
+																																																																																																																																																																					<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">20:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=13134441&amp;tcode=vt0020008" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-11-28">
+																											<div class="number">
+															<span class="label">sabato</span>
+															28
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="" data-filter-type="TEATRO" data-filter-genre="173430" data-filter-season="156866">
+																			                                                                                                                                                        <div class="event theater">
+																																									<div class="tag">Visita guidata</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/teatro-filarmonico-verona/visita-guidata-a-teatro-le-sale-della-musica/" title="Visita guidata a teatro | Le Sale della Musica">
+																							Visita guidata a teatro | Le Sale della Musica
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Teatro Filarmonico</span>
+																					</div>
+																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																															<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">10:30</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=prices&amp;pcode=13540417&amp;tcode=vt0020008" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																															<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">12:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=prices&amp;pcode=13563176&amp;tcode=vt0020008" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																																																									</div>
+																		</li>
+																																																																																					<li class="bh-calendarShow" data-filter-artist="" data-filter-type="TEATRO" data-filter-genre="173430" data-filter-season="156866">
+																			                                                                                                                                                        <div class="event theater">
+																																									<div class="tag">Visita guidata</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/teatro-filarmonico-verona/visita-guidata-a-teatro-le-sale-della-musica/" title="Visita guidata a teatro | Le Sale della Musica">
+																							Visita guidata a teatro | Le Sale della Musica
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Teatro Filarmonico</span>
+																					</div>
+																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																															<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">10:30</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=prices&amp;pcode=13540417&amp;tcode=vt0020008" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																															<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">12:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=prices&amp;pcode=13563176&amp;tcode=vt0020008" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																																																									</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-11-29">
+																											<div class="number">
+															<span class="label">domenica</span>
+															29
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="26755|84072|64691|123856" data-filter-type="TEATRO" data-filter-genre="1133" data-filter-season="156866">
+																			                                                                                                                                                        <div class="event theater">
+																																									<div class="tag">Opera</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/teatro-filarmonico-verona/la-boheme/" title="La Bohème">
+																							La Bohème
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Teatro Filarmonico</span>
+																					</div>
+																																																																																																																																																																																																														<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">15:30</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=13134439&amp;tcode=vt0020008" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																							</div>
+																		</li>
+																																																																																					<li class="bh-calendarShow" data-filter-artist="66675|67707" data-filter-type="TEATRO" data-filter-genre="31940" data-filter-season="156866">
+																			                                                                                                                                                        <div class="event theater">
+																																									<div class="tag">Musica da camera</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/teatro-filarmonico-verona/mozart-kreutzer-duo-e-settimino/" title="Mozart, Kreutzer | Duo e Settimino">
+																							Mozart, Kreutzer | Duo e Settimino
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Museo degli affreschi</span>
+																					</div>
+																																																																																			<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">11:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/it/event/mozart-kreutzer-duo-e-settimino/291083" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																							</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																						</div>
+																																																		<div class="row g-0">
+										                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-11-30">
+																											<div class="number">
+															<span class="label">lunedì</span>
+															30
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-11---">
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-11---">
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-11---">
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-11---">
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-11---">
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-11---">
+																									</div>
+											</div>
+																						</div>
+																																					</div>
+							</li>
+													<li>
+								<a href="javascript:void(more);" class="cta-item bh-linkControl " title="Cta More">
+									dicembre 2026
+								</a>
+                                								<div class="int-item bh-itemContent">
+																																																<div class="row g-0">
+										                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-12---">
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-12-01">
+																											<div class="number">
+															<span class="label">martedì</span>
+															01
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-12-02">
+																											<div class="number">
+															<span class="label">mercoledì</span>
+															02
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-12-03">
+																											<div class="number">
+															<span class="label">giovedì</span>
+															03
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-12-04">
+																											<div class="number">
+															<span class="label">venerdì</span>
+															04
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-12-05">
+																											<div class="number">
+															<span class="label">sabato</span>
+															05
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-12-06">
+																											<div class="number">
+															<span class="label">domenica</span>
+															06
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																						</div>
+																																																		<div class="row g-0">
+										                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-12-07">
+																											<div class="number">
+															<span class="label">lunedì</span>
+															07
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-12-08">
+																											<div class="number">
+															<span class="label">martedì</span>
+															08
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-12-09">
+																											<div class="number">
+															<span class="label">mercoledì</span>
+															09
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-12-10">
+																											<div class="number">
+															<span class="label">giovedì</span>
+															10
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-12-11">
+																											<div class="number">
+															<span class="label">venerdì</span>
+															11
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-12-12">
+																											<div class="number">
+															<span class="label">sabato</span>
+															12
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="" data-filter-type="TEATRO" data-filter-genre="169222" data-filter-season="156866">
+																			                                                                                                                                                        <div class="event theater">
+																																									<div class="tag">Proiezione</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/teatro-filarmonico-verona/black-swan-proiezione/" title="Black Swan | Proiezione">
+																							Black Swan | Proiezione
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Teatro Filarmonico</span>
+																					</div>
+																																																																																			<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">18:30</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/it/event/black-swan-di-d-aronovsky/288967" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																							</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-12-13">
+																											<div class="number">
+															<span class="label">domenica</span>
+															13
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="" data-filter-type="TEATRO" data-filter-genre="2941" data-filter-season="156866">
+																			                                                                                                                                                        <div class="event theater">
+																																									<div class="tag">Balletto</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/teatro-filarmonico-verona/il-lago-dei-cigni/" title="Il Lago dei Cigni">
+																							Il Lago dei Cigni
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Teatro Filarmonico</span>
+																					</div>
+																																																																																			<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">15:30</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=13134434&amp;tcode=vt0020008" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																																																																																																																																																																																				</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																						</div>
+																																																		<div class="row g-0">
+										                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-12-14">
+																											<div class="number">
+															<span class="label">lunedì</span>
+															14
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-12-15">
+																											<div class="number">
+															<span class="label">martedì</span>
+															15
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-12-16">
+																											<div class="number">
+															<span class="label">mercoledì</span>
+															16
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="" data-filter-type="TEATRO" data-filter-genre="2941" data-filter-season="156866">
+																			                                                                                                                                                        <div class="event theater">
+																																									<div class="tag">Balletto</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/teatro-filarmonico-verona/il-lago-dei-cigni/" title="Il Lago dei Cigni">
+																							Il Lago dei Cigni
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Teatro Filarmonico</span>
+																					</div>
+																																																																																																																												<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">19:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=13134436&amp;tcode=vt0020008" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																																																																																																																																											</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-12-17">
+																											<div class="number">
+															<span class="label">giovedì</span>
+															17
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-12-18">
+																											<div class="number">
+															<span class="label">venerdì</span>
+															18
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="" data-filter-type="TEATRO" data-filter-genre="2941" data-filter-season="156866">
+																			                                                                                                                                                        <div class="event theater">
+																																									<div class="tag">Balletto</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/teatro-filarmonico-verona/il-lago-dei-cigni/" title="Il Lago dei Cigni">
+																							Il Lago dei Cigni
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Teatro Filarmonico</span>
+																					</div>
+																																																																																																																																																																					<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">20:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=13134437&amp;tcode=vt0020008" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																																																																																																		</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-12-19">
+																											<div class="number">
+															<span class="label">sabato</span>
+															19
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="" data-filter-type="TEATRO" data-filter-genre="173430" data-filter-season="156866">
+																			                                                                                                                                                        <div class="event theater">
+																																									<div class="tag">Visita guidata</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/teatro-filarmonico-verona/visita-guidata-a-teatro-le-sale-della-musica/" title="Visita guidata a teatro | Le Sale della Musica">
+																							Visita guidata a teatro | Le Sale della Musica
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Teatro Filarmonico</span>
+																					</div>
+																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																	<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">10:30</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=prices&amp;pcode=13540418&amp;tcode=vt0020008" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																															<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">12:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=prices&amp;pcode=13563177&amp;tcode=vt0020008" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																							</div>
+																		</li>
+																																																																																					<li class="bh-calendarShow" data-filter-artist="" data-filter-type="TEATRO" data-filter-genre="173430" data-filter-season="156866">
+																			                                                                                                                                                        <div class="event theater">
+																																									<div class="tag">Visita guidata</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/teatro-filarmonico-verona/visita-guidata-a-teatro-le-sale-della-musica/" title="Visita guidata a teatro | Le Sale della Musica">
+																							Visita guidata a teatro | Le Sale della Musica
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Teatro Filarmonico</span>
+																					</div>
+																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																	<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">10:30</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=prices&amp;pcode=13540418&amp;tcode=vt0020008" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																															<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">12:00</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=prices&amp;pcode=13563177&amp;tcode=vt0020008" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																							</div>
+																		</li>
+																																																																																					<li class="bh-calendarShow" data-filter-artist="" data-filter-type="TEATRO" data-filter-genre="2941" data-filter-season="156866">
+																			                                                                                                                                                        <div class="event theater">
+																																									<div class="tag">Balletto</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/teatro-filarmonico-verona/il-lago-dei-cigni/" title="Il Lago dei Cigni">
+																							Il Lago dei Cigni
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Teatro Filarmonico</span>
+																					</div>
+																																																																																																																																																																																																														<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">15:30</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.arena.it/it/event/il-lago-dei-cigni/283410" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																																																									</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-12-20">
+																											<div class="number">
+															<span class="label">domenica</span>
+															20
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="" data-filter-type="TEATRO" data-filter-genre="2941" data-filter-season="156866">
+																			                                                                                                                                                        <div class="event theater">
+																																									<div class="tag">Balletto</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/teatro-filarmonico-verona/il-lago-dei-cigni/" title="Il Lago dei Cigni">
+																							Il Lago dei Cigni
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Teatro Filarmonico</span>
+																					</div>
+																																																																																																																																																																																																																																																							<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">15:30</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=13134435&amp;tcode=vt0020008" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																																																																</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																						</div>
+																																																		<div class="row g-0">
+										                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-12-21">
+																											<div class="number">
+															<span class="label">lunedì</span>
+															21
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-12-22">
+																											<div class="number">
+															<span class="label">martedì</span>
+															22
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-12-23">
+																											<div class="number">
+															<span class="label">mercoledì</span>
+															23
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-12-24">
+																											<div class="number">
+															<span class="label">giovedì</span>
+															24
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-12-25">
+																											<div class="number">
+															<span class="label">venerdì</span>
+															25
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-12-26">
+																											<div class="number">
+															<span class="label">sabato</span>
+															26
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-12-27">
+																											<div class="number">
+															<span class="label">domenica</span>
+															27
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																						</div>
+																																																		<div class="row g-0">
+										                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-12-28">
+																											<div class="number">
+															<span class="label">lunedì</span>
+															28
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-12-29">
+																											<div class="number">
+															<span class="label">martedì</span>
+															29
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-12-30">
+																											<div class="number">
+															<span class="label">mercoledì</span>
+															30
+														</div>
+														<ul>
+																													</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex">
+												<div class="day" data-day="2026-12-31">
+																											<div class="number">
+															<span class="label">giovedì</span>
+															31
+														</div>
+														<ul>
+																																																																																			<li class="bh-calendarShow" data-filter-artist="" data-filter-type="TEATRO" data-filter-genre="2941" data-filter-season="156866">
+																			                                                                                                                                                        <div class="event theater">
+																																									<div class="tag">Balletto</div>
+																																								<header class="heading">
+																					<h2 class="title-base medium bold">
+																						<a href="/teatro-filarmonico-verona/il-lago-dei-cigni/" title="Il Lago dei Cigni">
+																							Il Lago dei Cigni
+																						</a>
+																					</h2>
+																				</header>
+																																									<div class="info-icon">
+																						<span class="icon location-secondary"></span>
+																						<span class="label">Teatro Filarmonico</span>
+																					</div>
+																																																																																																																																																																																																																																																																																																<div class="info-icon">
+																							<span class="icon time-secondary"></span>
+																							<span class="label">19:30</span>
+																						</div>
+                                                                                        																						                                <a href="https://shop.arena.it/it/event/il-lago-dei-cigni/299154" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+                                                                                                                                                                                																																							</div>
+																		</li>
+																																																														</ul>
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-12---">
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-12---">
+																									</div>
+											</div>
+																																								                                                                                                                                    											<div class="col-xl d-flex d-none d-xl-flex d-xxl-flex">
+												<div class="day" data-day="2026-12---">
+																									</div>
+											</div>
+																						</div>
+																																					</div>
+							</li>
+															</ul>
+			</div>
+		</div>
+	
+			<div class="bh-view" data-view="LIST" style="display:none">
+			<div class="panel-default" style="margin-top:0">
+				<div class="content">
+
+					
+					
+						<article class="box-show bh-calendarShow" data-filter-artist="27966|124096|4160|27966|124096|4160" data-filter-type="TEATRO" data-filter-genre="2940" data-filter-season="156866"
+                            style=""
+                        >
+							<div class="container">
+								<div class="row gy-4">
+									<div class="col-lg-6">
+										<figure class="ctn-img">
+											<a href="/teatro-filarmonico-verona/rossini-petite-messe-solennelle/" title="Scopri di più">
+												<img 
+													class="bh-lasy-image" 
+													src="/site/assets/files/157151/1_concerto-1.jpg"
+													data-src="/site/assets/files/157151/1_concerto-1.jpg" 
+													alt="Rossini Petite Messe Solennelle" 
+													style=""/>
+											</a>
+										</figure>
+									</div>
+									<div class="col-lg-6">
+										<section class="ctn-text">
+																							<div class="tag">Concerto</div>
+																						<header class="heading">
+												<h2 class="subtitle">
+													<a href="/teatro-filarmonico-verona/rossini-petite-messe-solennelle/" title="Scopri di più">
+														Rossini Petite Messe Solennelle
+													</a>
+												</h2>
+											</header>
+											<div class="txt big">
+												<p>Gioachino Rossini</p>
+											</div>
+											<div class="txt">
+												<p>Il primo concerto della stagione sinfonica 2026 al Teatro Filarmonico</p>
+												<p></p>
+											</div>
+											
+                                                                                            
+	<div class="data-show ">
+		<div class="int">			<div class="tit">
+				<span class="icon calendar"></span>
+				<span class="label">Prossime date</span>
+			</div>
+            <ul>
+            				<li>
+					Dal
+					<time datetime="2026-04-03T00:00">
+						03.04
+					</time>
+					al
+					<time datetime="2026-04-04T00:00">
+						04.04
+					</time>
+				</li>
+			            </ul>
+		</div>	</div>
+
+                                            
+											<div class="buttons-bar">
+                                                												                                <a href="https://shop.fondazionearena.it/it/buy-ticket/arenaverona-tutto/?filter_show=1%20Concerto%20-%20Rossini%20Petite%20Messe%20Solennelle" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+    												                                                <a href="/teatro-filarmonico-verona/rossini-petite-messe-solennelle/" class="btn secondary small full-down-sm" title="Scopri di più">
+													<span class="label">Scopri di più</span>
+												</a>
+											</div>
+										</section>
+									</div>
+								</div>
+							</div>
+						</article>
+					
+						<article class="box-show bh-calendarShow" data-filter-artist="" data-filter-type="TEATRO" data-filter-genre="173430" data-filter-season="156866"
+                            style=""
+                        >
+							<div class="container">
+								<div class="row gy-4">
+									<div class="col-lg-6">
+										<figure class="ctn-img">
+											<a href="/teatro-filarmonico-verona/visita-guidata-a-teatro-le-sale-della-musica/" title="Scopri di più">
+												<img 
+													class="bh-lasy-image" 
+													src="/site/assets/files/173329/5.jpg"
+													data-src="/site/assets/files/173329/5.jpg" 
+													alt="Visita guidata a teatro | Le Sale della Musica" 
+													style=""/>
+											</a>
+										</figure>
+									</div>
+									<div class="col-lg-6">
+										<section class="ctn-text">
+																							<div class="tag">Visita guidata</div>
+																						<header class="heading">
+												<h2 class="subtitle">
+													<a href="/teatro-filarmonico-verona/visita-guidata-a-teatro-le-sale-della-musica/" title="Scopri di più">
+														Visita guidata a teatro | Le Sale della Musica
+													</a>
+												</h2>
+											</header>
+											<div class="txt big">
+												<p></p>
+											</div>
+											<div class="txt">
+												<p>Visite guidate al Teatro Filarmonico</p>
+												<p></p>
+											</div>
+											
+                                                                                            
+	<div class="data-show ">
+		<div class="int">			<div class="tit">
+				<span class="icon calendar"></span>
+				<span class="label">Prossime date</span>
+			</div>
+            <ul>
+            				<li>
+					Dal
+					<time datetime="2026-04-04T00:00">
+						04.04
+					</time>
+					al
+					<time datetime="2026-12-19T00:00">
+						19.12
+					</time>
+				</li>
+			            </ul>
+		</div>	</div>
+
+                                            
+											<div class="buttons-bar">
+                                                												                                <a href="https://shop.fondazionearena.it/it/event/le-sale-della-musica-visita-guidata-a-teatro/293067" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+    												                                                <a href="/teatro-filarmonico-verona/visita-guidata-a-teatro-le-sale-della-musica/" class="btn secondary small full-down-sm" title="Scopri di più">
+													<span class="label">Scopri di più</span>
+												</a>
+											</div>
+										</section>
+									</div>
+								</div>
+							</div>
+						</article>
+					
+						<article class="box-show bh-calendarShow" data-filter-artist="" data-filter-type="TEATRO" data-filter-genre="2940" data-filter-season="156866"
+                            style=""
+                        >
+							<div class="container">
+								<div class="row gy-4">
+									<div class="col-lg-6">
+										<figure class="ctn-img">
+											<a href="/teatro-filarmonico-verona/berlioz-fantastique/" title="Scopri di più">
+												<img 
+													class="bh-lasy-image" 
+													src="/site/assets/files/157183/2_concerto-1.jpg"
+													data-src="/site/assets/files/157183/2_concerto-1.jpg" 
+													alt="Berlioz Fantastique" 
+													style=""/>
+											</a>
+										</figure>
+									</div>
+									<div class="col-lg-6">
+										<section class="ctn-text">
+																							<div class="tag">Concerto</div>
+																						<header class="heading">
+												<h2 class="subtitle">
+													<a href="/teatro-filarmonico-verona/berlioz-fantastique/" title="Scopri di più">
+														Berlioz Fantastique
+													</a>
+												</h2>
+											</header>
+											<div class="txt big">
+												<p>Felix Mendelssohn-Bartholdy, Hector Louis Berlioz</p>
+											</div>
+											<div class="txt">
+												<p>Il secondo concerto della stagione sinfonica 2026 al Teatro Filarmonico</p>
+												<p></p>
+											</div>
+											
+                                                                                            
+	<div class="data-show ">
+		<div class="int">			<div class="tit">
+				<span class="icon calendar"></span>
+				<span class="label">Prossime date</span>
+			</div>
+            <ul>
+            				<li>
+					Dal
+					<time datetime="2026-04-10T00:00">
+						10.04
+					</time>
+					al
+					<time datetime="2026-04-12T00:00">
+						12.04
+					</time>
+				</li>
+			            </ul>
+		</div>	</div>
+
+                                            
+											<div class="buttons-bar">
+                                                												                                <a href="https://shop.fondazionearena.it/it/buy-ticket/arenaverona-tutto/?filter_show=2%20Concerto%20-%20Berlioz%20Fantastique" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+    												                                                <a href="/teatro-filarmonico-verona/berlioz-fantastique/" class="btn secondary small full-down-sm" title="Scopri di più">
+													<span class="label">Scopri di più</span>
+												</a>
+											</div>
+										</section>
+									</div>
+								</div>
+							</div>
+						</article>
+					
+						<article class="box-show bh-calendarShow" data-filter-artist="" data-filter-type="TEATRO" data-filter-genre="2940" data-filter-season="156866"
+                            style=""
+                        >
+							<div class="container">
+								<div class="row gy-4">
+									<div class="col-lg-6">
+										<figure class="ctn-img">
+											<a href="/teatro-filarmonico-verona/musorgskij-quadri/" title="Scopri di più">
+												<img 
+													class="bh-lasy-image" 
+													src="/site/assets/files/157215/3_concerto-1.jpg"
+													data-src="/site/assets/files/157215/3_concerto-1.jpg" 
+													alt="Musorgskij Quadri" 
+													style=""/>
+											</a>
+										</figure>
+									</div>
+									<div class="col-lg-6">
+										<section class="ctn-text">
+																							<div class="tag">Concerto</div>
+																						<header class="heading">
+												<h2 class="subtitle">
+													<a href="/teatro-filarmonico-verona/musorgskij-quadri/" title="Scopri di più">
+														Musorgskij Quadri
+													</a>
+												</h2>
+											</header>
+											<div class="txt big">
+												<p>Antonín Dvořák, Carlo Galante, Modest Petrovič Musorgskij</p>
+											</div>
+											<div class="txt">
+												<p>Il terzo concerto della stagione sinfonica 2026 al Teatro Filarmonico</p>
+												<p></p>
+											</div>
+											
+                                                                                            
+	<div class="data-show ">
+		<div class="int">			<div class="tit">
+				<span class="icon calendar"></span>
+				<span class="label">Prossime date</span>
+			</div>
+            <ul>
+            				<li>
+					Dal
+					<time datetime="2026-04-17T00:00">
+						17.04
+					</time>
+					al
+					<time datetime="2026-04-18T00:00">
+						18.04
+					</time>
+				</li>
+			            </ul>
+		</div>	</div>
+
+                                            
+											<div class="buttons-bar">
+                                                												                                <a href="https://shop.fondazionearena.it/it/buy-ticket/arenaverona-tutto/?filter_show=3%20Concerto%20-%20Musorgskij%20Quadri" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+    												                                                <a href="/teatro-filarmonico-verona/musorgskij-quadri/" class="btn secondary small full-down-sm" title="Scopri di più">
+													<span class="label">Scopri di più</span>
+												</a>
+											</div>
+										</section>
+									</div>
+								</div>
+							</div>
+						</article>
+					
+						<article class="box-show bh-calendarShow" data-filter-artist="" data-filter-type="TEATRO" data-filter-genre="31899" data-filter-season="156866"
+                            style=""
+                        >
+							<div class="container">
+								<div class="row gy-4">
+									<div class="col-lg-6">
+										<figure class="ctn-img">
+											<a href="/teatro-filarmonico-verona/opera-in-giallo-pagliacci/" title="Scopri di più">
+												<img 
+													class="bh-lasy-image" 
+													src="/site/assets/files/161239/arena_young-2025-arena-di-verona_01.jpg"
+													data-src="/site/assets/files/161239/arena_young-2025-arena-di-verona_01.jpg" 
+													alt="Opera in giallo | Pagliacci | Arena Young" 
+													style=""/>
+											</a>
+										</figure>
+									</div>
+									<div class="col-lg-6">
+										<section class="ctn-text">
+																							<div class="tag">Arena Young</div>
+																						<header class="heading">
+												<h2 class="subtitle">
+													<a href="/teatro-filarmonico-verona/opera-in-giallo-pagliacci/" title="Scopri di più">
+														Opera in giallo | Pagliacci | Arena Young
+													</a>
+												</h2>
+											</header>
+											<div class="txt big">
+												<p>Ruggero Leoncavallo</p>
+											</div>
+											<div class="txt">
+												<p>L’opera Pagliacci di Ruggero Leoncavallo sarà l’oggetto del nuovo spettacolo di Opera in Giallo</p>
+												<p></p>
+											</div>
+											
+                                                                                            
+	<div class="data-show ">
+		<div class="int">			<div class="tit">
+				<span class="icon calendar"></span>
+				<span class="label">Prossima data</span>
+			</div>
+            <ul>
+            				<li>
+					Il
+					<time datetime="2026-04-18T00:00">
+						18.04
+					</time>
+				</li>
+			            </ul>
+		</div>	</div>
+
+                                            
+											<div class="buttons-bar">
+                                                												                                <a href="https://shop.fondazionearena.it/index.php?nvpg[sell]&amp;cmd=pricesmap&amp;pcode=13134472&amp;tcode=vt0020006" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+    												                                                <a href="/teatro-filarmonico-verona/opera-in-giallo-pagliacci/" class="btn secondary small full-down-sm" title="Scopri di più">
+													<span class="label">Scopri di più</span>
+												</a>
+											</div>
+										</section>
+									</div>
+								</div>
+							</div>
+						</article>
+					
+						<article class="box-show bh-calendarShow" data-filter-artist="" data-filter-type="TEATRO" data-filter-genre="31940" data-filter-season="156866"
+                            style=""
+                        >
+							<div class="container">
+								<div class="row gy-4">
+									<div class="col-lg-6">
+										<figure class="ctn-img">
+											<a href="/teatro-filarmonico-verona/rossini-trascrizioni-per-quartetto-di-fiati/" title="Scopri di più">
+												<img 
+													class="bh-lasy-image" 
+													src="/site/assets/files/168083/palazzo_maffei-1.jpg"
+													data-src="/site/assets/files/168083/palazzo_maffei-1.jpg" 
+													alt="Rossini | Trascrizioni per quartetto di fiati" 
+													style=""/>
+											</a>
+										</figure>
+									</div>
+									<div class="col-lg-6">
+										<section class="ctn-text">
+																							<div class="tag">Musica da camera</div>
+																						<header class="heading">
+												<h2 class="subtitle">
+													<a href="/teatro-filarmonico-verona/rossini-trascrizioni-per-quartetto-di-fiati/" title="Scopri di più">
+														Rossini | Trascrizioni per quartetto di fiati
+													</a>
+												</h2>
+											</header>
+											<div class="txt big">
+												<p>Gioachino Rossini, Vincenzo Gambaro</p>
+											</div>
+											<div class="txt">
+												<p>Il terzo concerto di Musei in Musica 2026</p>
+												<p></p>
+											</div>
+											
+                                                                                            
+	<div class="data-show ">
+		<div class="int">			<div class="tit">
+				<span class="icon calendar"></span>
+				<span class="label">Prossima data</span>
+			</div>
+            <ul>
+            				<li>
+					Il
+					<time datetime="2026-04-19T00:00">
+						19.04
+					</time>
+				</li>
+			            </ul>
+		</div>	</div>
+
+                                            
+											<div class="buttons-bar">
+                                                												                                <a href="https://shop.fondazionearena.it/it/event/rossini-trascrizioni-per-quartetto-di-fiati/291087" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+    												                                                <a href="/teatro-filarmonico-verona/rossini-trascrizioni-per-quartetto-di-fiati/" class="btn secondary small full-down-sm" title="Scopri di più">
+													<span class="label">Scopri di più</span>
+												</a>
+											</div>
+										</section>
+									</div>
+								</div>
+							</div>
+						</article>
+					
+						<article class="box-show bh-calendarShow" data-filter-artist="" data-filter-type="TEATRO" data-filter-genre="2940" data-filter-season="156866"
+                            style=""
+                        >
+							<div class="container">
+								<div class="row gy-4">
+									<div class="col-lg-6">
+										<figure class="ctn-img">
+											<a href="/teatro-filarmonico-verona/mahler-9/" title="Scopri di più">
+												<img 
+													class="bh-lasy-image" 
+													src="/site/assets/files/157247/4_concerto-1.jpg"
+													data-src="/site/assets/files/157247/4_concerto-1.jpg" 
+													alt="Mahler 9" 
+													style=""/>
+											</a>
+										</figure>
+									</div>
+									<div class="col-lg-6">
+										<section class="ctn-text">
+																							<div class="tag">Concerto</div>
+																						<header class="heading">
+												<h2 class="subtitle">
+													<a href="/teatro-filarmonico-verona/mahler-9/" title="Scopri di più">
+														Mahler 9
+													</a>
+												</h2>
+											</header>
+											<div class="txt big">
+												<p>Gustav Mahler</p>
+											</div>
+											<div class="txt">
+												<p>Il quarto concerto della stagione sinfonica 2026 al Teatro Filarmonico</p>
+												<p></p>
+											</div>
+											
+                                                                                            
+	<div class="data-show ">
+		<div class="int">			<div class="tit">
+				<span class="icon calendar"></span>
+				<span class="label">Prossime date</span>
+			</div>
+            <ul>
+            				<li>
+					Dal
+					<time datetime="2026-04-24T00:00">
+						24.04
+					</time>
+					al
+					<time datetime="2026-04-25T00:00">
+						25.04
+					</time>
+				</li>
+			            </ul>
+		</div>	</div>
+
+                                            
+											<div class="buttons-bar">
+                                                												                                <a href="https://shop.fondazionearena.it/it/buy-ticket/arenaverona-tutto/?filter_show=4%20Concerto%20-%20Mahler%209" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+    												                                                <a href="/teatro-filarmonico-verona/mahler-9/" class="btn secondary small full-down-sm" title="Scopri di più">
+													<span class="label">Scopri di più</span>
+												</a>
+											</div>
+										</section>
+									</div>
+								</div>
+							</div>
+						</article>
+					
+						<article class="box-show bh-calendarShow" data-filter-artist="67571|67775" data-filter-type="TEATRO" data-filter-genre="31940" data-filter-season="156866"
+                            style=""
+                        >
+							<div class="container">
+								<div class="row gy-4">
+									<div class="col-lg-6">
+										<figure class="ctn-img">
+											<a href="/teatro-filarmonico-verona/bach-couperin-carter-sonate-e-concerti/" title="Scopri di più">
+												<img 
+													class="bh-lasy-image" 
+													src="/site/assets/files/168822/palazzo_maffei-1.jpg"
+													data-src="/site/assets/files/168822/palazzo_maffei-1.jpg" 
+													alt="Bach, Couperin, Carter | Sonate e concerti" 
+													style=""/>
+											</a>
+										</figure>
+									</div>
+									<div class="col-lg-6">
+										<section class="ctn-text">
+																							<div class="tag">Musica da camera</div>
+																						<header class="heading">
+												<h2 class="subtitle">
+													<a href="/teatro-filarmonico-verona/bach-couperin-carter-sonate-e-concerti/" title="Scopri di più">
+														Bach, Couperin, Carter | Sonate e concerti
+													</a>
+												</h2>
+											</header>
+											<div class="txt big">
+												<p>Johann Sebastian Bach, François Couperin, Elliott Carter</p>
+											</div>
+											<div class="txt">
+												<p>Il quarto concerto di Musei in Musica 2026</p>
+												<p></p>
+											</div>
+											
+                                                                                            
+	<div class="data-show ">
+		<div class="int">			<div class="tit">
+				<span class="icon calendar"></span>
+				<span class="label">Prossima data</span>
+			</div>
+            <ul>
+            				<li>
+					Il
+					<time datetime="2026-04-26T00:00">
+						26.04
+					</time>
+				</li>
+			            </ul>
+		</div>	</div>
+
+                                            
+											<div class="buttons-bar">
+                                                												                                <a href="https://shop.fondazionearena.it/it/event/bach-couperin-carter-sonate-e-concerti/291085" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+    												                                                <a href="/teatro-filarmonico-verona/bach-couperin-carter-sonate-e-concerti/" class="btn secondary small full-down-sm" title="Scopri di più">
+													<span class="label">Scopri di più</span>
+												</a>
+											</div>
+										</section>
+									</div>
+								</div>
+							</div>
+						</article>
+					
+						<article class="box-show bh-calendarShow" data-filter-artist="26605" data-filter-type="TEATRO" data-filter-genre="31940" data-filter-season="156866"
+                            style=""
+                        >
+							<div class="container">
+								<div class="row gy-4">
+									<div class="col-lg-6">
+										<figure class="ctn-img">
+											<a href="/teatro-filarmonico-verona/brahms-sestetti/" title="Scopri di più">
+												<img 
+													class="bh-lasy-image" 
+													src="/site/assets/files/169410/biblioteca_capitolare_ph_ivanrossi-1.jpg"
+													data-src="/site/assets/files/169410/biblioteca_capitolare_ph_ivanrossi-1.jpg" 
+													alt="Brahms | Sestetti" 
+													style=""/>
+											</a>
+										</figure>
+									</div>
+									<div class="col-lg-6">
+										<section class="ctn-text">
+																							<div class="tag">Musica da camera</div>
+																						<header class="heading">
+												<h2 class="subtitle">
+													<a href="/teatro-filarmonico-verona/brahms-sestetti/" title="Scopri di più">
+														Brahms | Sestetti
+													</a>
+												</h2>
+											</header>
+											<div class="txt big">
+												<p>Johannes Brahms</p>
+											</div>
+											<div class="txt">
+												<p>Il quinto concerto di Musei in Musica 2026</p>
+												<p></p>
+											</div>
+											
+                                                                                            
+	<div class="data-show ">
+		<div class="int">			<div class="tit">
+				<span class="icon calendar"></span>
+				<span class="label">Prossima data</span>
+			</div>
+            <ul>
+            				<li>
+					Il
+					<time datetime="2026-05-03T00:00">
+						03.05
+					</time>
+				</li>
+			            </ul>
+		</div>	</div>
+
+                                            
+											<div class="buttons-bar">
+                                                												                                <a href="https://shop.fondazionearena.it/it/event/brahms-sestetti/291082" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+    												                                                <a href="/teatro-filarmonico-verona/brahms-sestetti/" class="btn secondary small full-down-sm" title="Scopri di più">
+													<span class="label">Scopri di più</span>
+												</a>
+											</div>
+										</section>
+									</div>
+								</div>
+							</div>
+						</article>
+					
+						<article class="box-show bh-calendarShow" data-filter-artist="" data-filter-type="TEATRO" data-filter-genre="2940" data-filter-season="156866"
+                            style=""
+                        >
+							<div class="container">
+								<div class="row gy-4">
+									<div class="col-lg-6">
+										<figure class="ctn-img">
+											<a href="/teatro-filarmonico-verona/beethoven-missa-solemnis/" title="Scopri di più">
+												<img 
+													class="bh-lasy-image" 
+													src="/site/assets/files/157279/5_concerto-1.jpg"
+													data-src="/site/assets/files/157279/5_concerto-1.jpg" 
+													alt="Beethoven Missa Solemnis" 
+													style=""/>
+											</a>
+										</figure>
+									</div>
+									<div class="col-lg-6">
+										<section class="ctn-text">
+																							<div class="tag">Concerto</div>
+																						<header class="heading">
+												<h2 class="subtitle">
+													<a href="/teatro-filarmonico-verona/beethoven-missa-solemnis/" title="Scopri di più">
+														Beethoven Missa Solemnis
+													</a>
+												</h2>
+											</header>
+											<div class="txt big">
+												<p>Ludwig van Beethoven</p>
+											</div>
+											<div class="txt">
+												<p>Il quinto concerto della stagione sinfonica 2026 al Teatro Filarmonico</p>
+												<p></p>
+											</div>
+											
+                                                                                            
+	<div class="data-show ">
+		<div class="int">			<div class="tit">
+				<span class="icon calendar"></span>
+				<span class="label">Prossime date</span>
+			</div>
+            <ul>
+            				<li>
+					Dal
+					<time datetime="2026-05-08T00:00">
+						08.05
+					</time>
+					al
+					<time datetime="2026-05-09T00:00">
+						09.05
+					</time>
+				</li>
+			            </ul>
+		</div>	</div>
+
+                                            
+											<div class="buttons-bar">
+                                                												                                <a href="https://shop.fondazionearena.it/it/buy-ticket/arenaverona-tutto/?filter_show=5%20Concerto%20-%20Beethoven%20Missa%20Solemnis" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+    												                                                <a href="/teatro-filarmonico-verona/beethoven-missa-solemnis/" class="btn secondary small full-down-sm" title="Scopri di più">
+													<span class="label">Scopri di più</span>
+												</a>
+											</div>
+										</section>
+									</div>
+								</div>
+							</div>
+						</article>
+					
+						<article class="box-show bh-calendarShow" data-filter-artist="" data-filter-type="OPERA" data-filter-genre="1133" data-filter-season="129831"
+                            style=""
+                        >
+							<div class="container">
+								<div class="row gy-4">
+									<div class="col-lg-6">
+										<figure class="ctn-img">
+											<a href="/arena-opera-festival/turandot-enigmi-al-museo/" title="Scopri di più">
+												<img 
+													class="bh-lasy-image" 
+													src="/site/assets/files/181829/turandot_enigmi_web_628x628.jpg"
+													data-src="/site/assets/files/181829/turandot_enigmi_web_628x628.jpg" 
+													alt="Turandot | Enigmi al museo" 
+													style=""/>
+											</a>
+										</figure>
+									</div>
+									<div class="col-lg-6">
+										<section class="ctn-text">
+																							<div class="tag">Opera</div>
+																							<div class="tag">2026</div>
+																						<header class="heading">
+												<h2 class="subtitle">
+													<a href="/arena-opera-festival/turandot-enigmi-al-museo/" title="Scopri di più">
+														Turandot | Enigmi al museo
+													</a>
+												</h2>
+											</header>
+											<div class="txt big">
+												<p>Giacomo Puccini</p>
+											</div>
+											<div class="txt">
+												<p>Un&#039;avventura per tutta la famiglia</p>
+												<p></p>
+											</div>
+											
+                                                                                            
+	<div class="data-show ">
+		<div class="int">			<div class="tit">
+				<span class="icon calendar"></span>
+				<span class="label">Prossima data</span>
+			</div>
+            <ul>
+            				<li>
+					Il
+					<time datetime="2026-05-09T00:00">
+						09.05
+					</time>
+				</li>
+			            </ul>
+		</div>	</div>
+
+                                            
+											<div class="buttons-bar">
+                                                												                                <a href="https://shop.arena.it/it/event/turandot-enigmi-al-museo/292749" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+    												                                                <a href="/arena-opera-festival/turandot-enigmi-al-museo/" class="btn secondary small full-down-sm" title="Scopri di più">
+													<span class="label">Scopri di più</span>
+												</a>
+											</div>
+										</section>
+									</div>
+								</div>
+							</div>
+						</article>
+					
+						<article class="box-show bh-calendarShow" data-filter-artist="67291" data-filter-type="TEATRO" data-filter-genre="31940" data-filter-season="156866"
+                            style=""
+                        >
+							<div class="container">
+								<div class="row gy-4">
+									<div class="col-lg-6">
+										<figure class="ctn-img">
+											<a href="/teatro-filarmonico-verona/haydn-schubert-beethoven-trii-per-archi/" title="Scopri di più">
+												<img 
+													class="bh-lasy-image" 
+													src="/site/assets/files/169528/palazzo_maffei-1.jpg"
+													data-src="/site/assets/files/169528/palazzo_maffei-1.jpg" 
+													alt="Haydn, Schubert, Beethoven | Trii per archi" 
+													style=""/>
+											</a>
+										</figure>
+									</div>
+									<div class="col-lg-6">
+										<section class="ctn-text">
+																							<div class="tag">Musica da camera</div>
+																						<header class="heading">
+												<h2 class="subtitle">
+													<a href="/teatro-filarmonico-verona/haydn-schubert-beethoven-trii-per-archi/" title="Scopri di più">
+														Haydn, Schubert, Beethoven | Trii per archi
+													</a>
+												</h2>
+											</header>
+											<div class="txt big">
+												<p>Franz Joseph Haydn, Franz Schubert, Ludwig van Beethoven</p>
+											</div>
+											<div class="txt">
+												<p>Il sesto concerto di Musei in Musica 2026</p>
+												<p></p>
+											</div>
+											
+                                                                                            
+	<div class="data-show ">
+		<div class="int">			<div class="tit">
+				<span class="icon calendar"></span>
+				<span class="label">Prossima data</span>
+			</div>
+            <ul>
+            				<li>
+					Il
+					<time datetime="2026-05-10T00:00">
+						10.05
+					</time>
+				</li>
+			            </ul>
+		</div>	</div>
+
+                                            
+											<div class="buttons-bar">
+                                                												                                <a href="https://shop.fondazionearena.it/it/event/haydn-schubert-beethoven-trii-per-archi/291086" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+    												                                                <a href="/teatro-filarmonico-verona/haydn-schubert-beethoven-trii-per-archi/" class="btn secondary small full-down-sm" title="Scopri di più">
+													<span class="label">Scopri di più</span>
+												</a>
+											</div>
+										</section>
+									</div>
+								</div>
+							</div>
+						</article>
+					
+						<article class="box-show bh-calendarShow" data-filter-artist="" data-filter-type="TEATRO" data-filter-genre="2940" data-filter-season="156866"
+                            style=""
+                        >
+							<div class="container">
+								<div class="row gy-4">
+									<div class="col-lg-6">
+										<figure class="ctn-img">
+											<a href="/teatro-filarmonico-verona/dvorak-nuovo-mondo/" title="Scopri di più">
+												<img 
+													class="bh-lasy-image" 
+													src="/site/assets/files/157311/6_concerto-1.jpg"
+													data-src="/site/assets/files/157311/6_concerto-1.jpg" 
+													alt="Dvořák Nuovo Mondo" 
+													style=""/>
+											</a>
+										</figure>
+									</div>
+									<div class="col-lg-6">
+										<section class="ctn-text">
+																							<div class="tag">Concerto</div>
+																						<header class="heading">
+												<h2 class="subtitle">
+													<a href="/teatro-filarmonico-verona/dvorak-nuovo-mondo/" title="Scopri di più">
+														Dvořák Nuovo Mondo
+													</a>
+												</h2>
+											</header>
+											<div class="txt big">
+												<p>Dmitrij Dmitrievič Šostakovič, Antonín Dvořák</p>
+											</div>
+											<div class="txt">
+												<p>Il sesto concerto della stagione sinfonica 2026 al Teatro Filarmonico</p>
+												<p></p>
+											</div>
+											
+                                                                                            
+	<div class="data-show ">
+		<div class="int">			<div class="tit">
+				<span class="icon calendar"></span>
+				<span class="label">Prossime date</span>
+			</div>
+            <ul>
+            				<li>
+					Dal
+					<time datetime="2026-05-15T00:00">
+						15.05
+					</time>
+					al
+					<time datetime="2026-05-16T00:00">
+						16.05
+					</time>
+				</li>
+			            </ul>
+		</div>	</div>
+
+                                            
+											<div class="buttons-bar">
+                                                												                                <a href="https://shop.fondazionearena.it/it/buy-ticket/arenaverona-tutto/?filter_show=6%20Concerto%20-%20Dvorak%20Nuovo%20Mondo" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+    												                                                <a href="/teatro-filarmonico-verona/dvorak-nuovo-mondo/" class="btn secondary small full-down-sm" title="Scopri di più">
+													<span class="label">Scopri di più</span>
+												</a>
+											</div>
+										</section>
+									</div>
+								</div>
+							</div>
+						</article>
+					
+						<article class="box-show bh-calendarShow" data-filter-artist="64120|67503|67639" data-filter-type="TEATRO" data-filter-genre="31940" data-filter-season="156866"
+                            style=""
+                        >
+							<div class="container">
+								<div class="row gy-4">
+									<div class="col-lg-6">
+										<figure class="ctn-img">
+											<a href="/teatro-filarmonico-verona/mozart-beethoven-brani-per-ottetto-di-fiati/" title="Scopri di più">
+												<img 
+													class="bh-lasy-image" 
+													src="/site/assets/files/169643/circolo-unificato-dell-esercito_232671-1.jpg"
+													data-src="/site/assets/files/169643/circolo-unificato-dell-esercito_232671-1.jpg" 
+													alt="Mozart, Beethoven | Brani per ottetto di fiati" 
+													style=""/>
+											</a>
+										</figure>
+									</div>
+									<div class="col-lg-6">
+										<section class="ctn-text">
+																							<div class="tag">Musica da camera</div>
+																						<header class="heading">
+												<h2 class="subtitle">
+													<a href="/teatro-filarmonico-verona/mozart-beethoven-brani-per-ottetto-di-fiati/" title="Scopri di più">
+														Mozart, Beethoven | Brani per ottetto di fiati
+													</a>
+												</h2>
+											</header>
+											<div class="txt big">
+												<p>Wolfgang Amadeus Mozart, Ludwig van Beethoven</p>
+											</div>
+											<div class="txt">
+												<p>Il settimo concerto di Musei in Musica 2026</p>
+												<p></p>
+											</div>
+											
+                                                                                            
+	<div class="data-show ">
+		<div class="int">			<div class="tit">
+				<span class="icon calendar"></span>
+				<span class="label">Prossima data</span>
+			</div>
+            <ul>
+            				<li>
+					Il
+					<time datetime="2026-05-17T00:00">
+						17.05
+					</time>
+				</li>
+			            </ul>
+		</div>	</div>
+
+                                            
+											<div class="buttons-bar">
+                                                												                                <a href="https://shop.fondazionearena.it/it/event/mozart-rossini-beethoven-brani-per-ottetto-di-fiati/291090" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+    												                                                <a href="/teatro-filarmonico-verona/mozart-beethoven-brani-per-ottetto-di-fiati/" class="btn secondary small full-down-sm" title="Scopri di più">
+													<span class="label">Scopri di più</span>
+												</a>
+											</div>
+										</section>
+									</div>
+								</div>
+							</div>
+						</article>
+					
+						<article class="box-show bh-calendarShow" data-filter-artist="" data-filter-type="TEATRO" data-filter-genre="2940" data-filter-season="156866"
+                            style=""
+                        >
+							<div class="container">
+								<div class="row gy-4">
+									<div class="col-lg-6">
+										<figure class="ctn-img">
+											<a href="/teatro-filarmonico-verona/grieg-concerto/" title="Scopri di più">
+												<img 
+													class="bh-lasy-image" 
+													src="/site/assets/files/157343/7_concerto-1.jpg"
+													data-src="/site/assets/files/157343/7_concerto-1.jpg" 
+													alt="Grieg Concerto" 
+													style=""/>
+											</a>
+										</figure>
+									</div>
+									<div class="col-lg-6">
+										<section class="ctn-text">
+																							<div class="tag">Concerto</div>
+																						<header class="heading">
+												<h2 class="subtitle">
+													<a href="/teatro-filarmonico-verona/grieg-concerto/" title="Scopri di più">
+														Grieg Concerto
+													</a>
+												</h2>
+											</header>
+											<div class="txt big">
+												<p>Edvard Grieg, Béla Bartók</p>
+											</div>
+											<div class="txt">
+												<p>Il settimo concerto della stagione sinfonica 2026 al Teatro Filarmonico</p>
+												<p></p>
+											</div>
+											
+                                                                                            
+	<div class="data-show ">
+		<div class="int">			<div class="tit">
+				<span class="icon calendar"></span>
+				<span class="label">Prossime date</span>
+			</div>
+            <ul>
+            				<li>
+					Dal
+					<time datetime="2026-05-22T00:00">
+						22.05
+					</time>
+					al
+					<time datetime="2026-05-23T00:00">
+						23.05
+					</time>
+				</li>
+			            </ul>
+		</div>	</div>
+
+                                            
+											<div class="buttons-bar">
+                                                												                                <a href="https://shop.fondazionearena.it/it/buy-ticket/arenaverona-tutto/?filter_show=7%20Concerto%20-%20Grieg%20Concerto" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+    												                                                <a href="/teatro-filarmonico-verona/grieg-concerto/" class="btn secondary small full-down-sm" title="Scopri di più">
+													<span class="label">Scopri di più</span>
+												</a>
+											</div>
+										</section>
+									</div>
+								</div>
+							</div>
+						</article>
+					
+						<article class="box-show bh-calendarShow" data-filter-artist="64077|124096|4845|1823|4445|4788|28468|27554|64077|28538|124096|4845|84072|4445|4788|28468|27554|64077|124096|4845|1823|4788|28468|27554|64077|28538|124096|4845|84072|4788|28468|27554|64077|4845|27654|4502|4788|28468|64691|64077|4845|27654|3415|4788|28468|64691|27117|64077|27966|4845|63922|4502|4788|28468|64691|27117|64077|27966|124096|4845|172559|3243|4788|28468|64691|27117|64077|28568|124096|4845|66411|3243|4788|28468|64691|64077|28568|124096|4845|3243|4788|28468|64691|27117|28588|28568|124096|4845|3415|4788|28468|64691|27117|28588|28568|124096|4845|63922|3243|4788|28468|64691|27117|28588|124096|4845|1823|3243|4788|28468|64691|27117" data-filter-type="OPERA" data-filter-genre="1133" data-filter-season="129831"
+                            style=""
+                        >
+							<div class="container">
+								<div class="row gy-4">
+									<div class="col-lg-6">
+										<figure class="ctn-img">
+											<a href="/arena-opera-festival/la-traviata/" title="Scopri di più">
+												<img 
+													class="bh-lasy-image" 
+													src="/site/assets/files/129832/628_x_628_copertina_sito.jpg"
+													data-src="/site/assets/files/129832/628_x_628_copertina_sito.jpg" 
+													alt="La Traviata" 
+													style=""/>
+											</a>
+										</figure>
+									</div>
+									<div class="col-lg-6">
+										<section class="ctn-text">
+																							<div class="tag">Opera</div>
+																							<div class="tag">2026</div>
+																						<header class="heading">
+												<h2 class="subtitle">
+													<a href="/arena-opera-festival/la-traviata/" title="Scopri di più">
+														La Traviata
+													</a>
+												</h2>
+											</header>
+											<div class="txt big">
+												<p>Giuseppe Verdi</p>
+											</div>
+											<div class="txt">
+												<p>Il titolo d’opera più amato e rappresentato al mondo inaugura il 103° Festival areniano con un nuovo allestimento</p>
+												<p></p>
+											</div>
+											
+                                                                                            
+	<div class="data-show ">
+		<div class="int">			<div class="tit">
+				<span class="icon calendar"></span>
+				<span class="label">Prossime date</span>
+			</div>
+            <ul>
+            				<li>
+					Dal
+					<time datetime="2026-06-12T00:00">
+						12.06
+					</time>
+					al
+					<time datetime="2026-09-12T00:00">
+						12.09
+					</time>
+				</li>
+			            </ul>
+		</div>	</div>
+
+                                            
+											<div class="buttons-bar">
+                                                												                                <a href="https://shop.fondazionearena.it/?filter_show=La%20Traviata" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+    												                                                <a href="/arena-opera-festival/la-traviata/" class="btn secondary small full-down-sm" title="Scopri di più">
+													<span class="label">Scopri di più</span>
+												</a>
+											</div>
+										</section>
+									</div>
+								</div>
+							</div>
+						</article>
+					
+						<article class="box-show bh-calendarShow" data-filter-artist="39401|3758|1823|4445|64441|4788|4845|39401|63780|1823|4502|64441|4731|4845|39401|63780|3758|4102|4445|64441|4788|4845|39401|3758|4102|4445|64441|4731|4845|64441|3701|1823|4502|4217|27872|4845|64441|3701|3758|1823|4502|4217|27872|4845" data-filter-type="OPERA" data-filter-genre="1133" data-filter-season="129831"
+                            style=""
+                        >
+							<div class="container">
+								<div class="row gy-4">
+									<div class="col-lg-6">
+										<figure class="ctn-img">
+											<a href="/arena-opera-festival/aida-2023/" title="Scopri di più">
+												<img 
+													class="bh-lasy-image" 
+													src="/site/assets/files/130304/628_x_628_copertina_sito.jpg"
+													data-src="/site/assets/files/130304/628_x_628_copertina_sito.jpg" 
+													alt="Aida Ed. Stefano Poda" 
+													style=""/>
+											</a>
+										</figure>
+									</div>
+									<div class="col-lg-6">
+										<section class="ctn-text">
+																							<div class="tag">Opera</div>
+																							<div class="tag">2026</div>
+																						<header class="heading">
+												<h2 class="subtitle">
+													<a href="/arena-opera-festival/aida-2023/" title="Scopri di più">
+														Aida Ed. Stefano Poda
+													</a>
+												</h2>
+											</header>
+											<div class="txt big">
+												<p>Giuseppe Verdi</p>
+											</div>
+											<div class="txt">
+												<p>Audace e rivoluzionaria: è l’Aida “di cristallo” firmata da Stefano Poda, fra trasparenze e giochi di luce</p>
+												<p></p>
+											</div>
+											
+                                                                                            
+	<div class="data-show ">
+		<div class="int">			<div class="tit">
+				<span class="icon calendar"></span>
+				<span class="label">Prossime date</span>
+			</div>
+            <ul>
+            				<li>
+					Dal
+					<time datetime="2026-06-19T00:00">
+						19.06
+					</time>
+					al
+					<time datetime="2026-07-24T00:00">
+						24.07
+					</time>
+				</li>
+			            </ul>
+		</div>	</div>
+
+                                            
+											<div class="buttons-bar">
+                                                												                                <a href="https://shop.fondazionearena.it/?filter_show=Aida%20Ed.%20Stefano%20Poda" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+    												                                                <a href="/arena-opera-festival/aida-2023/" class="btn secondary small full-down-sm" title="Scopri di più">
+													<span class="label">Scopri di più</span>
+												</a>
+											</div>
+										</section>
+									</div>
+								</div>
+							</div>
+						</article>
+					
+						<article class="box-show bh-calendarShow" data-filter-artist="64077|4445|3758|26795|39537|84072|28468|4788|144951|64077|4445|3758|26795|64441|84072|28468|4731|144951|64077|3415|3758|124096|64441|84072|28468|4731|149940|64077|4502|3758|26795|4217|27654|27117|4731|144951|64077|4502|64130|124096|27654|27117|4788|149940|64077|3243|3758|124096|39537|27654|27117|27872|144951|4502|63846|124096|4217|27654|27117|27872|144951|3243|63846|124096|4217|91387|27117|27872|149940|3243|64130|124096|4217|91387|27117|27872|144951|3243|3758|26795|4160|84072|27117|4788|144951" data-filter-type="OPERA" data-filter-genre="1133" data-filter-season="129831"
+                            style=""
+                        >
+							<div class="container">
+								<div class="row gy-4">
+									<div class="col-lg-6">
+										<figure class="ctn-img">
+											<a href="/arena-opera-festival/nabucco/" title="Scopri di più">
+												<img 
+													class="bh-lasy-image" 
+													src="/site/assets/files/130445/2.jpg"
+													data-src="/site/assets/files/130445/2.jpg" 
+													alt="Nabucco" 
+													style=""/>
+											</a>
+										</figure>
+									</div>
+									<div class="col-lg-6">
+										<section class="ctn-text">
+																							<div class="tag">Opera</div>
+																							<div class="tag">2026</div>
+																						<header class="heading">
+												<h2 class="subtitle">
+													<a href="/arena-opera-festival/nabucco/" title="Scopri di più">
+														Nabucco
+													</a>
+												</h2>
+											</header>
+											<div class="txt big">
+												<p>Giuseppe Verdi</p>
+											</div>
+											<div class="txt">
+												<p>Un “Nabucco” poetico e visionario con l’inconfondibile firma di Stefano Poda</p>
+												<p></p>
+											</div>
+											
+                                                                                            
+	<div class="data-show ">
+		<div class="int">			<div class="tit">
+				<span class="icon calendar"></span>
+				<span class="label">Prossime date</span>
+			</div>
+            <ul>
+            				<li>
+					Dal
+					<time datetime="2026-06-26T00:00">
+						26.06
+					</time>
+					al
+					<time datetime="2026-09-09T00:00">
+						09.09
+					</time>
+				</li>
+			            </ul>
+		</div>	</div>
+
+                                            
+											<div class="buttons-bar">
+                                                												                                <a href="https://shop.fondazionearena.it/?filter_show=Nabucco" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+    												                                                <a href="/arena-opera-festival/nabucco/" class="btn secondary small full-down-sm" title="Scopri di più">
+													<span class="label">Scopri di più</span>
+												</a>
+											</div>
+										</section>
+									</div>
+								</div>
+							</div>
+						</article>
+					
+						<article class="box-show bh-calendarShow" data-filter-artist="28268|1823|64691|28468|39129|4788|28268|1823|64691|28468|39129|4788|28128|1823|64691|28468|39129|27872|28128|64691|28468|39129|27872" data-filter-type="OPERA" data-filter-genre="1133" data-filter-season="129831"
+                            style=""
+                        >
+							<div class="container">
+								<div class="row gy-4">
+									<div class="col-lg-6">
+										<figure class="ctn-img">
+											<a href="/arena-opera-festival/la-boheme/" title="Scopri di più">
+												<img 
+													class="bh-lasy-image" 
+													src="/site/assets/files/130684/boheme.jpg"
+													data-src="/site/assets/files/130684/boheme.jpg" 
+													alt="La Bohème" 
+													style=""/>
+											</a>
+										</figure>
+									</div>
+									<div class="col-lg-6">
+										<section class="ctn-text">
+																							<div class="tag">Opera</div>
+																							<div class="tag">2026</div>
+																						<header class="heading">
+												<h2 class="subtitle">
+													<a href="/arena-opera-festival/la-boheme/" title="Scopri di più">
+														La Bohème
+													</a>
+												</h2>
+											</header>
+											<div class="txt big">
+												<p>Giacomo Puccini</p>
+											</div>
+											<div class="txt">
+												<p>Amore e gioventù nella Parigi dell’Ottocento: in Arena torna la “Bohème” con regia di Alfonso Signorini.</p>
+												<p></p>
+											</div>
+											
+                                                                                            
+	<div class="data-show ">
+		<div class="int">			<div class="tit">
+				<span class="icon calendar"></span>
+				<span class="label">Prossime date</span>
+			</div>
+            <ul>
+            				<li>
+					Dal
+					<time datetime="2026-07-03T00:00">
+						03.07
+					</time>
+					al
+					<time datetime="2026-07-25T00:00">
+						25.07
+					</time>
+				</li>
+			            </ul>
+		</div>	</div>
+
+                                            
+											<div class="buttons-bar">
+                                                												                                <a href="https://shop.fondazionearena.it/?filter_show=La%20Boh%C3%A8me" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+    												                                                <a href="/arena-opera-festival/la-boheme/" class="btn secondary small full-down-sm" title="Scopri di più">
+													<span class="label">Scopri di più</span>
+												</a>
+											</div>
+										</section>
+									</div>
+								</div>
+							</div>
+						</article>
+					
+						<article class="box-show bh-calendarShow" data-filter-artist="" data-filter-type="OPERA" data-filter-genre="2941" data-filter-season="129831"
+                            style=""
+                        >
+							<div class="container">
+								<div class="row gy-4">
+									<div class="col-lg-6">
+										<figure class="ctn-img">
+											<a href="/arena-opera-festival/roberto-bolle-and-friends/" title="Scopri di più">
+												<img 
+													class="bh-lasy-image" 
+													src="/site/assets/files/130815/bolle-2026-arena-di-verona_thumb.jpg"
+													data-src="/site/assets/files/130815/bolle-2026-arena-di-verona_thumb.jpg" 
+													alt="Roberto Bolle and Friends" 
+													style=""/>
+											</a>
+										</figure>
+									</div>
+									<div class="col-lg-6">
+										<section class="ctn-text">
+																							<div class="tag">Balletto</div>
+																							<div class="tag">2026</div>
+																						<header class="heading">
+												<h2 class="subtitle">
+													<a href="/arena-opera-festival/roberto-bolle-and-friends/" title="Scopri di più">
+														Roberto Bolle and Friends
+													</a>
+												</h2>
+											</header>
+											<div class="txt big">
+												<p>Co-production con ArteDanza SRL</p>
+											</div>
+											<div class="txt">
+												<p>L’atteso appuntamento con Roberto Bolle e le star internazionali del balletto</p>
+												<p></p>
+											</div>
+											
+                                                                                            
+	<div class="data-show ">
+		<div class="int">			<div class="tit">
+				<span class="icon calendar"></span>
+				<span class="label">Prossima data</span>
+			</div>
+            <ul>
+            				<li>
+					Il
+					<time datetime="2026-07-21T00:00">
+						21.07
+					</time>
+				</li>
+			            </ul>
+		</div>	</div>
+
+                                            
+											<div class="buttons-bar">
+                                                												                                <a href="https://shop.fondazionearena.it/?filter_show=Roberto%20Bolle%20and%20Friends" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+    												                                                <a href="/arena-opera-festival/roberto-bolle-and-friends/" class="btn secondary small full-down-sm" title="Scopri di più">
+													<span class="label">Scopri di più</span>
+												</a>
+											</div>
+										</section>
+									</div>
+								</div>
+							</div>
+						</article>
+					
+						<article class="box-show bh-calendarShow" data-filter-artist="39401|3701|28046|4502|4217|4788|4845|64441|3701|28046|26635|4502|4217|4731|4845|39401|3701|3758|1823|4502|151967|4788|4845|3701|28046|26635|4502|64441|4731|4845|3701|1824|1823|3415|151967|4788|4845|3701|3758|91387|4502|64441|4731|4845|64441|3701|3758|4502|4217|4731|4845" data-filter-type="OPERA" data-filter-genre="1133" data-filter-season="129831"
+                            style=""
+                        >
+							<div class="container">
+								<div class="row gy-4">
+									<div class="col-lg-6">
+										<figure class="ctn-img">
+											<a href="/arena-opera-festival/aida/" title="Scopri di più">
+												<img 
+													class="bh-lasy-image" 
+													src="/site/assets/files/130930/aida_zeffirelli.jpg"
+													data-src="/site/assets/files/130930/aida_zeffirelli.jpg" 
+													alt="Aida Ed. Franco Zeffirelli" 
+													style=""/>
+											</a>
+										</figure>
+									</div>
+									<div class="col-lg-6">
+										<section class="ctn-text">
+																							<div class="tag">Opera</div>
+																							<div class="tag">2026</div>
+																						<header class="heading">
+												<h2 class="subtitle">
+													<a href="/arena-opera-festival/aida/" title="Scopri di più">
+														Aida Ed. Franco Zeffirelli
+													</a>
+												</h2>
+											</header>
+											<div class="txt big">
+												<p>Giuseppe Verdi</p>
+											</div>
+											<div class="txt">
+												<p>Una leggenda torna in Arena: la maestosa “Aida” immaginata da Zeffirelli è in scena per sette date al Festival 2026.</p>
+												<p></p>
+											</div>
+											
+                                                                                            
+	<div class="data-show ">
+		<div class="int">			<div class="tit">
+				<span class="icon calendar"></span>
+				<span class="label">Prossime date</span>
+			</div>
+            <ul>
+            				<li>
+					Dal
+					<time datetime="2026-07-30T00:00">
+						30.07
+					</time>
+					al
+					<time datetime="2026-09-10T00:00">
+						10.09
+					</time>
+				</li>
+			            </ul>
+		</div>	</div>
+
+                                            
+											<div class="buttons-bar">
+                                                												                                <a href="https://shop.fondazionearena.it/?filter_show=Aida%20Ed.%20Franco%20Zeffirelli" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+    												                                                <a href="/arena-opera-festival/aida/" class="btn secondary small full-down-sm" title="Scopri di più">
+													<span class="label">Scopri di più</span>
+												</a>
+											</div>
+										</section>
+									</div>
+								</div>
+							</div>
+						</article>
+					
+						<article class="box-show bh-calendarShow" data-filter-artist="27664|4788|3872|39537|28148|5133|27554|27872|28548|27664|4788|3872|39537|28148|27474|27554|27872|28548|27664|4788|123366|4160|28148|27474|27554|27872|28548|28588|4788|123366|4160|1823|27474|27554|27872|28548|27664|4788|3872|4160|1823|64135|27554|27872|28548|28588|4788|3872|4160|28148|64135|27554|27872|28548" data-filter-type="OPERA" data-filter-genre="1133" data-filter-season="129831"
+                            style=""
+                        >
+							<div class="container">
+								<div class="row gy-4">
+									<div class="col-lg-6">
+										<figure class="ctn-img">
+											<a href="/arena-opera-festival/turandot/" title="Scopri di più">
+												<img 
+													class="bh-lasy-image" 
+													src="/site/assets/files/131073/628_x_628_copertina_sito.jpg"
+													data-src="/site/assets/files/131073/628_x_628_copertina_sito.jpg" 
+													alt="Turandot" 
+													style=""/>
+											</a>
+										</figure>
+									</div>
+									<div class="col-lg-6">
+										<section class="ctn-text">
+																							<div class="tag">Opera</div>
+																							<div class="tag">2026</div>
+																						<header class="heading">
+												<h2 class="subtitle">
+													<a href="/arena-opera-festival/turandot/" title="Scopri di più">
+														Turandot
+													</a>
+												</h2>
+											</header>
+											<div class="txt big">
+												<p>Giacomo Puccini</p>
+											</div>
+											<div class="txt">
+												<p>Celebriamo i 100 anni di “Turandot” con il fiabesco allestimento di Zeffirelli!</p>
+												<p></p>
+											</div>
+											
+                                                                                            
+	<div class="data-show ">
+		<div class="int">			<div class="tit">
+				<span class="icon calendar"></span>
+				<span class="label">Prossime date</span>
+			</div>
+            <ul>
+            				<li>
+					Dal
+					<time datetime="2026-08-07T00:00">
+						07.08
+					</time>
+					al
+					<time datetime="2026-09-11T00:00">
+						11.09
+					</time>
+				</li>
+			            </ul>
+		</div>	</div>
+
+                                            
+											<div class="buttons-bar">
+                                                												                                <a href="https://shop.fondazionearena.it/?filter_show=Turandot" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+    												                                                <a href="/arena-opera-festival/turandot/" class="btn secondary small full-down-sm" title="Scopri di più">
+													<span class="label">Scopri di più</span>
+												</a>
+											</div>
+										</section>
+									</div>
+								</div>
+							</div>
+						</article>
+					
+						<article class="box-show bh-calendarShow" data-filter-artist="64062|153503" data-filter-type="OPERA" data-filter-genre="2940" data-filter-season="129831"
+                            style=""
+                        >
+							<div class="container">
+								<div class="row gy-4">
+									<div class="col-lg-6">
+										<figure class="ctn-img">
+											<a href="/arena-opera-festival/carmina-burana/" title="Scopri di più">
+												<img 
+													class="bh-lasy-image" 
+													src="/site/assets/files/131208/carmina_burana.jpg"
+													data-src="/site/assets/files/131208/carmina_burana.jpg" 
+													alt="Carmina Burana" 
+													style=""/>
+											</a>
+										</figure>
+									</div>
+									<div class="col-lg-6">
+										<section class="ctn-text">
+																							<div class="tag">Concerto</div>
+																							<div class="tag">2026</div>
+																						<header class="heading">
+												<h2 class="subtitle">
+													<a href="/arena-opera-festival/carmina-burana/" title="Scopri di più">
+														Carmina Burana
+													</a>
+												</h2>
+											</header>
+											<div class="txt big">
+												<p>Carl Orff</p>
+											</div>
+											<div class="txt">
+												<p>Le note travolgenti dei “Carmina Burana” tornano a infuocare l’Arena di Verona</p>
+												<p></p>
+											</div>
+											
+                                                                                            
+	<div class="data-show ">
+		<div class="int">			<div class="tit">
+				<span class="icon calendar"></span>
+				<span class="label">Prossima data</span>
+			</div>
+            <ul>
+            				<li>
+					Il
+					<time datetime="2026-08-13T00:00">
+						13.08
+					</time>
+				</li>
+			            </ul>
+		</div>	</div>
+
+                                            
+											<div class="buttons-bar">
+                                                												                                <a href="https://shop.fondazionearena.it/?filter_show=Carmina%20Burana" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+    												                                                <a href="/arena-opera-festival/carmina-burana/" class="btn secondary small full-down-sm" title="Scopri di più">
+													<span class="label">Scopri di più</span>
+												</a>
+											</div>
+										</section>
+									</div>
+								</div>
+							</div>
+						</article>
+					
+						<article class="box-show bh-calendarShow" data-filter-artist="" data-filter-type="OPERA" data-filter-genre="2940" data-filter-season="129831"
+                            style=""
+                        >
+							<div class="container">
+								<div class="row gy-4">
+									<div class="col-lg-6">
+										<figure class="ctn-img">
+											<a href="/arena-opera-festival/paganini-paradise/" title="Scopri di più">
+												<img 
+													class="bh-lasy-image" 
+													src="/site/assets/files/166959/628_x_628_copertina_sito-1.jpg"
+													data-src="/site/assets/files/166959/628_x_628_copertina_sito-1.jpg" 
+													alt="Paganini Paradise. Superlive Immersive Concert" 
+													style=""/>
+											</a>
+										</figure>
+									</div>
+									<div class="col-lg-6">
+										<section class="ctn-text">
+																							<div class="tag">Concerto</div>
+																							<div class="tag">2026</div>
+																						<header class="heading">
+												<h2 class="subtitle">
+													<a href="/arena-opera-festival/paganini-paradise/" title="Scopri di più">
+														Paganini Paradise. Superlive Immersive Concert
+													</a>
+												</h2>
+											</header>
+											<div class="txt big">
+												<p></p>
+											</div>
+											<div class="txt">
+												<p>Un&#039;anteprima mondiale e la celebrazione di virtuosismo, emozione e tecnologia</p>
+												<p></p>
+											</div>
+											
+                                                                                            
+	<div class="data-show ">
+		<div class="int">			<div class="tit">
+				<span class="icon calendar"></span>
+				<span class="label">Prossima data</span>
+			</div>
+            <ul>
+            				<li>
+					Il
+					<time datetime="2026-08-18T00:00">
+						18.08
+					</time>
+				</li>
+			            </ul>
+		</div>	</div>
+
+                                            
+											<div class="buttons-bar">
+                                                												                                <a href="https://shop.fondazionearena.it/it/event/paganini-paradise/291849" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+    												                                                <a href="/arena-opera-festival/paganini-paradise/" class="btn secondary small full-down-sm" title="Scopri di più">
+													<span class="label">Scopri di più</span>
+												</a>
+											</div>
+										</section>
+									</div>
+								</div>
+							</div>
+						</article>
+					
+						<article class="box-show bh-calendarShow" data-filter-artist="39605" data-filter-type="OPERA" data-filter-genre="2940" data-filter-season="129831"
+                            style=""
+                        >
+							<div class="container">
+								<div class="row gy-4">
+									<div class="col-lg-6">
+										<figure class="ctn-img">
+											<a href="/arena-opera-festival/viva-vivaldi/" title="Scopri di più">
+												<img 
+													class="bh-lasy-image" 
+													src="/site/assets/files/131308/viva_vivaldi.jpg"
+													data-src="/site/assets/files/131308/viva_vivaldi.jpg" 
+													alt="Viva Vivaldi. The Four Seasons Immersive Concert" 
+													style=""/>
+											</a>
+										</figure>
+									</div>
+									<div class="col-lg-6">
+										<section class="ctn-text">
+																							<div class="tag">Concerto</div>
+																							<div class="tag">2026</div>
+																						<header class="heading">
+												<h2 class="subtitle">
+													<a href="/arena-opera-festival/viva-vivaldi/" title="Scopri di più">
+														Viva Vivaldi. The Four Seasons Immersive Concert
+													</a>
+												</h2>
+											</header>
+											<div class="txt big">
+												<p></p>
+											</div>
+											<div class="txt">
+												<p>Lo spettacolo immersivo con proiezioni 3D che ha rivoluzionato l’idea di concerto sinfonico</p>
+												<p></p>
+											</div>
+											
+                                                                                            
+	<div class="data-show ">
+		<div class="int">			<div class="tit">
+				<span class="icon calendar"></span>
+				<span class="label">Prossima data</span>
+			</div>
+            <ul>
+            				<li>
+					Il
+					<time datetime="2026-08-19T00:00">
+						19.08
+					</time>
+				</li>
+			            </ul>
+		</div>	</div>
+
+                                            
+											<div class="buttons-bar">
+                                                												                                <a href="https://shop.fondazionearena.it/?filter_show=Viva%20Vivaldi.%20The%20Four%20Seasons%20Immersive%20Concert" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+    												                                                <a href="/arena-opera-festival/viva-vivaldi/" class="btn secondary small full-down-sm" title="Scopri di più">
+													<span class="label">Scopri di più</span>
+												</a>
+											</div>
+										</section>
+									</div>
+								</div>
+							</div>
+						</article>
+					
+						<article class="box-show bh-calendarShow" data-filter-artist="" data-filter-type="OPERA" data-filter-genre="2941" data-filter-season="129831"
+                            style="display:none"
+                        >
+							<div class="container">
+								<div class="row gy-4">
+									<div class="col-lg-6">
+										<figure class="ctn-img">
+											<a href="/arena-opera-festival/balletto/" title="Scopri di più">
+												<img 
+													class="bh-lasy-image" 
+													
+													data-src="/site/assets/files/131340/zorba-arena-di-verona-1.jpg" 
+													alt="Zorba il greco" 
+													style="display:none"/>
+											</a>
+										</figure>
+									</div>
+									<div class="col-lg-6">
+										<section class="ctn-text">
+																							<div class="tag">Balletto</div>
+																							<div class="tag">2026</div>
+																						<header class="heading">
+												<h2 class="subtitle">
+													<a href="/arena-opera-festival/balletto/" title="Scopri di più">
+														Zorba il greco
+													</a>
+												</h2>
+											</header>
+											<div class="txt big">
+												<p>Mikis Theodorakis</p>
+											</div>
+											<div class="txt">
+												<p>Zorba il greco ritorna al Teatro Romano di Verona per una serata unica a ritmo di sirtaki!</p>
+												<p></p>
+											</div>
+											
+                                                                                            
+	<div class="data-show ">
+		<div class="int">			<div class="tit">
+				<span class="icon calendar"></span>
+				<span class="label">Prossime date</span>
+			</div>
+            <ul>
+            				<li>
+					Dal
+					<time datetime="2026-08-25T00:00">
+						25.08
+					</time>
+					al
+					<time datetime="2026-08-26T00:00">
+						26.08
+					</time>
+				</li>
+			            </ul>
+		</div>	</div>
+
+                                            
+											<div class="buttons-bar">
+                                                												                                <a href="https://shop.fondazionearena.it/it/buy-ticket/arenaverona-tutto/?filter_show=Zorba%20il%20Greco" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+    												                                                <a href="/arena-opera-festival/balletto/" class="btn secondary small full-down-sm" title="Scopri di più">
+													<span class="label">Scopri di più</span>
+												</a>
+											</div>
+										</section>
+									</div>
+								</div>
+							</div>
+						</article>
+					
+						<article class="box-show bh-calendarShow" data-filter-artist="67571|67503|66675" data-filter-type="TEATRO" data-filter-genre="31940" data-filter-season="156866"
+                            style="display:none"
+                        >
+							<div class="container">
+								<div class="row gy-4">
+									<div class="col-lg-6">
+										<figure class="ctn-img">
+											<a href="/teatro-filarmonico-verona/gounod-nielsen-dvorak-serenate-e-sinfonie-per-fiati/" title="Scopri di più">
+												<img 
+													class="bh-lasy-image" 
+													
+													data-src="/site/assets/files/169772/accadeimia_agricoltura-1.jpg" 
+													alt="Gounod, Nielsen, Dvořák | Serenate e sinfonie per fiati" 
+													style="display:none"/>
+											</a>
+										</figure>
+									</div>
+									<div class="col-lg-6">
+										<section class="ctn-text">
+																							<div class="tag">Musica da camera</div>
+																						<header class="heading">
+												<h2 class="subtitle">
+													<a href="/teatro-filarmonico-verona/gounod-nielsen-dvorak-serenate-e-sinfonie-per-fiati/" title="Scopri di più">
+														Gounod, Nielsen, Dvořák | Serenate e sinfonie per fiati
+													</a>
+												</h2>
+											</header>
+											<div class="txt big">
+												<p>Charles Gounod, Carl Nielsen, Antonin Dvořák</p>
+											</div>
+											<div class="txt">
+												<p>L&#039;ottavo concerto di Musei in Musica 2026</p>
+												<p></p>
+											</div>
+											
+                                                                                            
+	<div class="data-show ">
+		<div class="int">			<div class="tit">
+				<span class="icon calendar"></span>
+				<span class="label">Prossima data</span>
+			</div>
+            <ul>
+            				<li>
+					Il
+					<time datetime="2026-10-18T00:00">
+						18.10
+					</time>
+				</li>
+			            </ul>
+		</div>	</div>
+
+                                            
+											<div class="buttons-bar">
+                                                												                                <a href="https://shop.fondazionearena.it/it/event/gounod-nielsen-dvorak-serenate-e-sinfonie-per-fiati/291081" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+    												                                                <a href="/teatro-filarmonico-verona/gounod-nielsen-dvorak-serenate-e-sinfonie-per-fiati/" class="btn secondary small full-down-sm" title="Scopri di più">
+													<span class="label">Scopri di più</span>
+												</a>
+											</div>
+										</section>
+									</div>
+								</div>
+							</div>
+						</article>
+					
+						<article class="box-show bh-calendarShow" data-filter-artist="" data-filter-type="TEATRO" data-filter-genre="169222" data-filter-season="156866"
+                            style="display:none"
+                        >
+							<div class="container">
+								<div class="row gy-4">
+									<div class="col-lg-6">
+										<figure class="ctn-img">
+											<a href="/teatro-filarmonico-verona/strictly-ballroom-proiezione/" title="Scopri di più">
+												<img 
+													class="bh-lasy-image" 
+													
+													data-src="/site/assets/files/169302/6.jpg" 
+													alt="Strictly Ballroom | Proiezione" 
+													style="display:none"/>
+											</a>
+										</figure>
+									</div>
+									<div class="col-lg-6">
+										<section class="ctn-text">
+																							<div class="tag">Proiezione</div>
+																						<header class="heading">
+												<h2 class="subtitle">
+													<a href="/teatro-filarmonico-verona/strictly-ballroom-proiezione/" title="Scopri di più">
+														Strictly Ballroom | Proiezione
+													</a>
+												</h2>
+											</header>
+											<div class="txt big">
+												<p>Baz Luhrmann</p>
+											</div>
+											<div class="txt">
+												<p>Il quarto appuntamento della rassegna &quot;Musica e cinema&quot;</p>
+												<p></p>
+											</div>
+											
+                                                                                            
+	<div class="data-show ">
+		<div class="int">			<div class="tit">
+				<span class="icon calendar"></span>
+				<span class="label">Prossima data</span>
+			</div>
+            <ul>
+            				<li>
+					Il
+					<time datetime="2026-10-24T00:00">
+						24.10
+					</time>
+				</li>
+			            </ul>
+		</div>	</div>
+
+                                            
+											<div class="buttons-bar">
+                                                												                                <a href="https://shop.fondazionearena.it/it/event/strictly-ballroom-di-b-luhrmann/288970" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+    												                                                <a href="/teatro-filarmonico-verona/strictly-ballroom-proiezione/" class="btn secondary small full-down-sm" title="Scopri di più">
+													<span class="label">Scopri di più</span>
+												</a>
+											</div>
+										</section>
+									</div>
+								</div>
+							</div>
+						</article>
+					
+						<article class="box-show bh-calendarShow" data-filter-artist="27792|27554|28768|123286|27792|27554|28768|123286|27792|27554|28768|123286|27792|27554|28768|123286" data-filter-type="TEATRO" data-filter-genre="1133" data-filter-season="156866"
+                            style="display:none"
+                        >
+							<div class="container">
+								<div class="row gy-4">
+									<div class="col-lg-6">
+										<figure class="ctn-img">
+											<a href="/teatro-filarmonico-verona/amelia-al-ballo-jeu-de-cartes/" title="Scopri di più">
+												<img 
+													class="bh-lasy-image" 
+													
+													data-src="/site/assets/files/157055/amelia_al_ballo_-_interno_appartamento_amelia_-_300dpi-1.jpg" 
+													alt="Jeu de Cartes | Amelia al ballo" 
+													style="display:none"/>
+											</a>
+										</figure>
+									</div>
+									<div class="col-lg-6">
+										<section class="ctn-text">
+																							<div class="tag">Opera</div>
+																							<div class="tag">Balletto</div>
+																						<header class="heading">
+												<h2 class="subtitle">
+													<a href="/teatro-filarmonico-verona/amelia-al-ballo-jeu-de-cartes/" title="Scopri di più">
+														Jeu de Cartes | Amelia al ballo
+													</a>
+												</h2>
+											</header>
+											<div class="txt big">
+												<p>Gian Carlo Menotti, Igor Stravinsky</p>
+											</div>
+											<div class="txt">
+												<p>Balletto in tre mani di Igor Stravinsky | Opera buffa in un atto di Gian Carlo Menotti</p>
+												<p></p>
+											</div>
+											
+                                                                                            
+	<div class="data-show ">
+		<div class="int">			<div class="tit">
+				<span class="icon calendar"></span>
+				<span class="label">Prossime date</span>
+			</div>
+            <ul>
+            				<li>
+					Dal
+					<time datetime="2026-10-25T00:00">
+						25.10
+					</time>
+					al
+					<time datetime="2026-11-01T00:00">
+						01.11
+					</time>
+				</li>
+			            </ul>
+		</div>	</div>
+
+                                            
+											<div class="buttons-bar">
+                                                												                                <a href="https://shop.fondazionearena.it/it/buy-ticket/arenaverona-tutto/?filter_show=Jeu%20De%20Cartes%20/%20Amelia%20Al%20Ballo" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+    												                                                <a href="/teatro-filarmonico-verona/amelia-al-ballo-jeu-de-cartes/" class="btn secondary small full-down-sm" title="Scopri di più">
+													<span class="label">Scopri di più</span>
+												</a>
+											</div>
+										</section>
+									</div>
+								</div>
+							</div>
+						</article>
+					
+						<article class="box-show bh-calendarShow" data-filter-artist="" data-filter-type="TEATRO" data-filter-genre="2940" data-filter-season="156866"
+                            style="display:none"
+                        >
+							<div class="container">
+								<div class="row gy-4">
+									<div class="col-lg-6">
+										<figure class="ctn-img">
+											<a href="/teatro-filarmonico-verona/sinfonie-4-6-aspettando-beethoven/" title="Scopri di più">
+												<img 
+													class="bh-lasy-image" 
+													
+													data-src="/site/assets/files/173027/3.jpg" 
+													alt="Sinfonie n. 4, 6 | Aspettando Beethoven" 
+													style="display:none"/>
+											</a>
+										</figure>
+									</div>
+									<div class="col-lg-6">
+										<section class="ctn-text">
+																							<div class="tag">Concerto</div>
+																						<header class="heading">
+												<h2 class="subtitle">
+													<a href="/teatro-filarmonico-verona/sinfonie-4-6-aspettando-beethoven/" title="Scopri di più">
+														Sinfonie n. 4, 6 | Aspettando Beethoven
+													</a>
+												</h2>
+											</header>
+											<div class="txt big">
+												<p>Ludwig van Beethoven</p>
+											</div>
+											<div class="txt">
+												<p>Il terzo concerto di &quot;Aspettando Beethoven&quot;</p>
+												<p></p>
+											</div>
+											
+                                                                                            
+	<div class="data-show ">
+		<div class="int">			<div class="tit">
+				<span class="icon calendar"></span>
+				<span class="label">Prossima data</span>
+			</div>
+            <ul>
+            				<li>
+					Il
+					<time datetime="2026-10-31T00:00">
+						31.10
+					</time>
+				</li>
+			            </ul>
+		</div>	</div>
+
+                                            
+											<div class="buttons-bar">
+                                                												                                <a href="https://shop.fondazionearena.it/it/event/aspettando-beethoven-sinfonie-n-4-6/293077" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+    												                                                <a href="/teatro-filarmonico-verona/sinfonie-4-6-aspettando-beethoven/" class="btn secondary small full-down-sm" title="Scopri di più">
+													<span class="label">Scopri di più</span>
+												</a>
+											</div>
+										</section>
+									</div>
+								</div>
+							</div>
+						</article>
+					
+						<article class="box-show bh-calendarShow" data-filter-artist="" data-filter-type="TEATRO" data-filter-genre="2940" data-filter-season="156866"
+                            style="display:none"
+                        >
+							<div class="container">
+								<div class="row gy-4">
+									<div class="col-lg-6">
+										<figure class="ctn-img">
+											<a href="/teatro-filarmonico-verona/brahms-serenata/" title="Scopri di più">
+												<img 
+													class="bh-lasy-image" 
+													
+													data-src="/site/assets/files/157375/8_concerto-1.jpg" 
+													alt="Brahms Serenata" 
+													style="display:none"/>
+											</a>
+										</figure>
+									</div>
+									<div class="col-lg-6">
+										<section class="ctn-text">
+																							<div class="tag">Concerto</div>
+																						<header class="heading">
+												<h2 class="subtitle">
+													<a href="/teatro-filarmonico-verona/brahms-serenata/" title="Scopri di più">
+														Brahms Serenata
+													</a>
+												</h2>
+											</header>
+											<div class="txt big">
+												<p>Johannes Brahms, Johann Nepomuk Hummel</p>
+											</div>
+											<div class="txt">
+												<p>L&#039;ottavo concerto della stagione sinfonica 2026 al Teatro Filarmonico</p>
+												<p></p>
+											</div>
+											
+                                                                                            
+	<div class="data-show ">
+		<div class="int">			<div class="tit">
+				<span class="icon calendar"></span>
+				<span class="label">Prossime date</span>
+			</div>
+            <ul>
+            				<li>
+					Dal
+					<time datetime="2026-11-06T00:00">
+						06.11
+					</time>
+					al
+					<time datetime="2026-11-07T00:00">
+						07.11
+					</time>
+				</li>
+			            </ul>
+		</div>	</div>
+
+                                            
+											<div class="buttons-bar">
+                                                												                                <a href="https://shop.fondazionearena.it/it/buy-ticket/arenaverona-tutto/?filter_show=8%20Concerto%20-%20Brahms%20Serenata" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+    												                                                <a href="/teatro-filarmonico-verona/brahms-serenata/" class="btn secondary small full-down-sm" title="Scopri di più">
+													<span class="label">Scopri di più</span>
+												</a>
+											</div>
+										</section>
+									</div>
+								</div>
+							</div>
+						</article>
+					
+						<article class="box-show bh-calendarShow" data-filter-artist="" data-filter-type="TEATRO" data-filter-genre="31940" data-filter-season="156866"
+                            style="display:none"
+                        >
+							<div class="container">
+								<div class="row gy-4">
+									<div class="col-lg-6">
+										<figure class="ctn-img">
+											<a href="/teatro-filarmonico-verona/beethoven-schubert-quartetti-per-archi/" title="Scopri di più">
+												<img 
+													class="bh-lasy-image" 
+													
+													data-src="/site/assets/files/169899/museo_nicolis_villafranca_verona-_lancia_astura_berlina_del_1936-_ph_mercazin-1.jpg" 
+													alt="Beethoven, Schubert | Quartetti per archi" 
+													style="display:none"/>
+											</a>
+										</figure>
+									</div>
+									<div class="col-lg-6">
+										<section class="ctn-text">
+																							<div class="tag">Musica da camera</div>
+																						<header class="heading">
+												<h2 class="subtitle">
+													<a href="/teatro-filarmonico-verona/beethoven-schubert-quartetti-per-archi/" title="Scopri di più">
+														Beethoven, Schubert | Quartetti per archi
+													</a>
+												</h2>
+											</header>
+											<div class="txt big">
+												<p>Ludwig van Beethoven, Franz Schubert</p>
+											</div>
+											<div class="txt">
+												<p>Il nono concerto di Musei in Musica 2026</p>
+												<p></p>
+											</div>
+											
+                                                                                            
+	<div class="data-show ">
+		<div class="int">			<div class="tit">
+				<span class="icon calendar"></span>
+				<span class="label">Prossima data</span>
+			</div>
+            <ul>
+            				<li>
+					Il
+					<time datetime="2026-11-08T00:00">
+						08.11
+					</time>
+				</li>
+			            </ul>
+		</div>	</div>
+
+                                            
+											<div class="buttons-bar">
+                                                												                                <a href="https://shop.fondazionearena.it/it/event/beethoven-schubert-quartetti-per-archi/291084" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+    												                                                <a href="/teatro-filarmonico-verona/beethoven-schubert-quartetti-per-archi/" class="btn secondary small full-down-sm" title="Scopri di più">
+													<span class="label">Scopri di più</span>
+												</a>
+											</div>
+										</section>
+									</div>
+								</div>
+							</div>
+						</article>
+					
+						<article class="box-show bh-calendarShow" data-filter-artist="" data-filter-type="TEATRO" data-filter-genre="169222" data-filter-season="156866"
+                            style="display:none"
+                        >
+							<div class="container">
+								<div class="row gy-4">
+									<div class="col-lg-6">
+										<figure class="ctn-img">
+											<a href="/teatro-filarmonico-verona/the-dreamers-proiezione/" title="Scopri di più">
+												<img 
+													class="bh-lasy-image" 
+													
+													data-src="/site/assets/files/169338/7.jpg" 
+													alt="The Dreamers | Proiezione" 
+													style="display:none"/>
+											</a>
+										</figure>
+									</div>
+									<div class="col-lg-6">
+										<section class="ctn-text">
+																							<div class="tag">Proiezione</div>
+																						<header class="heading">
+												<h2 class="subtitle">
+													<a href="/teatro-filarmonico-verona/the-dreamers-proiezione/" title="Scopri di più">
+														The Dreamers | Proiezione
+													</a>
+												</h2>
+											</header>
+											<div class="txt big">
+												<p>Bernardo Bertolucci</p>
+											</div>
+											<div class="txt">
+												<p>Il quinto appuntamento della rassegna &quot;Musica e cinema&quot;</p>
+												<p></p>
+											</div>
+											
+                                                                                            
+	<div class="data-show ">
+		<div class="int">			<div class="tit">
+				<span class="icon calendar"></span>
+				<span class="label">Prossima data</span>
+			</div>
+            <ul>
+            				<li>
+					Il
+					<time datetime="2026-11-21T00:00">
+						21.11
+					</time>
+				</li>
+			            </ul>
+		</div>	</div>
+
+                                            
+											<div class="buttons-bar">
+                                                												                                <a href="https://shop.fondazionearena.it/it/event/the-dreamers-di-b-bertolucci/288971" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+    												                                                <a href="/teatro-filarmonico-verona/the-dreamers-proiezione/" class="btn secondary small full-down-sm" title="Scopri di più">
+													<span class="label">Scopri di più</span>
+												</a>
+											</div>
+										</section>
+									</div>
+								</div>
+							</div>
+						</article>
+					
+						<article class="box-show bh-calendarShow" data-filter-artist="" data-filter-type="TEATRO" data-filter-genre="2940" data-filter-season="156866"
+                            style="display:none"
+                        >
+							<div class="container">
+								<div class="row gy-4">
+									<div class="col-lg-6">
+										<figure class="ctn-img">
+											<a href="/teatro-filarmonico-verona/sinfonie-7-8-aspettando-beethoven/" title="Scopri di più">
+												<img 
+													class="bh-lasy-image" 
+													
+													data-src="/site/assets/files/173141/4.jpg" 
+													alt="Sinfonie n. 7, 8 | Aspettando Beethoven" 
+													style="display:none"/>
+											</a>
+										</figure>
+									</div>
+									<div class="col-lg-6">
+										<section class="ctn-text">
+																							<div class="tag">Concerto</div>
+																						<header class="heading">
+												<h2 class="subtitle">
+													<a href="/teatro-filarmonico-verona/sinfonie-7-8-aspettando-beethoven/" title="Scopri di più">
+														Sinfonie n. 7, 8 | Aspettando Beethoven
+													</a>
+												</h2>
+											</header>
+											<div class="txt big">
+												<p>Ludwig van Beethoven</p>
+											</div>
+											<div class="txt">
+												<p>Il quarto concerto di &quot;Aspettando Beethoven&quot;</p>
+												<p></p>
+											</div>
+											
+                                                                                            
+	<div class="data-show ">
+		<div class="int">			<div class="tit">
+				<span class="icon calendar"></span>
+				<span class="label">Prossima data</span>
+			</div>
+            <ul>
+            				<li>
+					Il
+					<time datetime="2026-11-21T00:00">
+						21.11
+					</time>
+				</li>
+			            </ul>
+		</div>	</div>
+
+                                            
+											<div class="buttons-bar">
+                                                												                                <a href="https://shop.fondazionearena.it/it/event/aspettando-beethoven-sinfonie-n-7-8/293078" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+    												                                                <a href="/teatro-filarmonico-verona/sinfonie-7-8-aspettando-beethoven/" class="btn secondary small full-down-sm" title="Scopri di più">
+													<span class="label">Scopri di più</span>
+												</a>
+											</div>
+										</section>
+									</div>
+								</div>
+							</div>
+						</article>
+					
+						<article class="box-show bh-calendarShow" data-filter-artist="26755|84072|64691|123856|26755|84072|64691|123856|26755|84072|64691|123856|26755|84072|64691|123856" data-filter-type="TEATRO" data-filter-genre="1133" data-filter-season="156866"
+                            style="display:none"
+                        >
+							<div class="container">
+								<div class="row gy-4">
+									<div class="col-lg-6">
+										<figure class="ctn-img">
+											<a href="/teatro-filarmonico-verona/la-boheme/" title="Scopri di più">
+												<img 
+													class="bh-lasy-image" 
+													
+													data-src="/site/assets/files/157087/labohe_me_111222_ennevifoto_272-1.jpg" 
+													alt="La Bohème" 
+													style="display:none"/>
+											</a>
+										</figure>
+									</div>
+									<div class="col-lg-6">
+										<section class="ctn-text">
+																							<div class="tag">Opera</div>
+																						<header class="heading">
+												<h2 class="subtitle">
+													<a href="/teatro-filarmonico-verona/la-boheme/" title="Scopri di più">
+														La Bohème
+													</a>
+												</h2>
+											</header>
+											<div class="txt big">
+												<p>Giacomo Puccini</p>
+											</div>
+											<div class="txt">
+												<p>Opera in quattro quadri di Giacomo Puccini su libretto di Giuseppe Giacosa e Luigi Illica nel 130° anniversario della prima assoluta</p>
+												<p></p>
+											</div>
+											
+                                                                                            
+	<div class="data-show ">
+		<div class="int">			<div class="tit">
+				<span class="icon calendar"></span>
+				<span class="label">Prossime date</span>
+			</div>
+            <ul>
+            				<li>
+					Dal
+					<time datetime="2026-11-22T00:00">
+						22.11
+					</time>
+					al
+					<time datetime="2026-11-29T00:00">
+						29.11
+					</time>
+				</li>
+			            </ul>
+		</div>	</div>
+
+                                            
+											<div class="buttons-bar">
+                                                												                                <a href="https://shop.fondazionearena.it/it/buy-ticket/arenaverona-tutto/?filter_show=La%20Boh%C3%A8me%20al%20Filarmonico" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+    												                                                <a href="/teatro-filarmonico-verona/la-boheme/" class="btn secondary small full-down-sm" title="Scopri di più">
+													<span class="label">Scopri di più</span>
+												</a>
+											</div>
+										</section>
+									</div>
+								</div>
+							</div>
+						</article>
+					
+						<article class="box-show bh-calendarShow" data-filter-artist="66675|67707" data-filter-type="TEATRO" data-filter-genre="31940" data-filter-season="156866"
+                            style="display:none"
+                        >
+							<div class="container">
+								<div class="row gy-4">
+									<div class="col-lg-6">
+										<figure class="ctn-img">
+											<a href="/teatro-filarmonico-verona/mozart-kreutzer-duo-e-settimino/" title="Scopri di più">
+												<img 
+													class="bh-lasy-image" 
+													
+													data-src="/site/assets/files/170015/museo_affreschi_img_07-1.jpg" 
+													alt="Mozart, Kreutzer | Duo e Settimino" 
+													style="display:none"/>
+											</a>
+										</figure>
+									</div>
+									<div class="col-lg-6">
+										<section class="ctn-text">
+																							<div class="tag">Musica da camera</div>
+																						<header class="heading">
+												<h2 class="subtitle">
+													<a href="/teatro-filarmonico-verona/mozart-kreutzer-duo-e-settimino/" title="Scopri di più">
+														Mozart, Kreutzer | Duo e Settimino
+													</a>
+												</h2>
+											</header>
+											<div class="txt big">
+												<p>Wolfgang Amadeus Mozart, Conradin Kreutzer</p>
+											</div>
+											<div class="txt">
+												<p>Il decimo concerto di Musei in Musica 2026</p>
+												<p></p>
+											</div>
+											
+                                                                                            
+	<div class="data-show ">
+		<div class="int">			<div class="tit">
+				<span class="icon calendar"></span>
+				<span class="label">Prossima data</span>
+			</div>
+            <ul>
+            				<li>
+					Il
+					<time datetime="2026-11-29T00:00">
+						29.11
+					</time>
+				</li>
+			            </ul>
+		</div>	</div>
+
+                                            
+											<div class="buttons-bar">
+                                                												                                <a href="https://shop.fondazionearena.it/it/event/mozart-kreutzer-duo-e-settimino/291083" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+    												                                                <a href="/teatro-filarmonico-verona/mozart-kreutzer-duo-e-settimino/" class="btn secondary small full-down-sm" title="Scopri di più">
+													<span class="label">Scopri di più</span>
+												</a>
+											</div>
+										</section>
+									</div>
+								</div>
+							</div>
+						</article>
+					
+						<article class="box-show bh-calendarShow" data-filter-artist="" data-filter-type="TEATRO" data-filter-genre="169222" data-filter-season="156866"
+                            style="display:none"
+                        >
+							<div class="container">
+								<div class="row gy-4">
+									<div class="col-lg-6">
+										<figure class="ctn-img">
+											<a href="/teatro-filarmonico-verona/black-swan-proiezione/" title="Scopri di più">
+												<img 
+													class="bh-lasy-image" 
+													
+													data-src="/site/assets/files/169374/2.jpg" 
+													alt="Black Swan | Proiezione" 
+													style="display:none"/>
+											</a>
+										</figure>
+									</div>
+									<div class="col-lg-6">
+										<section class="ctn-text">
+																							<div class="tag">Proiezione</div>
+																						<header class="heading">
+												<h2 class="subtitle">
+													<a href="/teatro-filarmonico-verona/black-swan-proiezione/" title="Scopri di più">
+														Black Swan | Proiezione
+													</a>
+												</h2>
+											</header>
+											<div class="txt big">
+												<p>Darren Aronofsky</p>
+											</div>
+											<div class="txt">
+												<p>Il sesto e ultimo appuntamento della rassegna &quot;Musica e cinema&quot;</p>
+												<p></p>
+											</div>
+											
+                                                                                            
+	<div class="data-show ">
+		<div class="int">			<div class="tit">
+				<span class="icon calendar"></span>
+				<span class="label">Prossima data</span>
+			</div>
+            <ul>
+            				<li>
+					Il
+					<time datetime="2026-12-12T00:00">
+						12.12
+					</time>
+				</li>
+			            </ul>
+		</div>	</div>
+
+                                            
+											<div class="buttons-bar">
+                                                												                                <a href="https://shop.fondazionearena.it/it/event/black-swan-di-d-aronovsky/288967" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+    												                                                <a href="/teatro-filarmonico-verona/black-swan-proiezione/" class="btn secondary small full-down-sm" title="Scopri di più">
+													<span class="label">Scopri di più</span>
+												</a>
+											</div>
+										</section>
+									</div>
+								</div>
+							</div>
+						</article>
+					
+						<article class="box-show bh-calendarShow" data-filter-artist="" data-filter-type="TEATRO" data-filter-genre="2941" data-filter-season="156866"
+                            style="display:none"
+                        >
+							<div class="container">
+								<div class="row gy-4">
+									<div class="col-lg-6">
+										<figure class="ctn-img">
+											<a href="/teatro-filarmonico-verona/il-lago-dei-cigni/" title="Scopri di più">
+												<img 
+													class="bh-lasy-image" 
+													
+													data-src="/site/assets/files/157119/lagodeicigni_ennevifoto_151224_dscf4571-1.jpg" 
+													alt="Il Lago dei Cigni" 
+													style="display:none"/>
+											</a>
+										</figure>
+									</div>
+									<div class="col-lg-6">
+										<section class="ctn-text">
+																							<div class="tag">Balletto</div>
+																						<header class="heading">
+												<h2 class="subtitle">
+													<a href="/teatro-filarmonico-verona/il-lago-dei-cigni/" title="Scopri di più">
+														Il Lago dei Cigni
+													</a>
+												</h2>
+											</header>
+											<div class="txt big">
+												<p>Pëtr Il’ič Čajkovskij</p>
+											</div>
+											<div class="txt">
+												<p>Balletto in un quattro atti di Pëtr Il’ič Čajkovskij nel 150° anniversario della composizione</p>
+												<p></p>
+											</div>
+											
+                                                                                            
+	<div class="data-show ">
+		<div class="int">			<div class="tit">
+				<span class="icon calendar"></span>
+				<span class="label">Prossime date</span>
+			</div>
+            <ul>
+            				<li>
+					Dal
+					<time datetime="2026-12-13T00:00">
+						13.12
+					</time>
+					al
+					<time datetime="2026-12-31T00:00">
+						31.12
+					</time>
+				</li>
+			            </ul>
+		</div>	</div>
+
+                                            
+											<div class="buttons-bar">
+                                                												                                <a href="https://shop.fondazionearena.it/it/buy-ticket/arenaverona-tutto/?filter_show=Il%20Lago%20Dei%20Cigni" class="btn primary small full-down-sm" title="Acquista" target="_blank">
+                            <span class="icon buy  left"></span>
+                        <span class="label">Acquista</span>
+        </a>
+    												                                                <a href="/teatro-filarmonico-verona/il-lago-dei-cigni/" class="btn secondary small full-down-sm" title="Scopri di più">
+													<span class="label">Scopri di più</span>
+												</a>
+											</div>
+										</section>
+									</div>
+								</div>
+							</div>
+						</article>
+					
+				</div>
+			</div>
+			<div class="pagination bh-paginationPanel">
+				<div class="content">
+					<div class="container">
+						<div class="row">
+							<div class="col">
+								<ul class="bh-paginationList"></ul>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>    
+            
+    
+	
+
+
+<div class="panel-default">
+	<div class="ctn-title-special">
+		<header class="heading spacer-bottom-1">
+			<h2 class="title special small">Soci Fondatori e Partner</h2>
+		</header>
+	</div>
+	<div class="ctn-loghi">
+		<div class="content">
+			<div class="container">
+
+				
+										
+					
+						<style>
+							.listing-loghi.m_s li img {
+								height: 70px !important;
+							}
+
+							@media(max-width: 1400px) {
+								.listing-loghi.m_s li img {
+									height: 50px !important;
+								}
+							}
+						</style>
+
+                                                    						                            
+                        						
+						<div class="row gy-4">
+							<div class="col">
+								<div class="toolbar center">
+									<header class="heading">
+										<h3 class="title-base bold ">Soci Fondatori</h3>
+									</header>
+								</div>
+																	<ul class="listing-loghi m_s">
+																																																																																							<li>
+												<figure>
+																											<img src="/site/assets/files/25586/logo-repubblica.png" alt=""/>
+																										</figure>
+											</li>
+																																																																																							<li>
+												<figure>
+																											<img src="/site/assets/files/25580/logo-ministero-della-cultura.png" alt=""/>
+																										</figure>
+											</li>
+																																																																																							<li>
+												<figure>
+																											<img src="/site/assets/files/25583/logo-regione-del-veneto.png" alt=""/>
+																										</figure>
+											</li>
+																																																																																							<li>
+												<figure>
+																											<img src="/site/assets/files/25577/logo-comune-di-verona.png" alt=""/>
+																										</figure>
+											</li>
+																																																																																							<li>
+												<figure>
+																											<img src="/site/assets/files/25571/logo-camera-di-commercio.png" alt=""/>
+																										</figure>
+											</li>
+																																																																																							<li>
+												<figure>
+																											<img src="/site/assets/files/25574/generali_orizzontale_sito.png" alt=""/>
+																										</figure>
+											</li>
+																			</ul>
+															</div>
+
+													</div>
+
+					
+
+				
+										
+					
+						<style>
+							.listing-loghi.m_s li img {
+								height: 70px !important;
+							}
+
+							@media(max-width: 1400px) {
+								.listing-loghi.m_s li img {
+									height: 50px !important;
+								}
+							}
+						</style>
+
+                        
+                                                    						                            						
+						<div class="row gy-4">
+							<div class="col-md-6 col-lg-6">
+								<div class="toolbar center">
+									<header class="heading">
+										<h3 class="title-base bold center">Main Partner Arena di Verona Opera Festival</h3>
+									</header>
+								</div>
+																	<ul class="listing-loghi m_s">
+																																																																																							<li>
+												<figure>
+																											<a href="https://www.unicreditgroup.eu/en.html" rel="noopener">
+																												<img src="/site/assets/files/79426/logo-unicredit.png" alt=""/>
+																												</a>
+																									</figure>
+											</li>
+																			</ul>
+															</div>
+
+															<div class="col-md-6 col-lg-6">
+									<div class="toolbar center">
+										<header class="heading">
+											<h3 class="title-base bold center">Major Partner Arena di Verona Opera Festival</h3>
+										</header>
+									</div>
+																			<ul class="listing-loghi m_s">
+																																																																																															<li>
+													<figure>
+																													<a href="https://www.vivaticket.com/" rel="noopener">
+																														<img src="/site/assets/files/166251/vivaticket_logo_sito.png" alt=""/>
+																														</a>
+																											</figure>
+												</li>
+																					</ul>
+																	</div>
+													</div>
+
+					
+
+				
+			</div>
+		</div>
+	</div>
+</div>
+    
+
+		</div>
+
+		
+
+
+		<footer class="footer">
+	<div class="content">
+		<div class="container">
+			<div class="row">
+				<div class="col-lg-6">
+					<div class="logo vertical">
+																		<a href="" title="Fondazione - Arena di Verona">Fondazione - Arena di Verona</a>
+					</div>
+
+																					
+                        						
+                        <nav aria-labelledby="footermenusocial" class="menu-social">
+							<h3 id="footermenusocial" title="Menu Social">Seguici su</h3>
+							<ul>
+																	<li>
+										<a href="https://www.instagram.com/arenadiverona/" class="icon instagram-light " title="Instagram">Instagram</a>
+									</li>
+																	<li>
+										<a href="https://www.facebook.com/arenaverona" class="icon facebook-light " title="Facebook">Facebook</a>
+									</li>
+																	<li>
+										<a href="https://www.youtube.com/arenaverona" class="icon youtube-light " title="Youtube">Youtube</a>
+									</li>
+															</ul>
+						</nav>
+					
+					<div class="newsletter">
+						<div class="txt">
+							<p class="medium">
+								<strong>Restiamo in contatto!</strong>
+							</p>
+							<p>Iscriviti alla newsletter per ricevere gli ultimi aggiornamenti su programmi, iniziative, cast e promozioni</p>
+						</div>
+						<a href="https://www.arena.it/newsletter/" class="btn light" title="Iscriviti">
+							<span class="icon email-send light left"></span>
+							<span class="label">Iscriviti</span>
+						</a>
+					</div>
+
+				</div>
+				<div class="col-lg-3">
+					<nav aria-label="footermenumaincontents" class="menu-link">
+						<h3 class="visually-hidden" id="footermenumaincontents" title="Menu Contenuti">Menu Contenuti</h3>
+																		<ul>
+															<li>
+									<a href="/fondazione-arena/" title="La Fondazione Arena">La Fondazione Arena</a>
+																												<ul>
+																							<li>
+													<a href="/fondazione-arena/chi-siamo/" title="Chi siamo">Chi siamo</a>
+												</li>
+																							<li>
+													<a href="/fondazione-arena/personale-artistico/" title="Personale artistico">Personale artistico</a>
+												</li>
+																							<li>
+													<a href="/fondazione-arena/personale-tecnico-e-amministrativo/" title="Personale tecnico e amministrativo">Personale tecnico e amministrativo</a>
+												</li>
+																							<li>
+													<a href="/contattaci/" title="Contattaci">Contattaci</a>
+												</li>
+																							<li>
+													<a href="/fondazione-arena/statuto/" title="Statuto">Statuto</a>
+												</li>
+																					</ul>
+
+																	</li>
+															<li>
+									<a href="/trasparenza/" title="Trasparenza">Trasparenza</a>
+																												<ul>
+																							<li>
+													<a href="/trasparenza/amministrazione-trasparente/" title="Amministrazione trasparente">Amministrazione trasparente</a>
+												</li>
+																							<li>
+													<a href="/trasparenza/responsabilita-sociale/" title="Responsabilità sociale">Responsabilità sociale</a>
+												</li>
+																							<li>
+													<a href="/trasparenza/bandi-scaduti/" title="Bandi Scaduti">Bandi Scaduti</a>
+												</li>
+																					</ul>
+
+																	</li>
+															<li>
+									<a href="/all-defaults/" title="Le nostre opere">Le nostre opere</a>
+																										</li>
+															<li>
+									<a href="/history/" title="Stagioni passate">Stagioni passate</a>
+																										</li>
+															<li>
+									<a href="/artisti/" title="I nostri artisti">I nostri artisti</a>
+																										</li>
+															<li>
+									<a href="/area-stampa/" title="Area stampa">Area stampa</a>
+																										</li>
+															<li>
+									<a href="/arena-young/" title="Arena Young">Arena Young</a>
+																										</li>
+													</ul>
+					</nav>
+				</div>
+				<div class="col-lg-3">
+					<nav aria-label="footermenumaincontents" class="menu-link">
+						<h3 class="visually-hidden" id="footermenumaincontents" title="Menu Contenuti">Menu Contenuti</h3>
+																		<ul>
+															<li>
+									<a href="/contattaci/" title="Assistenza">Assistenza</a>
+																												<ul>
+																							<li>
+													<a href="/arena-opera-festival/domande-frequenti/" title="FAQs Arena Opera Festival">FAQs Arena Opera Festival</a>
+												</li>
+
+
+																							<li>
+													<a href="/teatro-filarmonico-verona/domande-frequenti/" title="FAQs Teatro Filarmonico">FAQs Teatro Filarmonico</a>
+												</li>
+
+
+																					</ul>
+
+																	</li>
+															<li>
+									<a href="/sostienici/" title="Sostienici">Sostienici</a>
+																												<ul>
+																							<li>
+													<a href="/sostienici/67-colonne/" title="67 colonne">67 colonne</a>
+												</li>
+
+
+																							<li>
+													<a href="/sostienici/sponsor-partners/" title="Sponsor&partners">Sponsor&partners</a>
+												</li>
+
+
+																					</ul>
+
+																	</li>
+															<li>
+									<a href="/lavora-con-noi/" title="Lavora con noi">Lavora con noi</a>
+																												<ul>
+																							<li>
+													<a href="/lavora-con-noi/ricerca-personale/" title="Ricerca personale">Ricerca personale</a>
+												</li>
+
+
+																							<li>
+													<a href="/lavora-con-noi/gare-e-appalti/" title="Gare e appalti">Gare e appalti</a>
+												</li>
+
+
+																					</ul>
+
+																	</li>
+															<li>
+									<a href="/arena-opera-festival/regolamento/" title="Regolamento Opera Festival">Regolamento Opera Festival</a>
+																										</li>
+															<li>
+									<a href="/teatro-filarmonico-verona/biglietti/regolamento/" title="Regolamento Teatro Filarmonico">Regolamento Teatro Filarmonico</a>
+																										</li>
+													</ul>
+					</nav>
+				</div>
+			</div>
+			<div class="row">
+				<div class="col-lg-6">
+					<div class="copy">
+						<p>&copy;2026
+							Fondazione Arena di Verona Reg.Imp.VR 14244/2000 | P.I.00231130238<br/>Sede legale: via Roma 7/d, 37121 Verona</p>
+					</div>
+				</div>
+				<div class="col-lg-6">
+																					<nav aria-label="footermenuservices" class="menu-link-services">
+							<h3 class="visually-hidden" id="footermenuservices">Menu Servizi</h3>
+							<ul>
+																	<li>
+										<a href="/accessibilita/" title="Accessibilità">Accessibilità</a>
+									</li>
+																	<li>
+										<a href="/privacy/" title="Privacy">Privacy</a>
+									</li>
+																	<li>
+										<a href="/credits/" title="Credits">Credits</a>
+									</li>
+																	<li>
+										<a href="/sitemap/" title="Sitemap">Sitemap</a>
+									</li>
+															</ul>
+						</nav>
+									</div>
+			</div>
+		</div>
+	</div>
+</footer>
+
+		<!-- scripts -->
+		 <script src="/site/templates/res/js/vendor.min.js?v=20260129"></script>
+		 <script src="/site/templates/res/js/scripts.js?v=20260129"></script>
+
+		<!-- Google Tag Manager (noscript) -->
+			<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-PSSKRPF" height="0" width="0" style="display:none;visibility:hidden"> </iframe>
+		</noscript>
+		<!-- End Google Tag Manager (noscript) -->
+
+	<!-- Start of arenaverona Zendesk Widget script -->
+		 <script id="ze-snippet" src="https://static.zdassets.com/ekr/snippet.js?key=95b7aa53-5612-4a9c-b754-d2d44a6cc3c3"> </script>
+		<!-- End of arenaverona Zendesk Widget script -->
+	</body>
+</html>

--- a/src/scrapers/__tests__/arena-di-verona.test.ts
+++ b/src/scrapers/__tests__/arena-di-verona.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { describe, it, expect } from 'vitest';
 import { ArenaDiVeronaScraper } from '../arena-di-verona.js';
+import { testDbIntegration } from './helpers/db-integration.js';
 
 const fixture = readFileSync(new URL('../__fixtures__/arena-di-verona.html', import.meta.url), 'utf8');
 const scraper = new ArenaDiVeronaScraper({ fetchHtml: async () => fixture });
@@ -32,4 +33,6 @@ describe('ArenaDiVeronaScraper', () => {
     expect(withUrl).toBeDefined();
     expect(withUrl!.url).toMatch(/^https:\/\/www\.arena\.it\//);
   });
+
+  testDbIntegration(scraper);
 });

--- a/src/scrapers/__tests__/arena-di-verona.test.ts
+++ b/src/scrapers/__tests__/arena-di-verona.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from 'node:fs';
+import { describe, it, expect } from 'vitest';
+import { ArenaDiVeronaScraper } from '../arena-di-verona.js';
+
+const fixture = readFileSync(new URL('../__fixtures__/arena-di-verona.html', import.meta.url), 'utf8');
+const scraper = new ArenaDiVeronaScraper({ fetchHtml: async () => fixture });
+
+describe('ArenaDiVeronaScraper', () => {
+  it('parses events from fixture', async () => {
+    const events = await scraper.scrape();
+    expect(events.length).toBeGreaterThan(0);
+  });
+
+  it('extracts date, time, and location', async () => {
+    const events = await scraper.scrape();
+    const withTime = events.find(e => e.time !== null);
+    expect(withTime).toBeDefined();
+    expect(withTime!.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(withTime!.time).toMatch(/^\d{2}:\d{2}$/);
+  });
+
+  it('skips placeholder days with malformed dates', async () => {
+    const events = await scraper.scrape();
+    for (const e of events) {
+      expect(e.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    }
+  });
+
+  it('builds absolute URLs for event links', async () => {
+    const events = await scraper.scrape();
+    const withUrl = events.find(e => e.url !== null);
+    expect(withUrl).toBeDefined();
+    expect(withUrl!.url).toMatch(/^https:\/\/www\.arena\.it\//);
+  });
+});

--- a/src/scrapers/arena-di-verona.ts
+++ b/src/scrapers/arena-di-verona.ts
@@ -1,0 +1,92 @@
+import { load } from 'cheerio';
+import type { Event } from '../types.js';
+import { generateEventId, USER_AGENT, type Scraper, type VenueMeta } from './base.js';
+
+type FetchHtml = () => Promise<string>;
+
+const BASE_URL = 'https://www.arena.it';
+
+export class ArenaDiVeronaScraper implements Scraper {
+  readonly venue: VenueMeta = {
+    venueId: 'arena-di-verona',
+    venueName: 'Arena di Verona',
+    cityId: 'verona',
+    cityName: 'Verona',
+    country: 'IT',
+    scheduleUrl: 'https://www.arena.it/it/calendario/',
+  };
+
+  get venueId(): string { return this.venue.venueId; }
+
+  constructor(private readonly opts: { fetchHtml?: FetchHtml } = {}) {}
+
+  async scrape(): Promise<Event[]> {
+    const html = this.opts.fetchHtml
+      ? await this.opts.fetchHtml()
+      : await fetch(this.venue.scheduleUrl, {
+          headers: { 'User-Agent': USER_AGENT },
+          redirect: 'follow',
+        }).then((r) => {
+          if (!r.ok) throw new Error(`HTTP ${r.status} from ${this.venue.scheduleUrl}`);
+          return r.text();
+        });
+    return this.parse(html);
+  }
+
+  parse(html: string): Event[] {
+    const $ = load(html);
+    const events: Event[] = [];
+    const now = new Date().toISOString();
+
+    // The calendar view has div.day[data-day] elements, each containing
+    // li.bh-calendarShow entries for events on that date.
+    $('div.day[data-day]').each((_, dayEl) => {
+      const $day = $(dayEl);
+      const date = $day.attr('data-day') ?? '';
+
+      // Skip placeholder days with malformed dates like "2026-04---"
+      if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) return;
+
+      $day.find('li.bh-calendarShow').each((_, el) => {
+        try {
+          const $el = $(el);
+          const $event = $el.find('div.event');
+
+          // Title from h2 > a
+          const $titleLink = $event.find('h2.title-base a');
+          const title = $titleLink.text().trim();
+          const href = $titleLink.attr('href') ?? '';
+
+          if (!title) return;
+
+          // Time from the icon time-secondary sibling label
+          const timeLabel = $event.find('span.icon.time-secondary').parent().find('span.label').text().trim();
+          const time = /^\d{2}:\d{2}$/.test(timeLabel) ? timeLabel : null;
+
+          // Location from the icon location-secondary sibling label
+          const location = $event.find('span.icon.location-secondary').parent().find('span.label').text().trim() || null;
+
+          // URL: event detail link
+          const url = href ? new URL(href, BASE_URL + '/').href : null;
+
+          events.push({
+            id: generateEventId(this.venueId, date, time, title),
+            venue_id: this.venueId,
+            title,
+            date,
+            time,
+            conductor: null,
+            cast: null,
+            location,
+            url,
+            scraped_at: now,
+          });
+        } catch {
+          // skip malformed entries silently
+        }
+      });
+    });
+
+    return events;
+  }
+}

--- a/src/scrapers/arena-di-verona.ts
+++ b/src/scrapers/arena-di-verona.ts
@@ -87,6 +87,12 @@ export class ArenaDiVeronaScraper implements Scraper {
       });
     });
 
-    return events;
+    // Deduplicate — the calendar HTML sometimes lists the same event twice on a day
+    const seen = new Set<string>();
+    return events.filter(e => {
+      if (seen.has(e.id)) return false;
+      seen.add(e.id);
+      return true;
+    });
   }
 }


### PR DESCRIPTION
## Summary
- Add scraper for **Arena di Verona** (Verona, IT) — Closes #8
- **Schedule URL:** https://www.arena.it/it/calendario/
- Parses the Italian calendar page using Cheerio, extracting event title, date, time, location, and detail URL from `div.day[data-day]` and `li.bh-calendarShow` elements
- Skips placeholder days with malformed dates (e.g. `2026-04---`)

## Test plan
- [x] Fixture-based tests pass (4 tests: event count, date/time extraction, malformed date skipping, absolute URL construction)
- [x] All 23 tests pass (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)