### PR TITLE
scraper: Teatro La Fenice (Venezia)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Missing your favorite venue? PRs welcome! Read **[CONTRIBUTING.md](CONTRIBUTING.
 | San Francisco Opera | San Francisco |
 | Gran Teatre del Liceu | Barcelona |
 | Semperoper | Dresden |
+| Teatro La Fenice | Venezia |
 
 ## How it works
 

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -14,6 +14,7 @@ import { OperFrankfurtScraper } from './scrapers/oper-frankfurt.js';
 import { SanFranciscoOperaScraper } from './scrapers/san-francisco-opera.js';
 import { LiceuBarcelonaScraper } from './scrapers/liceu-barcelona.js';
 import { SemperoperDresdenScraper } from './scrapers/semperoper-dresden.js';
+import { TeatroLaFeniceScraper } from './scrapers/teatro-la-fenice.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -44,6 +45,7 @@ export const scrapers: Scraper[] = [
   new SanFranciscoOperaScraper(),
   new LiceuBarcelonaScraper(),
   new SemperoperDresdenScraper(),
+  new TeatroLaFeniceScraper(),
 ];
 
 export async function runScrapers(list: Scraper[]): Promise<void> {

--- a/src/scrapers/__fixtures__/teatro-la-fenice.html
+++ b/src/scrapers/__fixtures__/teatro-la-fenice.html
@@ -1,0 +1,6334 @@
+<!DOCTYPE html>
+<!--[if lt IE 7]><html class="no-js ie ie6 lt-ie9 lt-ie8 lt-ie7 lt-ie10" lang="it-IT"> <![endif]-->
+<!--[if IE 7]><html class="no-js ie ie7 lt-ie9 lt-ie8 lt-ie10" lang="it-IT"> <![endif]-->
+<!--[if IE 8]><html class="no-js ie ie8 lt-ie9 lt-ie10" lang="it-IT"> <![endif]-->
+<!--[if IE 9]><html class="no-js ie ie9 lt-ie10" lang="it-IT"> <![endif]-->
+<!--[if gt IE 9]><!--><html class="no-js" lang="it-IT"> <!--<![endif]-->
+<head>
+	<meta charset="UTF-8" />
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	
+	<link rel="shortcut icon" href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/obj/favicon.ico" />
+
+	<link rel="stylesheet" href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/stylesheets/main.css?v=5" type="text/css" media="screen" />
+	<script id="Cookiebot" src="https://consent.cookiebot.com/uc.js" data-cbid="0a969f0a-a139-4fad-a8a5-44bec8ec5806" data-blockingmode="auto" type="text/javascript"></script>
+
+	<script data-cookieconsent="ignore" src="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/javascripts/modernizr.js"></script>
+
+	<link rel="pingback" href="https://www.teatrolafenice.it/xmlrpc.php" />
+
+	
+	
+	<!-- Google Tag Manager -->
+		<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+		new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+		j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+		'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+		})(window,document,'script','dataLayer','GTM-N8JCG4H');</script>
+		<!-- End Google Tag Manager —>
+
+	<!-- Facebook Pixel Code -->
+	<script>
+	!function(f,b,e,v,n,t,s)
+	{if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+	n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+	if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+	n.queue=[];t=b.createElement(e);t.async=!0;
+	t.src=v;s=b.getElementsByTagName(e)[0];
+	s.parentNode.insertBefore(t,s)}(window,document,'script',
+	'https://connect.facebook.net/en_US/fbevents.js');
+	 fbq('init', '2550802651857463');
+	fbq('track', 'PageView');
+	</script>
+	<noscript>
+	 <img height="1" width="1"
+	src="https://www.facebook.com/tr?id=2550802651857463&ev=PageView
+	&noscript=1"/>
+	</noscript>
+	<!-- End Facebook Pixel Code -->
+
+	<link rel="alternate" hreflang="it" href="https://www.teatrolafenice.it/calendario/" />
+<link rel="alternate" hreflang="en" href="https://www.teatrolafenice.it/en/whats-on/" />
+
+<!-- This site is optimized with the Yoast SEO plugin v13.5 - https://yoast.com/wordpress/plugins/seo/ -->
+<title>Calendario - Teatro La Fenice</title>
+<meta name="description" content="Tutti gli eventi in programma giorno dopo giorno"/>
+<meta name="robots" content="max-snippet:-1, max-image-preview:large, max-video-preview:-1"/>
+<link rel="canonical" href="https://www.teatrolafenice.it/calendario/" />
+<meta property="og:locale" content="it_IT" />
+<meta property="og:type" content="article" />
+<meta property="og:title" content="Calendario - Teatro La Fenice" />
+<meta property="og:description" content="Tutti gli eventi in programma giorno dopo giorno" />
+<meta property="og:url" content="https://www.teatrolafenice.it/calendario/" />
+<meta property="og:site_name" content="Teatro La Fenice" />
+<meta property="og:image" content="https://www.teatrolafenice.it/wp-content/uploads/2019/03/10002777_10000113_calendario-2-1.jpg" />
+<meta property="og:image:secure_url" content="https://www.teatrolafenice.it/wp-content/uploads/2019/03/10002777_10000113_calendario-2-1.jpg" />
+<meta property="og:image:width" content="1600" />
+<meta property="og:image:height" content="1032" />
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:description" content="Tutti gli eventi in programma giorno dopo giorno" />
+<meta name="twitter:title" content="Calendario - Teatro La Fenice" />
+<meta name="twitter:image" content="https://www.teatrolafenice.it/wp-content/uploads/2019/03/10002777_10000113_calendario-2-1.jpg" />
+<script type='application/ld+json' class='yoast-schema-graph yoast-schema-graph--main'>{"@context":"https://schema.org","@graph":[{"@type":"WebSite","@id":"https://www.teatrolafenice.it/#website","url":"https://www.teatrolafenice.it/","name":"Teatro La Fenice","inLanguage":"it-IT","description":"Official website","potentialAction":[{"@type":"SearchAction","target":"https://www.teatrolafenice.it/?s={search_term_string}","query-input":"required name=search_term_string"}]},{"@type":"ImageObject","@id":"https://www.teatrolafenice.it/calendario/#primaryimage","inLanguage":"it-IT","url":"https://www.teatrolafenice.it/wp-content/uploads/2019/03/10002777_10000113_calendario-2-1.jpg","width":1600,"height":1032},{"@type":"WebPage","@id":"https://www.teatrolafenice.it/calendario/#webpage","url":"https://www.teatrolafenice.it/calendario/","name":"Calendario - Teatro La Fenice","isPartOf":{"@id":"https://www.teatrolafenice.it/#website"},"inLanguage":"it-IT","primaryImageOfPage":{"@id":"https://www.teatrolafenice.it/calendario/#primaryimage"},"datePublished":"2018-12-27T15:12:37+00:00","dateModified":"2020-01-22T15:22:13+00:00","description":"Tutti gli eventi in programma giorno dopo giorno","potentialAction":[{"@type":"ReadAction","target":["https://www.teatrolafenice.it/calendario/"]}]}]}</script>
+<!-- / Yoast SEO plugin. -->
+
+<link rel='dns-prefetch' href='//s.w.org' />
+		<script type="text/javascript">
+			window._wpemojiSettings = {"baseUrl":"https:\/\/s.w.org\/images\/core\/emoji\/12.0.0-1\/72x72\/","ext":".png","svgUrl":"https:\/\/s.w.org\/images\/core\/emoji\/12.0.0-1\/svg\/","svgExt":".svg","source":{"concatemoji":"https:\/\/www.teatrolafenice.it\/wp-includes\/js\/wp-emoji-release.min.js"}};
+			!function(e,a,t){var r,n,o,i,p=a.createElement("canvas"),s=p.getContext&&p.getContext("2d");function c(e,t){var a=String.fromCharCode;s.clearRect(0,0,p.width,p.height),s.fillText(a.apply(this,e),0,0);var r=p.toDataURL();return s.clearRect(0,0,p.width,p.height),s.fillText(a.apply(this,t),0,0),r===p.toDataURL()}function l(e){if(!s||!s.fillText)return!1;switch(s.textBaseline="top",s.font="600 32px Arial",e){case"flag":return!c([127987,65039,8205,9895,65039],[127987,65039,8203,9895,65039])&&(!c([55356,56826,55356,56819],[55356,56826,8203,55356,56819])&&!c([55356,57332,56128,56423,56128,56418,56128,56421,56128,56430,56128,56423,56128,56447],[55356,57332,8203,56128,56423,8203,56128,56418,8203,56128,56421,8203,56128,56430,8203,56128,56423,8203,56128,56447]));case"emoji":return!c([55357,56424,55356,57342,8205,55358,56605,8205,55357,56424,55356,57340],[55357,56424,55356,57342,8203,55358,56605,8203,55357,56424,55356,57340])}return!1}function d(e){var t=a.createElement("script");t.src=e,t.defer=t.type="text/javascript",a.getElementsByTagName("head")[0].appendChild(t)}for(i=Array("flag","emoji"),t.supports={everything:!0,everythingExceptFlag:!0},o=0;o<i.length;o++)t.supports[i[o]]=l(i[o]),t.supports.everything=t.supports.everything&&t.supports[i[o]],"flag"!==i[o]&&(t.supports.everythingExceptFlag=t.supports.everythingExceptFlag&&t.supports[i[o]]);t.supports.everythingExceptFlag=t.supports.everythingExceptFlag&&!t.supports.flag,t.DOMReady=!1,t.readyCallback=function(){t.DOMReady=!0},t.supports.everything||(n=function(){t.readyCallback()},a.addEventListener?(a.addEventListener("DOMContentLoaded",n,!1),e.addEventListener("load",n,!1)):(e.attachEvent("onload",n),a.attachEvent("onreadystatechange",function(){"complete"===a.readyState&&t.readyCallback()})),(r=t.source||{}).concatemoji?d(r.concatemoji):r.wpemoji&&r.twemoji&&(d(r.twemoji),d(r.wpemoji)))}(window,document,window._wpemojiSettings);
+		</script>
+		<style type="text/css">
+img.wp-smiley,
+img.emoji {
+	display: inline !important;
+	border: none !important;
+	box-shadow: none !important;
+	height: 1em !important;
+	width: 1em !important;
+	margin: 0 .07em !important;
+	vertical-align: -0.1em !important;
+	background: none !important;
+	padding: 0 !important;
+}
+</style>
+	<link rel='stylesheet' id='wp-block-library-css'  href='https://www.teatrolafenice.it/wp-includes/css/dist/block-library/style.min.css' type='text/css' media='all' />
+<script type='text/javascript' src='https://www.teatrolafenice.it/wp-includes/js/jquery/jquery.js'></script>
+<script type='text/javascript' src='https://www.teatrolafenice.it/wp-includes/js/jquery/jquery-migrate.min.js'></script>
+<script type='text/javascript' src='https://www.teatrolafenice.it/wp-content/plugins/sitepress-multilingual-cms/res/js/jquery.cookie.js'></script>
+<script type='text/javascript'>
+/* <![CDATA[ */
+var wpml_cookies = {"_icl_current_language":{"value":"it","expires":1,"path":"\/"}};
+var wpml_cookies = {"_icl_current_language":{"value":"it","expires":1,"path":"\/"}};
+/* ]]> */
+</script>
+<script type='text/javascript' src='https://www.teatrolafenice.it/wp-content/plugins/sitepress-multilingual-cms/res/js/cookies/language-cookie.js'></script>
+<link rel='https://api.w.org/' href='https://www.teatrolafenice.it/wp-json/' />
+<link rel="EditURI" type="application/rsd+xml" title="RSD" href="https://www.teatrolafenice.it/xmlrpc.php?rsd" />
+<link rel="wlwmanifest" type="application/wlwmanifest+xml" href="https://www.teatrolafenice.it/wp-includes/wlwmanifest.xml" /> 
+
+<link rel='shortlink' href='https://www.teatrolafenice.it/?p=103' />
+<link rel="alternate" type="application/json+oembed" href="https://www.teatrolafenice.it/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fwww.teatrolafenice.it%2Fcalendario%2F" />
+<link rel="alternate" type="text/xml+oembed" href="https://www.teatrolafenice.it/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fwww.teatrolafenice.it%2Fcalendario%2F&#038;format=xml" />
+
+
+</head>
+
+	<body class="page-template page-template-templates page-template-tpl-calendario page-template-templatestpl-calendario-php page page-id-103 " data-module="dom-ready">
+
+		<!-- Google Tag Manager (noscript) -->
+		<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-N8JCG4H"
+		height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+		<!-- End Google Tag Manager (noscript) -->
+
+		
+		<div class="sn_site_wrapper">
+
+							<header class="sn_header" data-module="header-utils">
+	<div class="sn_header_col _left">
+		<div class="sn_menu_toggle">
+			<p>Menu</p>
+			<span></span>
+			<span></span>
+			<span></span>
+		</div>
+
+		
+		<a href="javascript:;" class="sn_search_toggle d-md-none">
+			  <span class="sn_sprite _search ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#search" /></svg>
+  </span>
+
+		</a>
+
+	</div>
+
+	<div class="sn_header_col _center">
+		
+			<a href="https://www.teatrolafenice.it" title="Teatro La Fenice">
+				<img src="https://www.teatrolafenice.it/wp-content/uploads/2019/01/logo.png" alt="Teatro La Fenice" />
+			</a>
+		
+	</div>
+
+	<div class="sn_header_col _right">
+		<div class="d-flex align-items-center flex-row-reverse flex-md-row">
+						<div class="sn_reserved_area_menu">
+				<a href="https://www.teatrolafenice.it/reserved-area/">
+					  <span class="sn_sprite _user-profile-icon ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#user-profile-icon" /></svg>
+  </span>
+
+				</a>
+			</div>
+			
+			<a href="javascript:;" class="sn_search_toggle d-none d-md-block">
+				  <span class="sn_sprite _search ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#search" /></svg>
+  </span>
+
+			</a>
+
+							<div class="sn_langs dropdown">
+																													<a class="dropdown-toggle" href="#" data-toggle="dropdown" data-placement="bottom-center">
+								<span>it</span>
+							</a>
+											
+					<div class="dropdown-menu">
+																					<a class="dropdown-item" href="https://www.teatrolafenice.it/en/whats-on/">
+									<span>en</span>
+								</a>
+																															</div>
+				</div>
+			
+								  <a href="https://www.teatrolafenice.it/calendario/" class="btn btn-icon btn-header" target="_self" >
+		<div class="_icon_ct">
+			<div class="_icon">  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</div> <div class="_icon_ct_label">Calendario</div>
+		</div>
+	</a>
+
+			
+
+		</div>
+					<a href="https://www.teatrolafenice.it/fondazione-teatro-la-fenice/storia/" class="sn_header_right_link d-none d-lg-inline-block text-right">
+				LA FENICE & IL TEATRO MALIBRAN
+			</a>
+		
+
+	</div>
+
+	<div class="sn_header_menu">
+
+		<div class="sn_header_menu_backdrop"></div>
+
+		<div class="sn_header_menu_first">
+			<div class="sn_header_menu_first_wr">
+				<div class="sn_header_menu_first_in">
+
+					
+					<ul class="sn_header_menu_secondary">
+											</ul>
+
+					<ul class="sn_header_menu_primary">
+													<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-55936">
+								<a href="https://www.teatrolafenice.it/stagione-2025-26/">Stagione 2025/ 26</a>
+
+																		
+															</li>
+													<li class="__gift menu-item menu-item-type-post_type menu-item-object-post menu-item-58094">
+								<a href="https://www.teatrolafenice.it/gift-card-regala-la-fenice-2025-2026/">Regala La Fenice</a>
+
+																			  <span class="sn_sprite _gift ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#gift" /></svg>
+  </span>
+
+																		
+															</li>
+													<li class="menu-item menu-item-type-post_type menu-item-object-page current-menu-item page_item page-item-103 current_page_item menu-item-37399">
+								<a href="https://www.teatrolafenice.it/calendario/">Calendario</a>
+
+																		
+															</li>
+													<li class="menu-item menu-item-type-custom menu-item-object-custom menu-item-17208">
+								<a href="https://www.teatrolafenice.it/info-biglietteria-abbigliamento-disabili/">Biglietteria</a>
+
+																		
+															</li>
+													<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-55956">
+								<a href="https://www.teatrolafenice.it/abbonamenti/">Abbonamenti</a>
+
+																		
+															</li>
+													<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-32132">
+								<a href="https://www.teatrolafenice.it/come-arrivare-abbigliamento-regole/">Info utili</a>
+
+																		
+															</li>
+													<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-46709">
+								<a href="https://www.teatrolafenice.it/area-stampa-generale/">Area Stampa</a>
+
+																		
+															</li>
+													<li class="menu-item menu-item-type-custom menu-item-object-custom menu-item-37407">
+								<a href="https://education.teatrolafenice.it/">Fenice Education</a>
+
+																		
+															</li>
+													<li class="menu-item menu-item-type-custom menu-item-object-custom menu-item-46279">
+								<a href="https://www.teatrolafenice.it/archivio-storico/">Archivio storico</a>
+
+																		
+															</li>
+													<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-46302">
+								<a href="https://www.teatrolafenice.it/fondazione-teatro-la-fenice/visita-la-fenice/">Visita La Fenice</a>
+
+																		
+															</li>
+													<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-54567">
+								<a href="https://www.teatrolafenice.it/altro/premio-venezia/">Premio Venezia</a>
+
+																		
+															</li>
+													<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-53456">
+								<a href="https://www.teatrolafenice.it/reserved-area/">Area riservata</a>
+
+																		
+															</li>
+											</ul>
+
+					<ul class="sn_header_menu_mobile" id="sn_header_menu_mobile">
+													<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-55936">
+								<a href="https://www.teatrolafenice.it/stagione-2025-26/">Stagione 2025/ 26
+																								</a>
+
+															</li>
+													<li class="__gift menu-item menu-item-type-post_type menu-item-object-post menu-item-58094">
+								<a href="https://www.teatrolafenice.it/gift-card-regala-la-fenice-2025-2026/">Regala La Fenice
+																	  <span class="sn_sprite _gift ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#gift" /></svg>
+  </span>
+
+																								</a>
+
+															</li>
+													<li class="menu-item menu-item-type-post_type menu-item-object-page current-menu-item page_item page-item-103 current_page_item menu-item-37399">
+								<a href="https://www.teatrolafenice.it/calendario/">Calendario
+																								</a>
+
+															</li>
+													<li class="menu-item menu-item-type-custom menu-item-object-custom menu-item-17208">
+								<a href="https://www.teatrolafenice.it/info-biglietteria-abbigliamento-disabili/">Biglietteria
+																								</a>
+
+															</li>
+													<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-55956">
+								<a href="https://www.teatrolafenice.it/abbonamenti/">Abbonamenti
+																								</a>
+
+															</li>
+													<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-32132">
+								<a href="https://www.teatrolafenice.it/come-arrivare-abbigliamento-regole/">Info utili
+																								</a>
+
+															</li>
+													<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-46709">
+								<a href="https://www.teatrolafenice.it/area-stampa-generale/">Area Stampa
+																								</a>
+
+															</li>
+													<li class="menu-item menu-item-type-custom menu-item-object-custom menu-item-37407">
+								<a href="https://education.teatrolafenice.it/">Fenice Education
+																								</a>
+
+															</li>
+													<li class="menu-item menu-item-type-custom menu-item-object-custom menu-item-46279">
+								<a href="https://www.teatrolafenice.it/archivio-storico/">Archivio storico
+																								</a>
+
+															</li>
+													<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-46302">
+								<a href="https://www.teatrolafenice.it/fondazione-teatro-la-fenice/visita-la-fenice/">Visita La Fenice
+																								</a>
+
+															</li>
+													<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-54567">
+								<a href="https://www.teatrolafenice.it/altro/premio-venezia/">Premio Venezia
+																								</a>
+
+															</li>
+													<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-53456">
+								<a href="https://www.teatrolafenice.it/reserved-area/">Area riservata
+																								</a>
+
+															</li>
+											</ul>
+
+				</div>
+
+				<div class="sn_footer_banners">
+
+											<div class="swiper-container sn_footer_banners_slider"
+								data-module="swiper-slider"
+								data-module-args="{
+									params: {
+										slidesPerView: 1,
+										effect: 'fade',
+										loop: true,
+										autoHeight: true,
+										autoplay: {
+											delay: 3000
+										}
+									}
+								}">
+							<div class="swiper-wrapper">
+																	<div class="swiper-slide">
+										<a href="https://group.intesasanpaolo.com/it/" class="banner" title="Intesa San Paolo" target="_blank" style="background-image: url(https://www.teatrolafenice.it/wp-content/uploads/2020/10/ISP_FullColor.png);"></a>
+									</div>
+															</div>
+						</div>
+									</div>
+			</div>
+		</div>
+
+	</div>
+
+	<div class="sn_header_search">
+		<div class="sn_header_search_backdrop"></div>
+		<form class="sn_form_search" action="https://www.teatrolafenice.it" method="GET" autocomplete="off">
+			<div class="form-group m-0">
+				<input type="text" class="form-control" name="s" placeholder="CERCA">
+				<button type="submit" class="btn btn-primary">  <span class="sn_sprite _search ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#search" /></svg>
+  </span>
+</button>
+			</div>
+
+			<div class="form-group col-12 sn_form_radio">
+				<div class="sn_form_radio_in text-center border-0">
+					<div class="custom-control custom-radio custom-control-inline">
+						<input type="radio" id="all" name="search_filter" class="custom-control-input" value="all" checked="">
+						<label class="custom-control-label" for="all">Tutto il sito</label>
+					</div>
+					<br/>
+					<div class="custom-control custom-radio custom-control-inline">
+						<input type="radio" id="events" name="search_filter" class="custom-control-input" value="events">
+						<label class="custom-control-label" for="events">Eventi</label>
+					</div>
+					<br/>
+					<div class="custom-control custom-radio custom-control-inline">
+						<input type="radio" id="libretti" name="search_filter" class="custom-control-input" value="libretti">
+						<label class="custom-control-label" for="libretti">Libretti</label>
+					</div>
+					<br/>
+					<div class="custom-control custom-radio custom-control-inline">
+						<input type="radio" id="press" name="search_filter" class="custom-control-input" value="press">
+						<label class="custom-control-label" for="press">Materiali Stampa</label>
+					</div>
+					<br/>
+					<div class="custom-control custom-radio custom-control-inline">
+						<input type="radio" id="historical" name="search_filter" class="custom-control-input" value="historical">
+						<label class="custom-control-label" for="historical">Archivio Storico</label>
+					</div>
+
+					<div class="invalid-feedback">
+		        Questo campo è obbligatorio
+		      </div>
+				</div>
+			</div>
+
+		</form>
+	</div>
+</header>
+			
+			
+	<section class="sn_intro_calendar ">
+	<div class="sn_intro_calendar_ct">
+		<div class="container">
+			<div class="row">
+				<div class="col-12 col-lg-6">
+
+											<div class="">
+							<nav aria-label="breadcrumb" class="sn_breadcrumb">
+	<ol class="breadcrumb">
+					<li class="breadcrumb-item ">
+									<a href="https://www.teatrolafenice.it">
+						Home
+					</a>
+							</li>
+					<li class="breadcrumb-item active">
+									Calendario
+							</li>
+			</ol>
+</nav>
+						</div>
+					
+					<div class="sn_intro_calendar_content">
+						<h1>Calendario</h1>
+<p>Tutti gli eventi in programma giorno dopo giorno</p>
+
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+
+	<div class="sn_intro_calendar_image">
+		<img src="https://www.teatrolafenice.it/wp-content/uploads/2019/03/10002777_10000113_calendario-2-1.jpg" alt="">
+	</div>
+</section>
+	<section class="sn_main_partner_banner ">
+		<div class="container">
+			<figure>
+			<div>Main Partner</div>
+			<a href="https://www.intesasanpaolo.com">
+				<img src="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/obj/main-partner.png">
+			</a>
+		</figure>
+		</div>
+	</section>
+
+	<div data-today="04-03-2026"></div>
+
+	<section class="sn_calendar_block "
+		data-module="calendar-block"
+		data-module-args="{
+			features: {
+				strings: {
+					at: 'alle'
+				},
+								disabled_dates: '\u007B\u00221\u0022\u003A\u00222026\u002D01\u002D02\u0022,\u00222\u0022\u003A\u00222026\u002D01\u002D03\u0022,\u00224\u0022\u003A\u00222026\u002D01\u002D05\u0022,\u00225\u0022\u003A\u00222026\u002D01\u002D06\u0022,\u00227\u0022\u003A\u00222026\u002D01\u002D08\u0022,\u00228\u0022\u003A\u00222026\u002D01\u002D09\u0022,\u002211\u0022\u003A\u00222026\u002D01\u002D12\u0022,\u002212\u0022\u003A\u00222026\u002D01\u002D13\u0022,\u002213\u0022\u003A\u00222026\u002D01\u002D14\u0022,\u002214\u0022\u003A\u00222026\u002D01\u002D15\u0022,\u002215\u0022\u003A\u00222026\u002D01\u002D16\u0022,\u002216\u0022\u003A\u00222026\u002D01\u002D17\u0022,\u002217\u0022\u003A\u00222026\u002D01\u002D18\u0022,\u002221\u0022\u003A\u00222026\u002D01\u002D22\u0022,\u002223\u0022\u003A\u00222026\u002D01\u002D24\u0022,\u002225\u0022\u003A\u00222026\u002D01\u002D26\u0022,\u002232\u0022\u003A\u00222026\u002D02\u002D02\u0022,\u002235\u0022\u003A\u00222026\u002D02\u002D05\u0022,\u002236\u0022\u003A\u00222026\u002D02\u002D06\u0022,\u002246\u0022\u003A\u00222026\u002D02\u002D16\u0022,\u002252\u0022\u003A\u00222026\u002D02\u002D22\u0022,\u002253\u0022\u003A\u00222026\u002D02\u002D23\u0022,\u002270\u0022\u003A\u00222026\u002D03\u002D12\u0022,\u002271\u0022\u003A\u00222026\u002D03\u002D13\u0022,\u002274\u0022\u003A\u00222026\u002D03\u002D16\u0022,\u002276\u0022\u003A\u00222026\u002D03\u002D18\u0022,\u002277\u0022\u003A\u00222026\u002D03\u002D19\u0022,\u002281\u0022\u003A\u00222026\u002D03\u002D23\u0022,\u002288\u0022\u003A\u00222026\u002D03\u002D30\u0022,\u002294\u0022\u003A\u00222026\u002D04\u002D05\u0022,\u002295\u0022\u003A\u00222026\u002D04\u002D06\u0022,\u002299\u0022\u003A\u00222026\u002D04\u002D10\u0022,\u0022103\u0022\u003A\u00222026\u002D04\u002D14\u0022,\u0022109\u0022\u003A\u00222026\u002D04\u002D20\u0022,\u0022114\u0022\u003A\u00222026\u002D04\u002D25\u0022,\u0022116\u0022\u003A\u00222026\u002D04\u002D27\u0022,\u0022120\u0022\u003A\u00222026\u002D05\u002D01\u0022,\u0022124\u0022\u003A\u00222026\u002D05\u002D05\u0022,\u0022130\u0022\u003A\u00222026\u002D05\u002D11\u0022,\u0022131\u0022\u003A\u00222026\u002D05\u002D12\u0022,\u0022141\u0022\u003A\u00222026\u002D05\u002D22\u0022,\u0022142\u0022\u003A\u00222026\u002D05\u002D23\u0022,\u0022152\u0022\u003A\u00222026\u002D06\u002D02\u0022,\u0022158\u0022\u003A\u00222026\u002D06\u002D08\u0022,\u0022160\u0022\u003A\u00222026\u002D06\u002D10\u0022,\u0022161\u0022\u003A\u00222026\u002D06\u002D11\u0022,\u0022163\u0022\u003A\u00222026\u002D06\u002D13\u0022,\u0022172\u0022\u003A\u00222026\u002D06\u002D22\u0022,\u0022174\u0022\u003A\u00222026\u002D06\u002D24\u0022,\u0022175\u0022\u003A\u00222026\u002D06\u002D25\u0022,\u0022179\u0022\u003A\u00222026\u002D06\u002D29\u0022,\u0022182\u0022\u003A\u00222026\u002D07\u002D02\u0022,\u0022183\u0022\u003A\u00222026\u002D07\u002D03\u0022,\u0022184\u0022\u003A\u00222026\u002D07\u002D04\u0022,\u0022186\u0022\u003A\u00222026\u002D07\u002D06\u0022,\u0022187\u0022\u003A\u00222026\u002D07\u002D07\u0022,\u0022192\u0022\u003A\u00222026\u002D07\u002D12\u0022,\u0022193\u0022\u003A\u00222026\u002D07\u002D13\u0022,\u0022195\u0022\u003A\u00222026\u002D07\u002D15\u0022,\u0022196\u0022\u003A\u00222026\u002D07\u002D16\u0022,\u0022197\u0022\u003A\u00222026\u002D07\u002D17\u0022,\u0022198\u0022\u003A\u00222026\u002D07\u002D18\u0022,\u0022199\u0022\u003A\u00222026\u002D07\u002D19\u0022,\u0022200\u0022\u003A\u00222026\u002D07\u002D20\u0022,\u0022201\u0022\u003A\u00222026\u002D07\u002D21\u0022,\u0022202\u0022\u003A\u00222026\u002D07\u002D22\u0022,\u0022203\u0022\u003A\u00222026\u002D07\u002D23\u0022,\u0022204\u0022\u003A\u00222026\u002D07\u002D24\u0022,\u0022205\u0022\u003A\u00222026\u002D07\u002D25\u0022,\u0022206\u0022\u003A\u00222026\u002D07\u002D26\u0022,\u0022207\u0022\u003A\u00222026\u002D07\u002D27\u0022,\u0022208\u0022\u003A\u00222026\u002D07\u002D28\u0022,\u0022209\u0022\u003A\u00222026\u002D07\u002D29\u0022,\u0022210\u0022\u003A\u00222026\u002D07\u002D30\u0022,\u0022211\u0022\u003A\u00222026\u002D07\u002D31\u0022,\u0022212\u0022\u003A\u00222026\u002D08\u002D01\u0022,\u0022213\u0022\u003A\u00222026\u002D08\u002D02\u0022,\u0022214\u0022\u003A\u00222026\u002D08\u002D03\u0022,\u0022215\u0022\u003A\u00222026\u002D08\u002D04\u0022,\u0022216\u0022\u003A\u00222026\u002D08\u002D05\u0022,\u0022217\u0022\u003A\u00222026\u002D08\u002D06\u0022,\u0022218\u0022\u003A\u00222026\u002D08\u002D07\u0022,\u0022219\u0022\u003A\u00222026\u002D08\u002D08\u0022,\u0022220\u0022\u003A\u00222026\u002D08\u002D09\u0022,\u0022221\u0022\u003A\u00222026\u002D08\u002D10\u0022,\u0022222\u0022\u003A\u00222026\u002D08\u002D11\u0022,\u0022223\u0022\u003A\u00222026\u002D08\u002D12\u0022,\u0022224\u0022\u003A\u00222026\u002D08\u002D13\u0022,\u0022225\u0022\u003A\u00222026\u002D08\u002D14\u0022,\u0022226\u0022\u003A\u00222026\u002D08\u002D15\u0022,\u0022227\u0022\u003A\u00222026\u002D08\u002D16\u0022,\u0022228\u0022\u003A\u00222026\u002D08\u002D17\u0022,\u0022229\u0022\u003A\u00222026\u002D08\u002D18\u0022,\u0022230\u0022\u003A\u00222026\u002D08\u002D19\u0022,\u0022231\u0022\u003A\u00222026\u002D08\u002D20\u0022,\u0022232\u0022\u003A\u00222026\u002D08\u002D21\u0022,\u0022233\u0022\u003A\u00222026\u002D08\u002D22\u0022,\u0022234\u0022\u003A\u00222026\u002D08\u002D23\u0022,\u0022235\u0022\u003A\u00222026\u002D08\u002D24\u0022,\u0022236\u0022\u003A\u00222026\u002D08\u002D25\u0022,\u0022238\u0022\u003A\u00222026\u002D08\u002D27\u0022,\u0022240\u0022\u003A\u00222026\u002D08\u002D29\u0022,\u0022242\u0022\u003A\u00222026\u002D08\u002D31\u0022,\u0022244\u0022\u003A\u00222026\u002D09\u002D02\u0022,\u0022245\u0022\u003A\u00222026\u002D09\u002D03\u0022,\u0022246\u0022\u003A\u00222026\u002D09\u002D04\u0022,\u0022247\u0022\u003A\u00222026\u002D09\u002D05\u0022,\u0022248\u0022\u003A\u00222026\u002D09\u002D06\u0022,\u0022249\u0022\u003A\u00222026\u002D09\u002D07\u0022,\u0022250\u0022\u003A\u00222026\u002D09\u002D08\u0022,\u0022251\u0022\u003A\u00222026\u002D09\u002D09\u0022,\u0022252\u0022\u003A\u00222026\u002D09\u002D10\u0022,\u0022253\u0022\u003A\u00222026\u002D09\u002D11\u0022,\u0022254\u0022\u003A\u00222026\u002D09\u002D12\u0022,\u0022255\u0022\u003A\u00222026\u002D09\u002D13\u0022,\u0022256\u0022\u003A\u00222026\u002D09\u002D14\u0022,\u0022258\u0022\u003A\u00222026\u002D09\u002D16\u0022,\u0022261\u0022\u003A\u00222026\u002D09\u002D19\u0022,\u0022270\u0022\u003A\u00222026\u002D09\u002D28\u0022,\u0022271\u0022\u003A\u00222026\u002D09\u002D29\u0022,\u0022272\u0022\u003A\u00222026\u002D09\u002D30\u0022,\u0022276\u0022\u003A\u00222026\u002D10\u002D04\u0022,\u0022277\u0022\u003A\u00222026\u002D10\u002D05\u0022,\u0022284\u0022\u003A\u00222026\u002D10\u002D12\u0022,\u0022287\u0022\u003A\u00222026\u002D10\u002D15\u0022,\u0022290\u0022\u003A\u00222026\u002D10\u002D18\u0022,\u0022291\u0022\u003A\u00222026\u002D10\u002D19\u0022,\u0022293\u0022\u003A\u00222026\u002D10\u002D21\u0022,\u0022294\u0022\u003A\u00222026\u002D10\u002D22\u0022,\u0022297\u0022\u003A\u00222026\u002D10\u002D25\u0022,\u0022298\u0022\u003A\u00222026\u002D10\u002D26\u0022,\u0022299\u0022\u003A\u00222026\u002D10\u002D27\u0022,\u0022300\u0022\u003A\u00222026\u002D10\u002D28\u0022,\u0022301\u0022\u003A\u00222026\u002D10\u002D29\u0022,\u0022304\u0022\u003A\u00222026\u002D11\u002D01\u0022,\u0022305\u0022\u003A\u00222026\u002D11\u002D02\u0022,\u0022308\u0022\u003A\u00222026\u002D11\u002D05\u0022,\u0022309\u0022\u003A\u00222026\u002D11\u002D06\u0022,\u0022310\u0022\u003A\u00222026\u002D11\u002D07\u0022,\u0022311\u0022\u003A\u00222026\u002D11\u002D08\u0022,\u0022312\u0022\u003A\u00222026\u002D11\u002D09\u0022,\u0022313\u0022\u003A\u00222026\u002D11\u002D10\u0022,\u0022314\u0022\u003A\u00222026\u002D11\u002D11\u0022,\u0022316\u0022\u003A\u00222026\u002D11\u002D13\u0022,\u0022317\u0022\u003A\u00222026\u002D11\u002D14\u0022,\u0022318\u0022\u003A\u00222026\u002D11\u002D15\u0022,\u0022319\u0022\u003A\u00222026\u002D11\u002D16\u0022,\u0022320\u0022\u003A\u00222026\u002D11\u002D17\u0022,\u0022321\u0022\u003A\u00222026\u002D11\u002D18\u0022,\u0022322\u0022\u003A\u00222026\u002D11\u002D19\u0022,\u0022323\u0022\u003A\u00222026\u002D11\u002D20\u0022,\u0022324\u0022\u003A\u00222026\u002D11\u002D21\u0022,\u0022325\u0022\u003A\u00222026\u002D11\u002D22\u0022,\u0022326\u0022\u003A\u00222026\u002D11\u002D23\u0022,\u0022327\u0022\u003A\u00222026\u002D11\u002D24\u0022,\u0022329\u0022\u003A\u00222026\u002D11\u002D26\u0022,\u0022330\u0022\u003A\u00222026\u002D11\u002D27\u0022,\u0022331\u0022\u003A\u00222026\u002D11\u002D28\u0022,\u0022332\u0022\u003A\u00222026\u002D11\u002D29\u0022,\u0022333\u0022\u003A\u00222026\u002D11\u002D30\u0022,\u0022334\u0022\u003A\u00222026\u002D12\u002D01\u0022,\u0022335\u0022\u003A\u00222026\u002D12\u002D02\u0022,\u0022336\u0022\u003A\u00222026\u002D12\u002D03\u0022,\u0022337\u0022\u003A\u00222026\u002D12\u002D04\u0022,\u0022338\u0022\u003A\u00222026\u002D12\u002D05\u0022,\u0022339\u0022\u003A\u00222026\u002D12\u002D06\u0022,\u0022340\u0022\u003A\u00222026\u002D12\u002D07\u0022,\u0022341\u0022\u003A\u00222026\u002D12\u002D08\u0022,\u0022342\u0022\u003A\u00222026\u002D12\u002D09\u0022,\u0022343\u0022\u003A\u00222026\u002D12\u002D10\u0022,\u0022344\u0022\u003A\u00222026\u002D12\u002D11\u0022,\u0022345\u0022\u003A\u00222026\u002D12\u002D12\u0022,\u0022346\u0022\u003A\u00222026\u002D12\u002D13\u0022,\u0022347\u0022\u003A\u00222026\u002D12\u002D14\u0022,\u0022348\u0022\u003A\u00222026\u002D12\u002D15\u0022,\u0022349\u0022\u003A\u00222026\u002D12\u002D16\u0022,\u0022350\u0022\u003A\u00222026\u002D12\u002D17\u0022,\u0022351\u0022\u003A\u00222026\u002D12\u002D18\u0022,\u0022352\u0022\u003A\u00222026\u002D12\u002D19\u0022,\u0022353\u0022\u003A\u00222026\u002D12\u002D20\u0022,\u0022354\u0022\u003A\u00222026\u002D12\u002D21\u0022,\u0022355\u0022\u003A\u00222026\u002D12\u002D22\u0022,\u0022356\u0022\u003A\u00222026\u002D12\u002D23\u0022,\u0022357\u0022\u003A\u00222026\u002D12\u002D24\u0022,\u0022358\u0022\u003A\u00222026\u002D12\u002D25\u0022,\u0022359\u0022\u003A\u00222026\u002D12\u002D26\u0022,\u0022360\u0022\u003A\u00222026\u002D12\u002D27\u0022,\u0022361\u0022\u003A\u00222026\u002D12\u002D28\u0022,\u0022366\u0022\u003A\u00222027\u002D01\u002D02\u0022,\u0022367\u0022\u003A\u00222027\u002D01\u002D03\u0022,\u0022368\u0022\u003A\u00222027\u002D01\u002D04\u0022,\u0022369\u0022\u003A\u00222027\u002D01\u002D05\u0022,\u0022370\u0022\u003A\u00222027\u002D01\u002D06\u0022,\u0022371\u0022\u003A\u00222027\u002D01\u002D07\u0022,\u0022372\u0022\u003A\u00222027\u002D01\u002D08\u0022,\u0022373\u0022\u003A\u00222027\u002D01\u002D09\u0022,\u0022374\u0022\u003A\u00222027\u002D01\u002D10\u0022,\u0022375\u0022\u003A\u00222027\u002D01\u002D11\u0022,\u0022376\u0022\u003A\u00222027\u002D01\u002D12\u0022,\u0022377\u0022\u003A\u00222027\u002D01\u002D13\u0022,\u0022378\u0022\u003A\u00222027\u002D01\u002D14\u0022,\u0022379\u0022\u003A\u00222027\u002D01\u002D15\u0022,\u0022380\u0022\u003A\u00222027\u002D01\u002D16\u0022,\u0022381\u0022\u003A\u00222027\u002D01\u002D17\u0022,\u0022382\u0022\u003A\u00222027\u002D01\u002D18\u0022,\u0022383\u0022\u003A\u00222027\u002D01\u002D19\u0022,\u0022384\u0022\u003A\u00222027\u002D01\u002D20\u0022,\u0022385\u0022\u003A\u00222027\u002D01\u002D21\u0022,\u0022386\u0022\u003A\u00222027\u002D01\u002D22\u0022,\u0022387\u0022\u003A\u00222027\u002D01\u002D23\u0022,\u0022388\u0022\u003A\u00222027\u002D01\u002D24\u0022,\u0022389\u0022\u003A\u00222027\u002D01\u002D25\u0022,\u0022390\u0022\u003A\u00222027\u002D01\u002D26\u0022,\u0022391\u0022\u003A\u00222027\u002D01\u002D27\u0022,\u0022392\u0022\u003A\u00222027\u002D01\u002D28\u0022,\u0022393\u0022\u003A\u00222027\u002D01\u002D29\u0022,\u0022394\u0022\u003A\u00222027\u002D01\u002D30\u0022,\u0022395\u0022\u003A\u00222027\u002D01\u002D31\u0022,\u0022396\u0022\u003A\u00222027\u002D02\u002D01\u0022,\u0022397\u0022\u003A\u00222027\u002D02\u002D02\u0022,\u0022398\u0022\u003A\u00222027\u002D02\u002D03\u0022,\u0022399\u0022\u003A\u00222027\u002D02\u002D04\u0022,\u0022400\u0022\u003A\u00222027\u002D02\u002D05\u0022,\u0022401\u0022\u003A\u00222027\u002D02\u002D06\u0022,\u0022402\u0022\u003A\u00222027\u002D02\u002D07\u0022,\u0022403\u0022\u003A\u00222027\u002D02\u002D08\u0022,\u0022404\u0022\u003A\u00222027\u002D02\u002D09\u0022,\u0022405\u0022\u003A\u00222027\u002D02\u002D10\u0022,\u0022406\u0022\u003A\u00222027\u002D02\u002D11\u0022,\u0022407\u0022\u003A\u00222027\u002D02\u002D12\u0022,\u0022408\u0022\u003A\u00222027\u002D02\u002D13\u0022,\u0022409\u0022\u003A\u00222027\u002D02\u002D14\u0022,\u0022410\u0022\u003A\u00222027\u002D02\u002D15\u0022,\u0022411\u0022\u003A\u00222027\u002D02\u002D16\u0022,\u0022412\u0022\u003A\u00222027\u002D02\u002D17\u0022,\u0022413\u0022\u003A\u00222027\u002D02\u002D18\u0022,\u0022414\u0022\u003A\u00222027\u002D02\u002D19\u0022,\u0022415\u0022\u003A\u00222027\u002D02\u002D20\u0022,\u0022416\u0022\u003A\u00222027\u002D02\u002D21\u0022,\u0022417\u0022\u003A\u00222027\u002D02\u002D22\u0022,\u0022418\u0022\u003A\u00222027\u002D02\u002D23\u0022,\u0022419\u0022\u003A\u00222027\u002D02\u002D24\u0022,\u0022420\u0022\u003A\u00222027\u002D02\u002D25\u0022,\u0022421\u0022\u003A\u00222027\u002D02\u002D26\u0022,\u0022422\u0022\u003A\u00222027\u002D02\u002D27\u0022,\u0022423\u0022\u003A\u00222027\u002D02\u002D28\u0022,\u0022424\u0022\u003A\u00222027\u002D03\u002D01\u0022,\u0022425\u0022\u003A\u00222027\u002D03\u002D02\u0022,\u0022426\u0022\u003A\u00222027\u002D03\u002D03\u0022,\u0022427\u0022\u003A\u00222027\u002D03\u002D04\u0022,\u0022428\u0022\u003A\u00222027\u002D03\u002D05\u0022,\u0022429\u0022\u003A\u00222027\u002D03\u002D06\u0022,\u0022430\u0022\u003A\u00222027\u002D03\u002D07\u0022,\u0022431\u0022\u003A\u00222027\u002D03\u002D08\u0022,\u0022432\u0022\u003A\u00222027\u002D03\u002D09\u0022,\u0022433\u0022\u003A\u00222027\u002D03\u002D10\u0022,\u0022434\u0022\u003A\u00222027\u002D03\u002D11\u0022,\u0022435\u0022\u003A\u00222027\u002D03\u002D12\u0022,\u0022436\u0022\u003A\u00222027\u002D03\u002D13\u0022,\u0022437\u0022\u003A\u00222027\u002D03\u002D14\u0022,\u0022438\u0022\u003A\u00222027\u002D03\u002D15\u0022,\u0022439\u0022\u003A\u00222027\u002D03\u002D16\u0022,\u0022440\u0022\u003A\u00222027\u002D03\u002D17\u0022,\u0022441\u0022\u003A\u00222027\u002D03\u002D18\u0022,\u0022442\u0022\u003A\u00222027\u002D03\u002D19\u0022,\u0022443\u0022\u003A\u00222027\u002D03\u002D20\u0022,\u0022444\u0022\u003A\u00222027\u002D03\u002D21\u0022,\u0022445\u0022\u003A\u00222027\u002D03\u002D22\u0022,\u0022446\u0022\u003A\u00222027\u002D03\u002D23\u0022,\u0022447\u0022\u003A\u00222027\u002D03\u002D24\u0022,\u0022448\u0022\u003A\u00222027\u002D03\u002D25\u0022,\u0022449\u0022\u003A\u00222027\u002D03\u002D26\u0022,\u0022450\u0022\u003A\u00222027\u002D03\u002D27\u0022,\u0022451\u0022\u003A\u00222027\u002D03\u002D28\u0022,\u0022452\u0022\u003A\u00222027\u002D03\u002D29\u0022,\u0022453\u0022\u003A\u00222027\u002D03\u002D30\u0022,\u0022454\u0022\u003A\u00222027\u002D03\u002D31\u0022,\u0022455\u0022\u003A\u00222027\u002D04\u002D01\u0022,\u0022456\u0022\u003A\u00222027\u002D04\u002D02\u0022,\u0022457\u0022\u003A\u00222027\u002D04\u002D03\u0022,\u0022458\u0022\u003A\u00222027\u002D04\u002D04\u0022,\u0022459\u0022\u003A\u00222027\u002D04\u002D05\u0022,\u0022460\u0022\u003A\u00222027\u002D04\u002D06\u0022,\u0022461\u0022\u003A\u00222027\u002D04\u002D07\u0022,\u0022462\u0022\u003A\u00222027\u002D04\u002D08\u0022,\u0022463\u0022\u003A\u00222027\u002D04\u002D09\u0022,\u0022464\u0022\u003A\u00222027\u002D04\u002D10\u0022,\u0022465\u0022\u003A\u00222027\u002D04\u002D11\u0022,\u0022466\u0022\u003A\u00222027\u002D04\u002D12\u0022,\u0022467\u0022\u003A\u00222027\u002D04\u002D13\u0022,\u0022468\u0022\u003A\u00222027\u002D04\u002D14\u0022,\u0022469\u0022\u003A\u00222027\u002D04\u002D15\u0022,\u0022470\u0022\u003A\u00222027\u002D04\u002D16\u0022,\u0022471\u0022\u003A\u00222027\u002D04\u002D17\u0022,\u0022472\u0022\u003A\u00222027\u002D04\u002D18\u0022,\u0022473\u0022\u003A\u00222027\u002D04\u002D19\u0022,\u0022474\u0022\u003A\u00222027\u002D04\u002D20\u0022,\u0022475\u0022\u003A\u00222027\u002D04\u002D21\u0022,\u0022476\u0022\u003A\u00222027\u002D04\u002D22\u0022,\u0022477\u0022\u003A\u00222027\u002D04\u002D23\u0022,\u0022478\u0022\u003A\u00222027\u002D04\u002D24\u0022,\u0022479\u0022\u003A\u00222027\u002D04\u002D25\u0022,\u0022480\u0022\u003A\u00222027\u002D04\u002D26\u0022,\u0022481\u0022\u003A\u00222027\u002D04\u002D27\u0022,\u0022482\u0022\u003A\u00222027\u002D04\u002D28\u0022,\u0022483\u0022\u003A\u00222027\u002D04\u002D29\u0022,\u0022484\u0022\u003A\u00222027\u002D04\u002D30\u0022,\u0022485\u0022\u003A\u00222027\u002D05\u002D01\u0022,\u0022486\u0022\u003A\u00222027\u002D05\u002D02\u0022,\u0022487\u0022\u003A\u00222027\u002D05\u002D03\u0022,\u0022488\u0022\u003A\u00222027\u002D05\u002D04\u0022,\u0022489\u0022\u003A\u00222027\u002D05\u002D05\u0022,\u0022490\u0022\u003A\u00222027\u002D05\u002D06\u0022,\u0022491\u0022\u003A\u00222027\u002D05\u002D07\u0022,\u0022492\u0022\u003A\u00222027\u002D05\u002D08\u0022,\u0022493\u0022\u003A\u00222027\u002D05\u002D09\u0022,\u0022494\u0022\u003A\u00222027\u002D05\u002D10\u0022,\u0022495\u0022\u003A\u00222027\u002D05\u002D11\u0022,\u0022496\u0022\u003A\u00222027\u002D05\u002D12\u0022,\u0022497\u0022\u003A\u00222027\u002D05\u002D13\u0022,\u0022498\u0022\u003A\u00222027\u002D05\u002D14\u0022,\u0022499\u0022\u003A\u00222027\u002D05\u002D15\u0022,\u0022500\u0022\u003A\u00222027\u002D05\u002D16\u0022,\u0022501\u0022\u003A\u00222027\u002D05\u002D17\u0022,\u0022502\u0022\u003A\u00222027\u002D05\u002D18\u0022,\u0022503\u0022\u003A\u00222027\u002D05\u002D19\u0022,\u0022504\u0022\u003A\u00222027\u002D05\u002D20\u0022,\u0022505\u0022\u003A\u00222027\u002D05\u002D21\u0022,\u0022506\u0022\u003A\u00222027\u002D05\u002D22\u0022,\u0022507\u0022\u003A\u00222027\u002D05\u002D23\u0022,\u0022508\u0022\u003A\u00222027\u002D05\u002D24\u0022,\u0022509\u0022\u003A\u00222027\u002D05\u002D25\u0022,\u0022510\u0022\u003A\u00222027\u002D05\u002D26\u0022,\u0022511\u0022\u003A\u00222027\u002D05\u002D27\u0022,\u0022512\u0022\u003A\u00222027\u002D05\u002D28\u0022,\u0022513\u0022\u003A\u00222027\u002D05\u002D29\u0022,\u0022514\u0022\u003A\u00222027\u002D05\u002D30\u0022,\u0022515\u0022\u003A\u00222027\u002D05\u002D31\u0022,\u0022516\u0022\u003A\u00222027\u002D06\u002D01\u0022,\u0022517\u0022\u003A\u00222027\u002D06\u002D02\u0022,\u0022518\u0022\u003A\u00222027\u002D06\u002D03\u0022,\u0022519\u0022\u003A\u00222027\u002D06\u002D04\u0022,\u0022520\u0022\u003A\u00222027\u002D06\u002D05\u0022,\u0022521\u0022\u003A\u00222027\u002D06\u002D06\u0022,\u0022522\u0022\u003A\u00222027\u002D06\u002D07\u0022,\u0022523\u0022\u003A\u00222027\u002D06\u002D08\u0022,\u0022524\u0022\u003A\u00222027\u002D06\u002D09\u0022,\u0022525\u0022\u003A\u00222027\u002D06\u002D10\u0022,\u0022526\u0022\u003A\u00222027\u002D06\u002D11\u0022,\u0022527\u0022\u003A\u00222027\u002D06\u002D12\u0022,\u0022528\u0022\u003A\u00222027\u002D06\u002D13\u0022,\u0022529\u0022\u003A\u00222027\u002D06\u002D14\u0022,\u0022530\u0022\u003A\u00222027\u002D06\u002D15\u0022,\u0022531\u0022\u003A\u00222027\u002D06\u002D16\u0022,\u0022532\u0022\u003A\u00222027\u002D06\u002D17\u0022,\u0022533\u0022\u003A\u00222027\u002D06\u002D18\u0022,\u0022534\u0022\u003A\u00222027\u002D06\u002D19\u0022,\u0022535\u0022\u003A\u00222027\u002D06\u002D20\u0022,\u0022536\u0022\u003A\u00222027\u002D06\u002D21\u0022,\u0022537\u0022\u003A\u00222027\u002D06\u002D22\u0022,\u0022538\u0022\u003A\u00222027\u002D06\u002D23\u0022,\u0022539\u0022\u003A\u00222027\u002D06\u002D24\u0022,\u0022540\u0022\u003A\u00222027\u002D06\u002D25\u0022,\u0022541\u0022\u003A\u00222027\u002D06\u002D26\u0022,\u0022542\u0022\u003A\u00222027\u002D06\u002D27\u0022,\u0022543\u0022\u003A\u00222027\u002D06\u002D28\u0022,\u0022544\u0022\u003A\u00222027\u002D06\u002D29\u0022,\u0022545\u0022\u003A\u00222027\u002D06\u002D30\u0022,\u0022546\u0022\u003A\u00222027\u002D07\u002D01\u0022,\u0022547\u0022\u003A\u00222027\u002D07\u002D02\u0022,\u0022548\u0022\u003A\u00222027\u002D07\u002D03\u0022,\u0022549\u0022\u003A\u00222027\u002D07\u002D04\u0022,\u0022550\u0022\u003A\u00222027\u002D07\u002D05\u0022,\u0022551\u0022\u003A\u00222027\u002D07\u002D06\u0022,\u0022552\u0022\u003A\u00222027\u002D07\u002D07\u0022,\u0022553\u0022\u003A\u00222027\u002D07\u002D08\u0022,\u0022554\u0022\u003A\u00222027\u002D07\u002D09\u0022,\u0022555\u0022\u003A\u00222027\u002D07\u002D10\u0022,\u0022556\u0022\u003A\u00222027\u002D07\u002D11\u0022,\u0022557\u0022\u003A\u00222027\u002D07\u002D12\u0022,\u0022558\u0022\u003A\u00222027\u002D07\u002D13\u0022,\u0022559\u0022\u003A\u00222027\u002D07\u002D14\u0022,\u0022560\u0022\u003A\u00222027\u002D07\u002D15\u0022,\u0022561\u0022\u003A\u00222027\u002D07\u002D16\u0022,\u0022562\u0022\u003A\u00222027\u002D07\u002D17\u0022,\u0022563\u0022\u003A\u00222027\u002D07\u002D18\u0022,\u0022564\u0022\u003A\u00222027\u002D07\u002D19\u0022,\u0022565\u0022\u003A\u00222027\u002D07\u002D20\u0022,\u0022566\u0022\u003A\u00222027\u002D07\u002D21\u0022,\u0022567\u0022\u003A\u00222027\u002D07\u002D22\u0022,\u0022568\u0022\u003A\u00222027\u002D07\u002D23\u0022,\u0022569\u0022\u003A\u00222027\u002D07\u002D24\u0022,\u0022570\u0022\u003A\u00222027\u002D07\u002D25\u0022,\u0022571\u0022\u003A\u00222027\u002D07\u002D26\u0022,\u0022572\u0022\u003A\u00222027\u002D07\u002D27\u0022,\u0022573\u0022\u003A\u00222027\u002D07\u002D28\u0022,\u0022574\u0022\u003A\u00222027\u002D07\u002D29\u0022,\u0022575\u0022\u003A\u00222027\u002D07\u002D30\u0022,\u0022576\u0022\u003A\u00222027\u002D07\u002D31\u0022,\u0022577\u0022\u003A\u00222027\u002D08\u002D01\u0022,\u0022578\u0022\u003A\u00222027\u002D08\u002D02\u0022,\u0022579\u0022\u003A\u00222027\u002D08\u002D03\u0022,\u0022580\u0022\u003A\u00222027\u002D08\u002D04\u0022,\u0022581\u0022\u003A\u00222027\u002D08\u002D05\u0022,\u0022582\u0022\u003A\u00222027\u002D08\u002D06\u0022,\u0022583\u0022\u003A\u00222027\u002D08\u002D07\u0022,\u0022584\u0022\u003A\u00222027\u002D08\u002D08\u0022,\u0022585\u0022\u003A\u00222027\u002D08\u002D09\u0022,\u0022586\u0022\u003A\u00222027\u002D08\u002D10\u0022,\u0022587\u0022\u003A\u00222027\u002D08\u002D11\u0022,\u0022588\u0022\u003A\u00222027\u002D08\u002D12\u0022,\u0022589\u0022\u003A\u00222027\u002D08\u002D13\u0022,\u0022590\u0022\u003A\u00222027\u002D08\u002D14\u0022,\u0022591\u0022\u003A\u00222027\u002D08\u002D15\u0022,\u0022592\u0022\u003A\u00222027\u002D08\u002D16\u0022,\u0022593\u0022\u003A\u00222027\u002D08\u002D17\u0022,\u0022594\u0022\u003A\u00222027\u002D08\u002D18\u0022,\u0022595\u0022\u003A\u00222027\u002D08\u002D19\u0022,\u0022596\u0022\u003A\u00222027\u002D08\u002D20\u0022,\u0022597\u0022\u003A\u00222027\u002D08\u002D21\u0022,\u0022598\u0022\u003A\u00222027\u002D08\u002D22\u0022,\u0022599\u0022\u003A\u00222027\u002D08\u002D23\u0022,\u0022600\u0022\u003A\u00222027\u002D08\u002D24\u0022,\u0022601\u0022\u003A\u00222027\u002D08\u002D25\u0022,\u0022602\u0022\u003A\u00222027\u002D08\u002D26\u0022,\u0022603\u0022\u003A\u00222027\u002D08\u002D27\u0022,\u0022604\u0022\u003A\u00222027\u002D08\u002D28\u0022,\u0022605\u0022\u003A\u00222027\u002D08\u002D29\u0022,\u0022606\u0022\u003A\u00222027\u002D08\u002D30\u0022,\u0022607\u0022\u003A\u00222027\u002D08\u002D31\u0022,\u0022608\u0022\u003A\u00222027\u002D09\u002D01\u0022,\u0022609\u0022\u003A\u00222027\u002D09\u002D02\u0022,\u0022610\u0022\u003A\u00222027\u002D09\u002D03\u0022,\u0022611\u0022\u003A\u00222027\u002D09\u002D04\u0022,\u0022612\u0022\u003A\u00222027\u002D09\u002D05\u0022,\u0022613\u0022\u003A\u00222027\u002D09\u002D06\u0022,\u0022614\u0022\u003A\u00222027\u002D09\u002D07\u0022,\u0022615\u0022\u003A\u00222027\u002D09\u002D08\u0022,\u0022616\u0022\u003A\u00222027\u002D09\u002D09\u0022,\u0022617\u0022\u003A\u00222027\u002D09\u002D10\u0022,\u0022618\u0022\u003A\u00222027\u002D09\u002D11\u0022,\u0022619\u0022\u003A\u00222027\u002D09\u002D12\u0022,\u0022620\u0022\u003A\u00222027\u002D09\u002D13\u0022,\u0022621\u0022\u003A\u00222027\u002D09\u002D14\u0022,\u0022622\u0022\u003A\u00222027\u002D09\u002D15\u0022,\u0022623\u0022\u003A\u00222027\u002D09\u002D16\u0022,\u0022624\u0022\u003A\u00222027\u002D09\u002D17\u0022,\u0022625\u0022\u003A\u00222027\u002D09\u002D18\u0022,\u0022626\u0022\u003A\u00222027\u002D09\u002D19\u0022,\u0022627\u0022\u003A\u00222027\u002D09\u002D20\u0022,\u0022628\u0022\u003A\u00222027\u002D09\u002D21\u0022,\u0022629\u0022\u003A\u00222027\u002D09\u002D22\u0022,\u0022630\u0022\u003A\u00222027\u002D09\u002D23\u0022,\u0022631\u0022\u003A\u00222027\u002D09\u002D24\u0022,\u0022632\u0022\u003A\u00222027\u002D09\u002D25\u0022,\u0022633\u0022\u003A\u00222027\u002D09\u002D26\u0022,\u0022634\u0022\u003A\u00222027\u002D09\u002D27\u0022,\u0022635\u0022\u003A\u00222027\u002D09\u002D28\u0022,\u0022636\u0022\u003A\u00222027\u002D09\u002D29\u0022,\u0022637\u0022\u003A\u00222027\u002D09\u002D30\u0022,\u0022638\u0022\u003A\u00222027\u002D10\u002D01\u0022,\u0022639\u0022\u003A\u00222027\u002D10\u002D02\u0022,\u0022640\u0022\u003A\u00222027\u002D10\u002D03\u0022,\u0022641\u0022\u003A\u00222027\u002D10\u002D04\u0022,\u0022642\u0022\u003A\u00222027\u002D10\u002D05\u0022,\u0022643\u0022\u003A\u00222027\u002D10\u002D06\u0022,\u0022644\u0022\u003A\u00222027\u002D10\u002D07\u0022,\u0022645\u0022\u003A\u00222027\u002D10\u002D08\u0022,\u0022646\u0022\u003A\u00222027\u002D10\u002D09\u0022,\u0022647\u0022\u003A\u00222027\u002D10\u002D10\u0022,\u0022648\u0022\u003A\u00222027\u002D10\u002D11\u0022,\u0022649\u0022\u003A\u00222027\u002D10\u002D12\u0022,\u0022650\u0022\u003A\u00222027\u002D10\u002D13\u0022,\u0022651\u0022\u003A\u00222027\u002D10\u002D14\u0022,\u0022652\u0022\u003A\u00222027\u002D10\u002D15\u0022,\u0022653\u0022\u003A\u00222027\u002D10\u002D16\u0022,\u0022654\u0022\u003A\u00222027\u002D10\u002D17\u0022,\u0022655\u0022\u003A\u00222027\u002D10\u002D18\u0022,\u0022656\u0022\u003A\u00222027\u002D10\u002D19\u0022,\u0022657\u0022\u003A\u00222027\u002D10\u002D20\u0022,\u0022658\u0022\u003A\u00222027\u002D10\u002D21\u0022,\u0022659\u0022\u003A\u00222027\u002D10\u002D22\u0022,\u0022660\u0022\u003A\u00222027\u002D10\u002D23\u0022,\u0022661\u0022\u003A\u00222027\u002D10\u002D24\u0022,\u0022662\u0022\u003A\u00222027\u002D10\u002D25\u0022,\u0022663\u0022\u003A\u00222027\u002D10\u002D26\u0022,\u0022664\u0022\u003A\u00222027\u002D10\u002D27\u0022,\u0022665\u0022\u003A\u00222027\u002D10\u002D28\u0022,\u0022666\u0022\u003A\u00222027\u002D10\u002D29\u0022,\u0022667\u0022\u003A\u00222027\u002D10\u002D30\u0022,\u0022668\u0022\u003A\u00222027\u002D10\u002D31\u0022,\u0022669\u0022\u003A\u00222027\u002D11\u002D01\u0022,\u0022670\u0022\u003A\u00222027\u002D11\u002D02\u0022,\u0022671\u0022\u003A\u00222027\u002D11\u002D03\u0022,\u0022672\u0022\u003A\u00222027\u002D11\u002D04\u0022,\u0022673\u0022\u003A\u00222027\u002D11\u002D05\u0022,\u0022674\u0022\u003A\u00222027\u002D11\u002D06\u0022,\u0022675\u0022\u003A\u00222027\u002D11\u002D07\u0022,\u0022676\u0022\u003A\u00222027\u002D11\u002D08\u0022,\u0022677\u0022\u003A\u00222027\u002D11\u002D09\u0022,\u0022678\u0022\u003A\u00222027\u002D11\u002D10\u0022,\u0022679\u0022\u003A\u00222027\u002D11\u002D11\u0022,\u0022680\u0022\u003A\u00222027\u002D11\u002D12\u0022,\u0022681\u0022\u003A\u00222027\u002D11\u002D13\u0022,\u0022682\u0022\u003A\u00222027\u002D11\u002D14\u0022,\u0022683\u0022\u003A\u00222027\u002D11\u002D15\u0022,\u0022684\u0022\u003A\u00222027\u002D11\u002D16\u0022,\u0022685\u0022\u003A\u00222027\u002D11\u002D17\u0022,\u0022686\u0022\u003A\u00222027\u002D11\u002D18\u0022,\u0022687\u0022\u003A\u00222027\u002D11\u002D19\u0022,\u0022688\u0022\u003A\u00222027\u002D11\u002D20\u0022,\u0022689\u0022\u003A\u00222027\u002D11\u002D21\u0022,\u0022690\u0022\u003A\u00222027\u002D11\u002D22\u0022,\u0022691\u0022\u003A\u00222027\u002D11\u002D23\u0022,\u0022692\u0022\u003A\u00222027\u002D11\u002D24\u0022,\u0022693\u0022\u003A\u00222027\u002D11\u002D25\u0022,\u0022694\u0022\u003A\u00222027\u002D11\u002D26\u0022,\u0022695\u0022\u003A\u00222027\u002D11\u002D27\u0022,\u0022696\u0022\u003A\u00222027\u002D11\u002D28\u0022,\u0022697\u0022\u003A\u00222027\u002D11\u002D29\u0022,\u0022698\u0022\u003A\u00222027\u002D11\u002D30\u0022,\u0022699\u0022\u003A\u00222027\u002D12\u002D01\u0022,\u0022700\u0022\u003A\u00222027\u002D12\u002D02\u0022,\u0022701\u0022\u003A\u00222027\u002D12\u002D03\u0022,\u0022702\u0022\u003A\u00222027\u002D12\u002D04\u0022,\u0022703\u0022\u003A\u00222027\u002D12\u002D05\u0022,\u0022704\u0022\u003A\u00222027\u002D12\u002D06\u0022,\u0022705\u0022\u003A\u00222027\u002D12\u002D07\u0022,\u0022706\u0022\u003A\u00222027\u002D12\u002D08\u0022,\u0022707\u0022\u003A\u00222027\u002D12\u002D09\u0022,\u0022708\u0022\u003A\u00222027\u002D12\u002D10\u0022,\u0022709\u0022\u003A\u00222027\u002D12\u002D11\u0022,\u0022710\u0022\u003A\u00222027\u002D12\u002D12\u0022,\u0022711\u0022\u003A\u00222027\u002D12\u002D13\u0022,\u0022712\u0022\u003A\u00222027\u002D12\u002D14\u0022,\u0022713\u0022\u003A\u00222027\u002D12\u002D15\u0022,\u0022714\u0022\u003A\u00222027\u002D12\u002D16\u0022,\u0022715\u0022\u003A\u00222027\u002D12\u002D17\u0022,\u0022716\u0022\u003A\u00222027\u002D12\u002D18\u0022,\u0022717\u0022\u003A\u00222027\u002D12\u002D19\u0022,\u0022718\u0022\u003A\u00222027\u002D12\u002D20\u0022,\u0022719\u0022\u003A\u00222027\u002D12\u002D21\u0022,\u0022720\u0022\u003A\u00222027\u002D12\u002D22\u0022,\u0022721\u0022\u003A\u00222027\u002D12\u002D23\u0022,\u0022722\u0022\u003A\u00222027\u002D12\u002D24\u0022,\u0022723\u0022\u003A\u00222027\u002D12\u002D25\u0022,\u0022724\u0022\u003A\u00222027\u002D12\u002D26\u0022,\u0022725\u0022\u003A\u00222027\u002D12\u002D27\u0022,\u0022726\u0022\u003A\u00222027\u002D12\u002D28\u0022,\u0022727\u0022\u003A\u00222027\u002D12\u002D29\u0022,\u0022728\u0022\u003A\u00222027\u002D12\u002D30\u0022,\u0022729\u0022\u003A\u00222027\u002D12\u002D31\u0022\u007D',
+							},
+			params: {
+				locale: 'it',
+				events: '\u005B\u007B\u0022title\u0022\u003A\u0022Michele\u0020Mariotti\u0020dirige\u0020il\u0020Concerto\u0020di\u0020Capodanno\u00202026\u0022,\u0022start\u0022\u003A\u00222026\u002D01\u002D01T11\u003A15\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2021\\\/01\\\/1.jpg\u0022,\u0022category\u0022\u003A\u0022Concerti\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/michele\u002Dmariotti\u002Ddirige\u002Dil\u002Dconcerto\u002Ddi\u002Dcapodanno\u002D2026\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Concerto\u0020di\u0020Capodanno\u0020al\u0020Gran\u0020Teatre\u0020del\u0020Liceu\u0022,\u0022start\u0022\u003A\u00222026\u002D01\u002D04T18\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/12\\\/Liceu_Sala_Inauguracio\\u0301.jpg\u0022,\u0022category\u0022\u003A\u0022tourn\\u00e9e\u0022,\u0022place\u0022\u003A\u0022Altre\u0020Sedi\u0022,\u0022place_value\u0022\u003A\u0022other_theaters\u0022,\u0022other_place\u0022\u003A\u0022Gran\u0020Teatre\u0020del\u0020Liceu\u0022,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/concerto\u002Ddi\u002Dcapodanno\u002Dal\u002Dgran\u002Dteatre\u002Ddel\u002Dliceu\\\/\u0022,\u0022entrance\u0022\u003A\u0022tournee\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Fenice.\u0020Mito,\u0020rinascita,\u0020metamorfosi\u0022,\u0022start\u0022\u003A\u00222026\u002D01\u002D07T18\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/12\\\/fenice_libro\u002Dedito\u002Dmarsilio.png\u0022,\u0022category\u0022\u003A\u0022Presentazione\u0020libro\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/presentazione\u002Dlibro\u002Dfenice\u002Dmito\u002Drinascita\u002Dmetamorfosi\\\/\u0022,\u0022entrance\u0022\u003A\u0022free\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Concerto\u0020diretto\u0020da\u0020Vincenzo\u0020Milletar\\u00ec\u0022,\u0022start\u0022\u003A\u00222026\u002D01\u002D10T20\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/vincenzo\u002Dmilletari\u002Dscaled\u002De1765889161785.jpg\u0022,\u0022category\u0022\u003A\u0022Concerti\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020Malibran\u0022,\u0022place_value\u0022\u003A\u0022theater_malibran\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dconcerto\u002Ddiretto\u002Dda\u002Dvincenzo\u002Dmilletari\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Concerto\u0020diretto\u0020da\u0020Vincenzo\u0020Milletar\\u00ec\u0022,\u0022start\u0022\u003A\u00222026\u002D01\u002D11T17\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/vincenzo\u002Dmilletari\u002Dscaled\u002De1765889161785.jpg\u0022,\u0022category\u0022\u003A\u0022Concerti\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020Malibran\u0022,\u0022place_value\u0022\u003A\u0022theater_malibran\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dconcerto\u002Ddiretto\u002Dda\u002Dvincenzo\u002Dmilletari\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022INCONTRO\u0020POSTICIPATO\u0020\u0026\u00238211\u003B\u0020Percorsi\u0020della\u0020danza\u0020\u0026\u00238211\u003B\u0020Temi,\u0020Varazioni\u0020e\u0020Code\u0022,\u0022start\u0022\u003A\u00222026\u002D01\u002D19T18\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/09\\\/vivandiere.jpg\u0022,\u0022category\u0022\u003A\u0022Danza\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/percorsi\u002Ddella\u002Ddanza\u002Dtemi\u002Dvarazioni\u002De\u002Dcode\\\/\u0022,\u0022entrance\u0022\u003A\u0022free\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Incontro\u0020con\u0020l\u0026\u00238217\u003Bopera\u003A\u0020Simon\u0020Boccanegra\u0022,\u0022start\u0022\u003A\u00222026\u002D01\u002D20T18\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2022\\\/02\\\/Schermata\u002D2022\u002D02\u002D17\u002Dalle\u002D11.00.58.png\u0022,\u0022category\u0022\u003A\u0022conferenze\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/incontro\u002Dcon\u002Dlopera\u002Dsimon\u002Dboccanegra\\\/\u0022,\u0022entrance\u0022\u003A\u0022free\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Simon\u0020Boccanegra\u0020\u0026\u00238211\u003B\u0020mettiamoci\u0020all\u0026\u00238217\u003Bopera\u0022,\u0022start\u0022\u003A\u00222026\u002D01\u002D21T10\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/09\\\/d7c_SIMON_BOCCANEGRA.jpg\u0022,\u0022category\u0022\u003A\u0022Fenice\u0020education\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003A\u0022Sale\u0020Apollinee\u0020e\u0020Teatro\u0020Malibran\u0022,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/simon\u002Dboccanegra\u002Dmettiamoci\u002Dallopera\\\/\u0022,\u0022entrance\u0022\u003A\u0022school\u0022,\u0022next_events\u0022\u003A\u005B\u007B\u0022start\u0022\u003A\u00222026\u002D01\u002D21T12\u003A00\u003A00\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022other_place\u0022\u003A\u0022Sale\u0020Apollinee\u0020e\u0020Teatro\u0020Malibran\u0022\u007D\u005D\u007D,\u005B\u005D,\u007B\u0022title\u0022\u003A\u0022Simon\u0020Boccanegra\u0022,\u0022start\u0022\u003A\u00222026\u002D01\u002D23T19\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/Simon\u002DBoccanegra_Piazzola_paginawebevento\u002Dscaled.png\u0022,\u0022category\u0022\u003A\u0022Opera\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dsimon\u002Dboccanegra\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Giorno\u0020della\u0020Memoria\u00202026\u0022,\u0022start\u0022\u003A\u00222026\u002D01\u002D25T10\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2022\\\/01\\\/giorno\u002Ddella\u002Dmemoria.jpg\u0022,\u0022category\u0022\u003A\u0022Altri\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/giorno\u002Ddella\u002Dmemoria\u002D2026\\\/\u0022,\u0022entrance\u0022\u003A\u0022book\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Simon\u0020Boccanegra\u0022,\u0022start\u0022\u003A\u00222026\u002D01\u002D25T15\u003A30\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/Simon\u002DBoccanegra_Piazzola_paginawebevento\u002Dscaled.png\u0022,\u0022category\u0022\u003A\u0022Opera\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dsimon\u002Dboccanegra\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Simon\u0020Boccanegra\u0022,\u0022start\u0022\u003A\u00222026\u002D01\u002D27T19\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/Simon\u002DBoccanegra_Piazzola_paginawebevento\u002Dscaled.png\u0022,\u0022category\u0022\u003A\u0022Opera\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dsimon\u002Dboccanegra\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Incontro\u0020con\u0020l\u0026\u00238217\u003Bopera\u003A\u0020Piccolo\u0020Orso\u0020e\u0020la\u0020Montagna\u0020di\u0020ghiaccio\u0022,\u0022start\u0022\u003A\u00222026\u002D01\u002D28T18\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/AZu7sJxc8dAugpnmz4ERpQ\u002DAZu7sJxcKZkbU_FjIJz1VA.jpg\u0022,\u0022category\u0022\u003A\u0022conferenze\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/incontro\u002Dcon\u002Dlopera\u002Dpiccolo\u002Dorso\u002De\u002Dla\u002Dmontagna\u002Ddi\u002Dghiaccio\\\/\u0022,\u0022entrance\u0022\u003A\u0022free\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Piccolo\u0020Orso\u0020e\u0020la\u0020Montagna\u0020di\u0020ghiaccio\u0020\u0028riservato\u0020alle\u0020scuole\u0029\u0022,\u0022start\u0022\u003A\u00222026\u002D01\u002D29T09\u003A30\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/777_PICCOLO_ORSO_banner.jpg\u0022,\u0022category\u0022\u003A\u0022Fenice\u0020education\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020Malibran\u0022,\u0022place_value\u0022\u003A\u0022theater_malibran\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/piccolo\u002Dorso\u002De\u002Dla\u002Dmontagna\u002Ddi\u002Dghiaccio\u002Driservato\u002Dalle\u002Dscuole\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022,\u0022next_events\u0022\u003A\u005B\u007B\u0022start\u0022\u003A\u00222026\u002D01\u002D29T12\u003A00\u003A00\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020Malibran\u0022,\u0022other_place\u0022\u003Anull\u007D\u005D\u007D,\u005B\u005D,\u007B\u0022title\u0022\u003A\u0022Simon\u0020Boccanegra\u0022,\u0022start\u0022\u003A\u00222026\u002D01\u002D29T19\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/Simon\u002DBoccanegra_Piazzola_paginawebevento\u002Dscaled.png\u0022,\u0022category\u0022\u003A\u0022Opera\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dsimon\u002Dboccanegra\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Piccolo\u0020Orso\u0020e\u0020la\u0020Montagna\u0020di\u0020ghiaccio\u0020\u0028riservato\u0020alle\u0020scuole\u0029\u0022,\u0022start\u0022\u003A\u00222026\u002D01\u002D30T09\u003A30\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/777_PICCOLO_ORSO_banner.jpg\u0022,\u0022category\u0022\u003A\u0022Fenice\u0020education\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020Malibran\u0022,\u0022place_value\u0022\u003A\u0022theater_malibran\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/piccolo\u002Dorso\u002De\u002Dla\u002Dmontagna\u002Ddi\u002Dghiaccio\u002Driservato\u002Dalle\u002Dscuole\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022,\u0022next_events\u0022\u003A\u005B\u007B\u0022start\u0022\u003A\u00222026\u002D01\u002D30T12\u003A00\u003A00\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020Malibran\u0022,\u0022other_place\u0022\u003Anull\u007D\u005D\u007D,\u005B\u005D,\u007B\u0022title\u0022\u003A\u0022Quartetto\u0020Indaco\u0022,\u0022start\u0022\u003A\u00222026\u002D01\u002D30T20\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/12\\\/Indaco1\u002Dscaled.png\u0022,\u0022category\u0022\u003A\u0022Musik\\u00e0mera\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/musikamera\u002Dquartetto\u002Dindaco\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Piccolo\u0020Orso\u0020e\u0020la\u0020Montagna\u0020di\u0020ghiaccio\u0022,\u0022start\u0022\u003A\u00222026\u002D01\u002D31T15\u003A30\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/AZu7sJxc8dAugpnmz4ERpQ\u002DAZu7sJxcKZkbU_FjIJz1VA.jpg\u0022,\u0022category\u0022\u003A\u0022Opera\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020Malibran\u0022,\u0022place_value\u0022\u003A\u0022theater_malibran\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/evento\u002D25\u002D26\u002Dpiccolo\u002Dorso\u002De\u002Dla\u002Dmontagna\u002Ddi\u002Dghiaccio\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Quartetto\u0020Indaco\u0022,\u0022start\u0022\u003A\u00222026\u002D01\u002D31T20\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/12\\\/Indaco1\u002Dscaled.png\u0022,\u0022category\u0022\u003A\u0022Musik\\u00e0mera\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/musikamera\u002Dquartetto\u002Dindaco\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Piccolo\u0020Orso\u0020e\u0020la\u0020Montagna\u0020di\u0020ghiaccio\u0022,\u0022start\u0022\u003A\u00222026\u002D02\u002D01T11\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/AZu7sJxc8dAugpnmz4ERpQ\u002DAZu7sJxcKZkbU_FjIJz1VA.jpg\u0022,\u0022category\u0022\u003A\u0022Opera\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020Malibran\u0022,\u0022place_value\u0022\u003A\u0022theater_malibran\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/evento\u002D25\u002D26\u002Dpiccolo\u002Dorso\u002De\u002Dla\u002Dmontagna\u002Ddi\u002Dghiaccio\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Simon\u0020Boccanegra\u0022,\u0022start\u0022\u003A\u00222026\u002D02\u002D01T15\u003A30\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/Simon\u002DBoccanegra_Piazzola_paginawebevento\u002Dscaled.png\u0022,\u0022category\u0022\u003A\u0022Opera\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dsimon\u002Dboccanegra\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Piccolo\u0020Orso\u0020e\u0020la\u0020Montagna\u0020di\u0020ghiaccio\u0020\u0028riservato\u0020alle\u0020scuole\u0029\u0022,\u0022start\u0022\u003A\u00222026\u002D02\u002D03T09\u003A30\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/777_PICCOLO_ORSO_banner.jpg\u0022,\u0022category\u0022\u003A\u0022Fenice\u0020education\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020Malibran\u0022,\u0022place_value\u0022\u003A\u0022theater_malibran\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/piccolo\u002Dorso\u002De\u002Dla\u002Dmontagna\u002Ddi\u002Dghiaccio\u002Driservato\u002Dalle\u002Dscuole\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022,\u0022next_events\u0022\u003A\u005B\u007B\u0022start\u0022\u003A\u00222026\u002D02\u002D03T12\u003A00\u003A00\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020Malibran\u0022,\u0022other_place\u0022\u003Anull\u007D\u005D\u007D,\u005B\u005D,\u007B\u0022title\u0022\u003A\u0022Ian\u0020Bostridge\u0020e\u0020Roberto\u0020Prosseda\u0022,\u0022start\u0022\u003A\u00222026\u002D02\u002D03T20\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/12\\\/0602\u002D3\u002Dscaled.jpg\u0022,\u0022category\u0022\u003A\u0022Musik\\u00e0mera\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/musikamera\u002Dian\u002Dbostridge\u002De\u002Droberto\u002Dprosseda\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Piccolo\u0020Orso\u0020e\u0020la\u0020Montagna\u0020di\u0020ghiaccio\u0020\u0028riservato\u0020alle\u0020scuole\u0029\u0022,\u0022start\u0022\u003A\u00222026\u002D02\u002D04T09\u003A30\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/777_PICCOLO_ORSO_banner.jpg\u0022,\u0022category\u0022\u003A\u0022Fenice\u0020education\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020Malibran\u0022,\u0022place_value\u0022\u003A\u0022theater_malibran\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/piccolo\u002Dorso\u002De\u002Dla\u002Dmontagna\u002Ddi\u002Dghiaccio\u002Driservato\u002Dalle\u002Dscuole\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022,\u0022next_events\u0022\u003A\u005B\u007B\u0022start\u0022\u003A\u00222026\u002D02\u002D04T12\u003A00\u003A00\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020Malibran\u0022,\u0022other_place\u0022\u003Anull\u007D\u005D\u007D,\u005B\u005D,\u007B\u0022title\u0022\u003A\u0022Ian\u0020Bostridge\u0020e\u0020Roberto\u0020Prosseda\u0022,\u0022start\u0022\u003A\u00222026\u002D02\u002D04T20\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/12\\\/0602\u002D3\u002Dscaled.jpg\u0022,\u0022category\u0022\u003A\u0022Musik\\u00e0mera\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/musikamera\u002Dian\u002Dbostridge\u002De\u002Droberto\u002Dprosseda\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Davide\u0020Alogna\u0020e\u0020Enrico\u0020Pace\u0022,\u0022start\u0022\u003A\u00222026\u002D02\u002D07T20\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/12\\\/enrico\u002Dpace\u002De\u002Ddavide\u002Dalogna.jpg\u0022,\u0022category\u0022\u003A\u0022Musik\\u00e0mera\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/musikamera\u002Ddavide\u002Dalogna\u002De\u002Denrico\u002Dpace\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022La\u0020traviata\u0022,\u0022start\u0022\u003A\u00222026\u002D02\u002D08T19\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/03_Traviata\u002D1\u002Dscaled\u002De1749112809878.jpg\u0022,\u0022category\u0022\u003A\u0022Opera\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dla\u002Dtraviata\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Gidon\u0020Kremer\u0020\u0026\u0023038\u003B\u0020Kremerata\u0020Baltica\u0022,\u0022start\u0022\u003A\u00222026\u002D02\u002D09T20\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/Angie\u002DKremer\u002DPhotography1\u002De1749460835330.jpg\u0022,\u0022category\u0022\u003A\u0022Concerti\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dgidon\u002Dkremer\u002Dkremerata\u002Dbaltica\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Simon\u0020Boccanegra\u0022,\u0022start\u0022\u003A\u00222026\u002D02\u002D10T19\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/Simon\u002DBoccanegra_Piazzola_paginawebevento\u002Dscaled.png\u0022,\u0022category\u0022\u003A\u0022Opera\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dsimon\u002Dboccanegra\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022La\u0020traviata\u0022,\u0022start\u0022\u003A\u00222026\u002D02\u002D11T19\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/03_Traviata\u002D1\u002Dscaled\u002De1749112809878.jpg\u0022,\u0022category\u0022\u003A\u0022Opera\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dla\u002Dtraviata\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Simon\u0020Boccanegra\u0022,\u0022start\u0022\u003A\u00222026\u002D02\u002D12T19\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/Simon\u002DBoccanegra_Piazzola_paginawebevento\u002Dscaled.png\u0022,\u0022category\u0022\u003A\u0022Opera\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dsimon\u002Dboccanegra\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022La\u0020traviata\u0022,\u0022start\u0022\u003A\u00222026\u002D02\u002D13T19\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/03_Traviata\u002D1\u002Dscaled\u002De1749112809878.jpg\u0022,\u0022category\u0022\u003A\u0022Opera\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dla\u002Dtraviata\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Simon\u0020Boccanegra\u0020\u0026\u0023038\u003B\u0020Carnival\u0020Cocktail\u0022,\u0022start\u0022\u003A\u00222026\u002D02\u002D14T15\u003A30\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/12\\\/LaFenice_Carnevale\u002D160n\u002Dscaled.jpg\u0022,\u0022category\u0022\u003A\u0022\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/simon\u002Dboccanegra\u002Dcarnival\u002Dcocktail\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Simon\u0020Boccanegra\u0022,\u0022start\u0022\u003A\u00222026\u002D02\u002D14T15\u003A30\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/Simon\u002DBoccanegra_Piazzola_paginawebevento\u002Dscaled.png\u0022,\u0022category\u0022\u003A\u0022Opera\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dsimon\u002Dboccanegra\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022La\u0020traviata\u0022,\u0022start\u0022\u003A\u00222026\u002D02\u002D15T17\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/03_Traviata\u002D1\u002Dscaled\u002De1749112809878.jpg\u0022,\u0022category\u0022\u003A\u0022Opera\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dla\u002Dtraviata\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022La\u0020traviata\u0022,\u0022start\u0022\u003A\u00222026\u002D02\u002D17T19\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/03_Traviata\u002D1\u002Dscaled\u002De1749112809878.jpg\u0022,\u0022category\u0022\u003A\u0022Opera\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dla\u002Dtraviata\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Trio\u0020Orelon\u0022,\u0022start\u0022\u003A\u00222026\u002D02\u002D18T20\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/12\\\/Orelon2.png\u0022,\u0022category\u0022\u003A\u0022Musik\\u00e0mera\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/musikamera\u002Dtrio\u002Dorelon\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022XXI\u0020Concerto\u0020per\u0020il\u0020Mercoled\\u00ec\u0020delle\u0020Ceneri\u0022,\u0022start\u0022\u003A\u00222026\u002D02\u002D18T20\u003A30\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2022\\\/01\\\/Venezia_chiesa_dei_carmini_01\u002De1643276984584.jpeg\u0022,\u0022category\u0022\u003A\u0022Altri\u0022,\u0022place\u0022\u003A\u0022Altre\u0020Sedi\u0022,\u0022place_value\u0022\u003A\u0022other_theaters\u0022,\u0022other_place\u0022\u003A\u0022Chiesa\u0020di\u0020Santa\u0020Maria\u0020del\u0020Carmelo\u0020\u0028Carmini\u0029\u0022,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/xxi\u002Dconcerto\u002Dper\u002Dil\u002Dmercoledi\u002Ddelle\u002Dceneri\\\/\u0022,\u0022entrance\u0022\u003A\u0022free\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Trio\u0020Orelon\u0022,\u0022start\u0022\u003A\u00222026\u002D02\u002D19T20\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/12\\\/Orelon2.png\u0022,\u0022category\u0022\u003A\u0022Musik\\u00e0mera\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/musikamera\u002Dtrio\u002Dorelon\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Percorsi\u0020della\u0020danza\u0020\u0026\u00238211\u003B\u0020\u0026\u00238220\u003B1960\u0020Passi\u0020di\u0020Danza\u0026\u00238221\u003B\u0022,\u0022start\u0022\u003A\u00222026\u002D02\u002D20T18\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/09\\\/ballettodiroma\u002D1960\u002Dpassi\u002Ddi\u002Ddanza\u002De1758094194971.jpg\u0022,\u0022category\u0022\u003A\u0022Danza\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/percorsi\u002Ddella\u002Ddanza\u002Dlibro\u002D1960\u002Dpassi\u002Ddi\u002Ddanza\\\/\u0022,\u0022entrance\u0022\u003A\u0022free\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Andr\\u00e9s\u0020Barrios\u0020Trio\u0022,\u0022start\u0022\u003A\u00222026\u002D02\u002D21T19\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/12\\\/AndresBarrios\u002De1765791150591.jpeg\u0022,\u0022category\u0022\u003A\u0022JAZZ\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/jazz\u002Dandres\u002Dbarrios\u002Dtrio\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Lo\u0020Schiaccianoci\u0020\u0026\u00238211\u003B\u0020mettiamoci\u0020all\u0026\u00238217\u003Bopera\u0022,\u0022start\u0022\u003A\u00222026\u002D02\u002D24T10\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/09\\\/f26_SCHIACCIANOCI.jpg\u0022,\u0022category\u0022\u003A\u0022Fenice\u0020education\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003A\u0022Sale\u0020Apollinee\u0020e\u0020Teatro\u0020Malibran\u0022,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/lo\u002Dschiaccianoci\u002Dmettiamoci\u002Dallopera\\\/\u0022,\u0022entrance\u0022\u003A\u0022school\u0022,\u0022next_events\u0022\u003A\u005B\u007B\u0022start\u0022\u003A\u00222026\u002D02\u002D24T12\u003A00\u003A00\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022other_place\u0022\u003A\u0022Sale\u0020Apollinee\u0020e\u0020Teatro\u0020Malibran\u0022\u007D\u005D\u007D,\u005B\u005D,\u007B\u0022title\u0022\u003A\u0022Incontro\u0020con\u0020il\u0020balletto\u003A\u0020Lo\u0020schiaccianoci\u0022,\u0022start\u0022\u003A\u00222026\u002D02\u002D24T18\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2022\\\/02\\\/Schermata\u002D2022\u002D02\u002D17\u002Dalle\u002D11.00.58.png\u0022,\u0022category\u0022\u003A\u0022conferenze\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/incontro\u002Dcon\u002Dil\u002Dballetto\u002Dlo\u002Dschiaccianoci\\\/\u0022,\u0022entrance\u0022\u003A\u0022free\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Lo\u0020schiaccianoci\u0022,\u0022start\u0022\u003A\u00222026\u002D02\u002D25T19\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/schiaccianoci_operanazionalebudapest_stagione2526.jpg\u0022,\u0022category\u0022\u003A\u0022Danza\u00202025\\\/26\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/danza\u002D25\u002D26\u002Dlo\u002Dschiaccianoci\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Lo\u0020schiaccianoci\u0022,\u0022start\u0022\u003A\u00222026\u002D02\u002D26T19\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/schiaccianoci_operanazionalebudapest_stagione2526.jpg\u0022,\u0022category\u0022\u003A\u0022Danza\u00202025\\\/26\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/danza\u002D25\u002D26\u002Dlo\u002Dschiaccianoci\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Lo\u0020schiaccianoci\u0022,\u0022start\u0022\u003A\u00222026\u002D02\u002D27T19\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/schiaccianoci_operanazionalebudapest_stagione2526.jpg\u0022,\u0022category\u0022\u003A\u0022Danza\u00202025\\\/26\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/danza\u002D25\u002D26\u002Dlo\u002Dschiaccianoci\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Lo\u0020schiaccianoci\u0022,\u0022start\u0022\u003A\u00222026\u002D02\u002D28T15\u003A30\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/schiaccianoci_operanazionalebudapest_stagione2526.jpg\u0022,\u0022category\u0022\u003A\u0022Danza\u00202025\\\/26\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/danza\u002D25\u002D26\u002Dlo\u002Dschiaccianoci\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Lo\u0020schiaccianoci\u0022,\u0022start\u0022\u003A\u00222026\u002D03\u002D01T15\u003A30\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/schiaccianoci_operanazionalebudapest_stagione2526.jpg\u0022,\u0022category\u0022\u003A\u0022Danza\u00202025\\\/26\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/danza\u002D25\u002D26\u002Dlo\u002Dschiaccianoci\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Recital\u0020lirico\u0020\u0028Francesco\u0020Meli,\u0020Luca\u0020Salsi\u0029\u0022,\u0022start\u0022\u003A\u00222026\u002D03\u002D02T20\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/1\u002D3.jpg\u0022,\u0022category\u0022\u003A\u0022Concerti\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Drecital\u002Dlirico\u002Dfrancesco\u002Dmeli\u002Dluca\u002Dsalsi\u002De\u002Dnelson\u002Dcalzi\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Chaos\u0020String\u0020Quartet\u0022,\u0022start\u0022\u003A\u00222026\u002D03\u002D03T20\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/12\\\/Chaos2\u002Dscaled.png\u0022,\u0022category\u0022\u003A\u0022Musik\\u00e0mera\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/musikamera\u002Dchaos\u002Dstring\u002Dquartet\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Chaos\u0020String\u0020Quartet\u0022,\u0022start\u0022\u003A\u00222026\u002D03\u002D04T20\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/12\\\/Chaos2\u002Dscaled.png\u0022,\u0022category\u0022\u003A\u0022Musik\\u00e0mera\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/musikamera\u002Dchaos\u002Dstring\u002Dquartet\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Duo\u0020di\u0020percussioni\u0020\u0028lezione\u002Dconcerto\u0029\u0022,\u0022start\u0022\u003A\u00222026\u002D03\u002D05T10\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/09\\\/cbd_PERCUSSIONI.jpg\u0022,\u0022category\u0022\u003A\u0022Fenice\u0020education\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/duo\u002Ddi\u002Dpercussioni\u002Dlezione\u002Dconcerto\\\/\u0022,\u0022entrance\u0022\u003A\u0022school\u0022,\u0022next_events\u0022\u003A\u005B\u007B\u0022start\u0022\u003A\u00222026\u002D03\u002D05T12\u003A00\u003A00\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022other_place\u0022\u003Anull\u007D\u005D\u007D,\u005B\u005D,\u007B\u0022title\u0022\u003A\u0022Concerto\u0020diretto\u0020da\u0020Constantinos\u0020Carydis\u0022,\u0022start\u0022\u003A\u00222026\u002D03\u002D06T20\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/Y_260517\u002DConstantinos\u002DHigh\u002Dres\u002DThomas\u002DBrill_YMCK_R\u002De1749462878865.jpg\u0022,\u0022category\u0022\u003A\u0022Concerti\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dconcerto\u002Ddiretto\u002Dda\u002Dconstantinos\u002Dcarydis\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Concerto\u0020diretto\u0020da\u0020Constantinos\u0020Carydis\u0020\u0026\u00238211\u003B\u0020PROMO\u0020UNDER35\u0022,\u0022start\u0022\u003A\u00222026\u002D03\u002D07T20\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2026\\\/03\\\/under35_raimondo_slide.jpg\u0022,\u0022category\u0022\u003A\u0022Concerti\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/under35\u002Dconcerto\u002Ddiretto\u002Dda\u002Dconstantinos\u002Dcarydis\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Concerto\u0020diretto\u0020da\u0020Constantinos\u0020Carydis\u0022,\u0022start\u0022\u003A\u00222026\u002D03\u002D07T20\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/Y_260517\u002DConstantinos\u002DHigh\u002Dres\u002DThomas\u002DBrill_YMCK_R\u002De1749462878865.jpg\u0022,\u0022category\u0022\u003A\u0022Concerti\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dconcerto\u002Ddiretto\u002Dda\u002Dconstantinos\u002Dcarydis\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Concerto\u0020diretto\u0020da\u0020Constantinos\u0020Carydis\u0022,\u0022start\u0022\u003A\u00222026\u002D03\u002D08T17\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/Y_260517\u002DConstantinos\u002DHigh\u002Dres\u002DThomas\u002DBrill_YMCK_R\u002De1749462878865.jpg\u0022,\u0022category\u0022\u003A\u0022Concerti\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dconcerto\u002Ddiretto\u002Dda\u002Dconstantinos\u002Dcarydis\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Percorsi\u0020della\u0020danza\u0020\u0026\u00238211\u003B\u0020Temi,\u0020Variazioni\u0020e\u0020Code\u0022,\u0022start\u0022\u003A\u00222026\u002D03\u002D09T18\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/09\\\/vivandiere.jpg\u0022,\u0022category\u0022\u003A\u0022Danza\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/percorsi\u002Ddella\u002Ddanza\u002Dtemi\u002Dvariazioni\u002De\u002Dcode\\\/\u0022,\u0022entrance\u0022\u003A\u0022free\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Enrico\u0020Bronzi\u0020in\u0020concerto\u0022,\u0022start\u0022\u003A\u00222026\u002D03\u002D10T20\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/12\\\/Bronzi_violoncello.jpg\u0022,\u0022category\u0022\u003A\u0022Musik\\u00e0mera\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/musikamer\u002Denrico\u002Dbronzi\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Enrico\u0020Bronzi\u0020in\u0020concerto\u0022,\u0022start\u0022\u003A\u00222026\u002D03\u002D11T20\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/12\\\/Bronzi_violoncello.jpg\u0022,\u0022category\u0022\u003A\u0022Musik\\u00e0mera\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/musikamer\u002Denrico\u002Dbronzi\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Tom\u0020Ollendorff\u0020Quartet\u0020\u0026\u00238211\u003B\u0020Where\u0020in\u0020the\u0020World\u0022,\u0022start\u0022\u003A\u00222026\u002D03\u002D14T19\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2026\\\/01\\\/DSCF1937\u002Dcopy.jpeg\u0022,\u0022category\u0022\u003A\u0022JAZZ\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/veneto\u002Djazz\u002Dtom\u002Dollendorff\u002Dquartet\u002Dwhere\u002Din\u002Dthe\u002Dworld\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Axel\u0020Trolese\u0020in\u0020recital\u0022,\u0022start\u0022\u003A\u00222026\u002D03\u002D15T20\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2026\\\/02\\\/getpubthumb.png\u0022,\u0022category\u0022\u003A\u0022Archivio\u0020Musicale\u0020Guido\u0020Alberto\u0020Fano\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/axel\u002Dtrolese\u002Din\u002Drecital\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Ottone\u0020in\u0020villa\u0020\u0026\u00238211\u003B\u0020mettiamoci\u0020all\u0026\u00238217\u003Bopera\u0022,\u0022start\u0022\u003A\u00222026\u002D03\u002D17T10\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/09\\\/fcf_OTTONE_IN_VILLA.jpg\u0022,\u0022category\u0022\u003A\u0022Fenice\u0020education\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003A\u0022Sale\u0020Apollinee\u0020e\u0020Teatro\u0020Malibran\u0022,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/ottone\u002Din\u002Dvilla\u002Dmettiamoci\u002Dallopera\\\/\u0022,\u0022entrance\u0022\u003A\u0022school\u0022,\u0022next_events\u0022\u003A\u005B\u007B\u0022start\u0022\u003A\u00222026\u002D03\u002D17T12\u003A00\u003A00\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022other_place\u0022\u003A\u0022Sale\u0020Apollinee\u0020e\u0020Teatro\u0020Malibran\u0022\u007D\u005D\u007D,\u005B\u005D,\u007B\u0022title\u0022\u003A\u0022Incontro\u0020con\u0020l\u0026\u00238217\u003Bopera\u003A\u0020Ottone\u0020in\u0020villa\u0022,\u0022start\u0022\u003A\u00222026\u002D03\u002D17T18\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2022\\\/02\\\/Schermata\u002D2022\u002D02\u002D17\u002Dalle\u002D11.00.58.png\u0022,\u0022category\u0022\u003A\u0022conferenze\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/incontro\u002Dcon\u002Dlopera\u002Dottone\u002Din\u002Dvilla\\\/\u0022,\u0022entrance\u0022\u003A\u0022free\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Tentarmi\u0020\\u00e8\u0020vanit\\u00e0\u0022,\u0022start\u0022\u003A\u00222026\u002D03\u002D20T18\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2026\\\/01\\\/romanzo_tentarmi_vanita_annunziata.png\u0022,\u0022category\u0022\u003A\u0022Presentazione\u0020libro\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/libro\u002Dtentarmi\u002De\u002Dvanita\\\/\u0022,\u0022entrance\u0022\u003A\u0022free\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Ottone\u0020in\u0020villa\u0022,\u0022start\u0022\u003A\u00222026\u002D03\u002D20T19\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/ottone\u002Din\u002Dvilla_evento_web\u002Dscaled.png\u0022,\u0022category\u0022\u003A\u0022Opera\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020Malibran\u0022,\u0022place_value\u0022\u003A\u0022theater_malibran\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dottone\u002Din\u002Dvilla\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Antonii\u0020Baryshevskyi\u0020in\u0020recital\u0022,\u0022start\u0022\u003A\u00222026\u002D03\u002D21T19\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2026\\\/02\\\/Baryshevskyi\u002DAntonii\u002DLR\u002D4\u002DCopy\u002Dscaled\u002De1771833813594.jpg\u0022,\u0022category\u0022\u003A\u0022venezia\u0020piano\u0020festival\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/antonii\u002Dbaryshevskyi\u002Din\u002Drecital\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Ottone\u0020in\u0020villa\u0022,\u0022start\u0022\u003A\u00222026\u002D03\u002D22T15\u003A30\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/ottone\u002Din\u002Dvilla_evento_web\u002Dscaled.png\u0022,\u0022category\u0022\u003A\u0022Opera\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020Malibran\u0022,\u0022place_value\u0022\u003A\u0022theater_malibran\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dottone\u002Din\u002Dvilla\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Evgeny\u0020Kissin\u0020in\u0020concerto\u0022,\u0022start\u0022\u003A\u00222026\u002D03\u002D22T20\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/12\\\/Evgeny_Kissin_in_2021\u002Dscaled.jpg\u0022,\u0022category\u0022\u003A\u0022Musik\\u00e0mera\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/musikamera\u002Devgeny\u002Dkissin\u002Din\u002Dconcerto\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Duo\u0020violoncello\u0020e\u0020pianoforte\u0020\u0028lezione\u002Dconcerto\u0029\u0022,\u0022start\u0022\u003A\u00222026\u002D03\u002D24T10\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/09\\\/0b8_PIANO_VIOLONCELLO.jpg\u0022,\u0022category\u0022\u003A\u0022Fenice\u0020education\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/duo\u002Dvioloncello\u002De\u002Dpianoforte\u002Dlezione\u002Dconcerto\\\/\u0022,\u0022entrance\u0022\u003A\u0022school\u0022,\u0022next_events\u0022\u003A\u005B\u007B\u0022start\u0022\u003A\u00222026\u002D03\u002D24T12\u003A00\u003A00\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022other_place\u0022\u003Anull\u007D\u005D\u007D,\u005B\u005D,\u007B\u0022title\u0022\u003A\u0022Ottone\u0020in\u0020villa\u0022,\u0022start\u0022\u003A\u00222026\u002D03\u002D24T19\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/ottone\u002Din\u002Dvilla_evento_web\u002Dscaled.png\u0022,\u0022category\u0022\u003A\u0022Opera\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020Malibran\u0022,\u0022place_value\u0022\u003A\u0022theater_malibran\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dottone\u002Din\u002Dvilla\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Ars\u0020Trio\u0020di\u0020Roma\u0022,\u0022start\u0022\u003A\u00222026\u002D03\u002D25T20\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/12\\\/14\u002DArsTriodiRoma.jpg\u0022,\u0022category\u0022\u003A\u0022Musik\\u00e0mera\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/musikamera\u002Dars\u002Dtrio\u002Ddi\u002Droma\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Elia\u0020Cecino\u0020in\u0020recital\u0022,\u0022start\u0022\u003A\u00222026\u002D03\u002D26T19\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2026\\\/02\\\/3937_Elia\u002DCecino.jpg\u0022,\u0022category\u0022\u003A\u0022venezia\u0020piano\u0020festival\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/venezia\u002Dpiano\u002Dfestival\u002Delia\u002Dcecino\u002Din\u002Drecital\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Ottone\u0020in\u0020villa\u0022,\u0022start\u0022\u003A\u00222026\u002D03\u002D26T19\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/ottone\u002Din\u002Dvilla_evento_web\u002Dscaled.png\u0022,\u0022category\u0022\u003A\u0022Opera\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020Malibran\u0022,\u0022place_value\u0022\u003A\u0022theater_malibran\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dottone\u002Din\u002Dvilla\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Schipilliti,\u0020\u0026\u00238220\u003BGiuseppe\u0020Tartini\u0026\u00238221\u003B\u0020\u0026\u00238211\u003B\u0020PRESENTAZIONE\u0020LIBRO\u0022,\u0022start\u0022\u003A\u00222026\u002D03\u002D27T18\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2026\\\/03\\\/Tartini\u002De1773130349838.jpg\u0022,\u0022category\u0022\u003A\u0022Presentazione\u0020libro\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/schipilliti\u002Dgiuseppe\u002Dtartini\u002Dpresentazione\u002Dlibro\\\/\u0022,\u0022entrance\u0022\u003A\u0022free\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022David\u0020Helbock\u0020\\\/\u0020Julia\u0020Hofer\u0020Duo\u0022,\u0022start\u0022\u003A\u00222026\u002D03\u002D28T19\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/12\\\/David_Helbock_Julia_Hofer_by_Severin_Koller_web_4.jpeg\u0022,\u0022category\u0022\u003A\u0022JAZZ\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/david\u002Dhelbock\u002Djulia\u002Dhofer\u002Dduo\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Ottone\u0020in\u0020villa\u0022,\u0022start\u0022\u003A\u00222026\u002D03\u002D29T15\u003A30\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/ottone\u002Din\u002Dvilla_evento_web\u002Dscaled.png\u0022,\u0022category\u0022\u003A\u0022Opera\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020Malibran\u0022,\u0022place_value\u0022\u003A\u0022theater_malibran\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dottone\u002Din\u002Dvilla\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Federico\u0020Fiorio\u0020e\u0020Karalis\u0020Antiqua\u0020Ensemble\u0022,\u0022start\u0022\u003A\u00222026\u002D03\u002D31T20\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/12\\\/KA2026\u002D2.jpg\u0022,\u0022category\u0022\u003A\u0022Musik\\u00e0mera\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/musikamera\u002Dfederico\u002Dfiorio\u002De\u002Dkaralis\u002Dantiqua\u002Densemble\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Federico\u0020Fiorio\u0020e\u0020Karalis\u0020Antiqua\u0020Ensemble\u0022,\u0022start\u0022\u003A\u00222026\u002D04\u002D01T20\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/12\\\/KA2026\u002D2.jpg\u0022,\u0022category\u0022\u003A\u0022Musik\\u00e0mera\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/musikamera\u002Dfederico\u002Dfiorio\u002De\u002Dkaralis\u002Dantiqua\u002Densemble\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Incontro\u0020con\u0020l\u0026\u00238217\u003Bopera\u003A\u0020Lohengrin\u0022,\u0022start\u0022\u003A\u00222026\u002D04\u002D02T18\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2022\\\/02\\\/Schermata\u002D2022\u002D02\u002D17\u002Dalle\u002D11.00.58.png\u0022,\u0022category\u0022\u003A\u0022conferenze\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/incontro\u002Dcon\u002Dlopera\u002Dlohengrin\\\/\u0022,\u0022entrance\u0022\u003A\u0022free\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Concerto\u0020diretto\u0020da\u0020Michael\u0020Hofstetter\u0022,\u0022start\u0022\u003A\u00222026\u002D04\u002D03T20\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/Michael\u002DHofstetter_ph\u002DStuart\u002DArmitt\u002De1774854105993.jpg\u0022,\u0022category\u0022\u003A\u0022Concerti\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dconcerto\u002Ddiretto\u002Dda\u002Dmichael\u002Dhofstetter\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Concerto\u0020diretto\u0020da\u0020Michael\u0020Hofstetter\u0022,\u0022start\u0022\u003A\u00222026\u002D04\u002D04T17\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/Michael\u002DHofstetter_ph\u002DStuart\u002DArmitt\u002De1774854105993.jpg\u0022,\u0022category\u0022\u003A\u0022Concerti\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dconcerto\u002Ddiretto\u002Dda\u002Dmichael\u002Dhofstetter\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Concerto\u0020per\u0020la\u0020giornata\u0020internazionale\u0020della\u0020Popolazione\u0020Romani\u0022,\u0022start\u0022\u003A\u00222026\u002D04\u002D07T10\u003A30\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2023\\\/10\\\/1\u002D3.jpg\u0022,\u0022category\u0022\u003A\u0022\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/concerto\u002Dper\u002Dla\u002Dgiornata\u002Dinternazionale\u002Ddella\u002Dpopolazione\u002Dromani\\\/\u0022,\u0022entrance\u0022\u003A\u0022free\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Marina\u0020de\u0020Liso,\u0020Francesco\u0020Galligioni\u0020e\u0020Roberto\u0020Loreggian\u0022,\u0022start\u0022\u003A\u00222026\u002D04\u002D08T20\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/12\\\/DeLiso1.png\u0022,\u0022category\u0022\u003A\u0022Musik\\u00e0mera\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/musikamera\u002Dmarina\u002Dde\u002Dliso\u002Dfrancesco\u002Dgalligioni\u002De\u002Droberto\u002Dloreggian\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Lohengrin\u0020\u0026\u00238211\u003B\u0020mettiamoci\u0020all\u0026\u00238217\u003Bopera\u0022,\u0022start\u0022\u003A\u00222026\u002D04\u002D09T10\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/09\\\/1a8_LOHENGRIN.jpg\u0022,\u0022category\u0022\u003A\u0022Fenice\u0020education\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003A\u0022Sale\u0020Apollinee\u0020e\u0020Teatro\u0020Malibran\u0022,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/lohengrin\u002Dmettiamoci\u002Dallopera\\\/\u0022,\u0022entrance\u0022\u003A\u0022school\u0022,\u0022next_events\u0022\u003A\u005B\u007B\u0022start\u0022\u003A\u00222026\u002D04\u002D09T12\u003A00\u003A00\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022other_place\u0022\u003A\u0022Sale\u0020Apollinee\u0020e\u0020Teatro\u0020Malibran\u0022\u007D\u005D\u007D,\u005B\u005D,\u007B\u0022title\u0022\u003A\u0022Danny\u0020Grissett\u0020trio\\u2028\u0022,\u0022start\u0022\u003A\u00222026\u002D04\u002D11T19\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/12\\\/Danny\u002DGrissett.jpeg\u0022,\u0022category\u0022\u003A\u0022JAZZ\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/danny\u002Dgrissett\u002Dtrio\u0025e2\u002580\u0025a8\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Lohengrin\u0022,\u0022start\u0022\u003A\u00222026\u002D04\u002D12T18\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/Screenshot\u002D2026\u002D04\u002D02\u002Dalle\u002D09.03.32\u002Dscaled.png\u0022,\u0022category\u0022\u003A\u0022Opera\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dlohengrin\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Incontro\u0020con\u0020l\u0026\u00238217\u003Bopera\u003A\u0020Il\u0020piccolo\u0020principe\u0022,\u0022start\u0022\u003A\u00222026\u002D04\u002D13T18\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2022\\\/02\\\/Schermata\u002D2022\u002D02\u002D17\u002Dalle\u002D11.00.58.png\u0022,\u0022category\u0022\u003A\u0022conferenze\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/incontro\u002Dcon\u002Dlopera\u002Dil\u002Dpiccolo\u002Dprincipe\\\/\u0022,\u0022entrance\u0022\u003A\u0022free\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Il\u0020piccolo\u0020principe\u0020\u0028riservato\u0020alle\u0020scuole\u0029\u0022,\u0022start\u0022\u003A\u00222026\u002D04\u002D15T11\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/c5a_PICCOLO_PRINCIPE.jpg\u0022,\u0022category\u0022\u003A\u0022Fenice\u0020education\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020Malibran\u0022,\u0022place_value\u0022\u003A\u0022theater_malibran\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/education\u002D25\u002D26\u002Dil\u002Dpiccolo\u002Dprincipe\u002Driservato\u002Dalle\u002Dscuole\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Lohengrin\u0022,\u0022start\u0022\u003A\u00222026\u002D04\u002D15T18\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/Screenshot\u002D2026\u002D04\u002D02\u002Dalle\u002D09.03.32\u002Dscaled.png\u0022,\u0022category\u0022\u003A\u0022Opera\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dlohengrin\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Il\u0020piccolo\u0020principe\u0020\u0028riservato\u0020alle\u0020scuole\u0029\u0022,\u0022start\u0022\u003A\u00222026\u002D04\u002D16T11\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/c5a_PICCOLO_PRINCIPE.jpg\u0022,\u0022category\u0022\u003A\u0022Fenice\u0020education\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020Malibran\u0022,\u0022place_value\u0022\u003A\u0022theater_malibran\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/education\u002D25\u002D26\u002Dil\u002Dpiccolo\u002Dprincipe\u002Driservato\u002Dalle\u002Dscuole\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Il\u0020piccolo\u0020principe\u0020\u0028riservato\u0020alle\u0020scuole\u0029\u0022,\u0022start\u0022\u003A\u00222026\u002D04\u002D17T11\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/c5a_PICCOLO_PRINCIPE.jpg\u0022,\u0022category\u0022\u003A\u0022Fenice\u0020education\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020Malibran\u0022,\u0022place_value\u0022\u003A\u0022theater_malibran\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/education\u002D25\u002D26\u002Dil\u002Dpiccolo\u002Dprincipe\u002Driservato\u002Dalle\u002Dscuole\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Concerto\u0020diretto\u0020da\u0020Markus\u0020Stenz\u0022,\u0022start\u0022\u003A\u00222026\u002D04\u002D17T20\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/Markus\u002DStenz\u002Ddirige\u002Dl\u002DOrchestra\u002DLa\u002DFenice.jpg\u0022,\u0022category\u0022\u003A\u0022Concerti\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dconcerto\u002Ddiretto\u002Dda\u002Dmarkus\u002Dstenz\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Il\u0020piccolo\u0020principe\u0022,\u0022start\u0022\u003A\u00222026\u002D04\u002D18T15\u003A30\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/PICCOLO\u002DPRINCIPE.jpg\u0022,\u0022category\u0022\u003A\u0022Opera\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020Malibran\u0022,\u0022place_value\u0022\u003A\u0022theater_malibran\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/evento\u002D25\u002D26\u002Dil\u002Dpiccolo\u002Dprincipe\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Concerto\u0020diretto\u0020da\u0020Markus\u0020Stenz\u0022,\u0022start\u0022\u003A\u00222026\u002D04\u002D18T17\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/Markus\u002DStenz\u002Ddirige\u002Dl\u002DOrchestra\u002DLa\u002DFenice.jpg\u0022,\u0022category\u0022\u003A\u0022Concerti\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dconcerto\u002Ddiretto\u002Dda\u002Dmarkus\u002Dstenz\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Lohengrin\u0022,\u0022start\u0022\u003A\u00222026\u002D04\u002D19T15\u003A30\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/Screenshot\u002D2026\u002D04\u002D02\u002Dalle\u002D09.03.32\u002Dscaled.png\u0022,\u0022category\u0022\u003A\u0022Opera\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dlohengrin\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Sara\u0020Mingardo,\u0020Zoreslava\u0020Vynnyk,\u0020Edoardo\u0020Blasetti\u0020e\u0020Valeria\u0020Montanari\u0022,\u0022start\u0022\u003A\u00222026\u002D04\u002D21T20\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2023\\\/10\\\/1\u002D3.jpg\u0022,\u0022category\u0022\u003A\u0022Musik\\u00e0mera\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/musikamera\u002Dsara\u002Dmingardo\u002Dzoreslava\u002Dvynnyk\u002Dedoardo\u002Dblasetti\u002De\u002Dvaleria\u002Dmontanari\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Anche\u0020l\u0026\u00238217\u003BArgentina\u0020suona\u0021\u0020\u0028lezione\u002Dconcerto\u0029\u0022,\u0022start\u0022\u003A\u00222026\u002D04\u002D22T10\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/09\\\/5ec_TANGO.jpg\u0022,\u0022category\u0022\u003A\u0022Fenice\u0020education\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/anche\u002Dlargentina\u002Dsuona\u002Dlezione\u002Dconcerto\\\/\u0022,\u0022entrance\u0022\u003A\u0022school\u0022,\u0022next_events\u0022\u003A\u005B\u007B\u0022start\u0022\u003A\u00222026\u002D04\u002D22T12\u003A00\u003A00\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022other_place\u0022\u003Anull\u007D\u005D\u007D,\u005B\u005D,\u007B\u0022title\u0022\u003A\u0022Lohengrin\u0022,\u0022start\u0022\u003A\u00222026\u002D04\u002D22T18\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/Screenshot\u002D2026\u002D04\u002D02\u002Dalle\u002D09.03.32\u002Dscaled.png\u0022,\u0022category\u0022\u003A\u0022Opera\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dlohengrin\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Percorsi\u0020della\u0020danza\u0020\u0026\u00238211\u003B\u0020Rudolf\u0020Nureyev\u0020vs\u0020Marius\u0020Petipa\u0022,\u0022start\u0022\u003A\u00222026\u002D04\u002D23T18\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/09\\\/lacnoureev\u002D1.jpg\u0022,\u0022category\u0022\u003A\u0022Danza\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/percorsi\u002Ddella\u002Ddanza\u002Drudolph\u002Dnureev\u002Dvs\u002Dmarius\u002Dpetipa\\\/\u0022,\u0022entrance\u0022\u003A\u0022free\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Dulce\u0020Pontes\u002035\u0020Anos\u0020Tour\u0022,\u0022start\u0022\u003A\u00222026\u002D04\u002D23T20\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2026\\\/01\\\/Screenshot\u002D2026\u002D01\u002D14\u002Dalle\u002D08.51.45.png\u0022,\u0022category\u0022\u003A\u0022Veneto\u0020Jazz\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020Malibran\u0022,\u0022place_value\u0022\u003A\u0022theater_malibran\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/dulce\u002Dpontes\u002D35\u002Danos\u002Dtour\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Concerto\u0020diretto\u0020da\u0020Alpesh\u0020Chauhan\u0022,\u0022start\u0022\u003A\u00222026\u002D04\u002D24T20\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/Alpesh_Chauhan_foto_di_C\u002DMichele\u002DMonasta.\u002De1773052762936.jpg\u0022,\u0022category\u0022\u003A\u0022Concerti\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dconcerto\u002Ddiretto\u002Dda\u002Dalpesh\u002Dchauhan\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Lohengrin\u0022,\u0022start\u0022\u003A\u00222026\u002D04\u002D26T15\u003A30\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/Screenshot\u002D2026\u002D04\u002D02\u002Dalle\u002D09.03.32\u002Dscaled.png\u0022,\u0022category\u0022\u003A\u0022Opera\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dlohengrin\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Sophia\u0020Li\\u00f9\u0022,\u0022start\u0022\u003A\u00222026\u002D04\u002D28T20\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/12\\\/LIU\u002DSophia_001_\u0040Frances\u002DMarshall\u002Dscaled.jpg\u0022,\u0022category\u0022\u003A\u0022Musik\\u00e0mera\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/musikamera\u002Dsophia\u002Dliu\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Sophia\u0020Li\\u00f9\u0022,\u0022start\u0022\u003A\u00222026\u002D04\u002D29T20\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/12\\\/LIU\u002DSophia_001_\u0040Frances\u002DMarshall\u002Dscaled.jpg\u0022,\u0022category\u0022\u003A\u0022Musik\\u00e0mera\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/musikamera\u002Dsophia\u002Dliu\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Percorsi\u0020della\u0020danza\u0020\u0026\u00238211\u003B\u0020Ballando\u0020con\u0020Pina\u0022,\u0022start\u0022\u003A\u00222026\u002D04\u002D30T18\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2019\\\/01\\\/69I0886zm_5627bausch_ritratto\u002De1559732807674.jpg\u0022,\u0022category\u0022\u003A\u0022Danza\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/percorsi\u002Ddella\u002Ddanza\u002Dballando\u002Dcon\u002Dpina\\\/\u0022,\u0022entrance\u0022\u003A\u0022free\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Magenta\u0020e\u0020Francesco\u0020Olivato\u0020Trio\u0022,\u0022start\u0022\u003A\u00222026\u002D05\u002D02T19\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2026\\\/01\\\/MAGENTA\u002DORIZ.\u002Dcopia.jpg\u0022,\u0022category\u0022\u003A\u0022JAZZ\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/jazz\u002Dmagenta\u002De\u002Dfrancesco\u002Dolivato\u002Dtrio\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Concerto\u0020diretto\u0020da\u0020Ton\u0020Koopman\u0022,\u0022start\u0022\u003A\u00222026\u002D05\u002D02T20\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2019\\\/07\\\/1\u002D7.jpg\u0022,\u0022category\u0022\u003A\u0022Concerti\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020Malibran\u0022,\u0022place_value\u0022\u003A\u0022theater_malibran\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dconcerto\u002Ddiretto\u002Dda\u002Dton\u002Dkoopman\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Concerto\u0020diretto\u0020da\u0020Ton\u0020Koopman\u0022,\u0022start\u0022\u003A\u00222026\u002D05\u002D03T17\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2019\\\/07\\\/1\u002D7.jpg\u0022,\u0022category\u0022\u003A\u0022Concerti\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020Malibran\u0022,\u0022place_value\u0022\u003A\u0022theater_malibran\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dconcerto\u002Ddiretto\u002Dda\u002Dton\u002Dkoopman\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Incontro\u0020con\u0020la\u0020danza\u003A\u0020Martha\u0020Graham\u0020Dance\u0020Company\u0022,\u0022start\u0022\u003A\u00222026\u002D05\u002D04T18\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2022\\\/02\\\/Schermata\u002D2022\u002D02\u002D17\u002Dalle\u002D11.00.58.png\u0022,\u0022category\u0022\u003A\u0022conferenze\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/incontro\u002Dcon\u002Dla\u002Ddanza\u002Dmartha\u002Dgraham\u002Ddance\u002Dcompany\\\/\u0022,\u0022entrance\u0022\u003A\u0022free\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Martha\u0020Graham\u0020Dance\u0020Company\u0022,\u0022start\u0022\u003A\u00222026\u002D05\u002D06T19\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/Screenshot\u002D2026\u002D04\u002D02\u002Dalle\u002D08.50.39\u002Dscaled.png\u0022,\u0022category\u0022\u003A\u0022Danza\u00202025\\\/26\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/danza\u002D25\u002D26\u002Dmartha\u002Dgraham\u002Ddance\u002Dcompany\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Martha\u0020Graham\u0020Dance\u0020Company\u0022,\u0022start\u0022\u003A\u00222026\u002D05\u002D07T19\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/Screenshot\u002D2026\u002D04\u002D02\u002Dalle\u002D08.50.39\u002Dscaled.png\u0022,\u0022category\u0022\u003A\u0022Danza\u00202025\\\/26\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/danza\u002D25\u002D26\u002Dmartha\u002Dgraham\u002Ddance\u002Dcompany\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Martha\u0020Graham\u0020Dance\u0020Company\u0022,\u0022start\u0022\u003A\u00222026\u002D05\u002D08T19\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/Screenshot\u002D2026\u002D04\u002D02\u002Dalle\u002D08.50.39\u002Dscaled.png\u0022,\u0022category\u0022\u003A\u0022Danza\u00202025\\\/26\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/danza\u002D25\u002D26\u002Dmartha\u002Dgraham\u002Ddance\u002Dcompany\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Concerto\u0020diretto\u0020da\u0020John\u0020Axelrod\u0022,\u0022start\u0022\u003A\u00222026\u002D05\u002D08T20\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/Screenshot\u002D2026\u002D04\u002D02\u002Dalle\u002D08.59.21\u002De1775113217526.png\u0022,\u0022category\u0022\u003A\u0022Concerti\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020Malibran\u0022,\u0022place_value\u0022\u003A\u0022theater_malibran\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dconcerto\u002Ddiretto\u002Dda\u002Djohn\u002Daxelrod\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Martha\u0020Graham\u0020Dance\u0020Company\u0022,\u0022start\u0022\u003A\u00222026\u002D05\u002D09T15\u003A30\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/Screenshot\u002D2026\u002D04\u002D02\u002Dalle\u002D08.50.39\u002Dscaled.png\u0022,\u0022category\u0022\u003A\u0022Danza\u00202025\\\/26\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/danza\u002D25\u002D26\u002Dmartha\u002Dgraham\u002Ddance\u002Dcompany\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Concerto\u0020diretto\u0020da\u0020John\u0020Axelrod\u0022,\u0022start\u0022\u003A\u00222026\u002D05\u002D09T20\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/Screenshot\u002D2026\u002D04\u002D02\u002Dalle\u002D08.59.21\u002De1775113217526.png\u0022,\u0022category\u0022\u003A\u0022Concerti\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020Malibran\u0022,\u0022place_value\u0022\u003A\u0022theater_malibran\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dconcerto\u002Ddiretto\u002Dda\u002Djohn\u002Daxelrod\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Martha\u0020Graham\u0020Dance\u0020Company\u0022,\u0022start\u0022\u003A\u00222026\u002D05\u002D10T15\u003A30\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/Screenshot\u002D2026\u002D04\u002D02\u002Dalle\u002D08.50.39\u002Dscaled.png\u0022,\u0022category\u0022\u003A\u0022Danza\u00202025\\\/26\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/danza\u002D25\u002D26\u002Dmartha\u002Dgraham\u002Ddance\u002Dcompany\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Concerto\u0020diretto\u0020da\u0020John\u0020Axelrod\u0022,\u0022start\u0022\u003A\u00222026\u002D05\u002D10T17\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/Screenshot\u002D2026\u002D04\u002D02\u002Dalle\u002D08.59.21\u002De1775113217526.png\u0022,\u0022category\u0022\u003A\u0022Concerti\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020Malibran\u0022,\u0022place_value\u0022\u003A\u0022theater_malibran\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dconcerto\u002Ddiretto\u002Dda\u002Djohn\u002Daxelrod\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Schiaccianoci\u0020Kids\u0020\u0028scuole\u0029\u0022,\u0022start\u0022\u003A\u00222026\u002D05\u002D13T10\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/09\\\/c0b_SCHIACCIANOCI_KIDS.jpg\u0022,\u0022category\u0022\u003A\u0022Fenice\u0020education\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/schiaccianoci\u002Dkids\u002Dscuole\\\/\u0022,\u0022entrance\u0022\u003A\u0022school\u0022,\u0022next_events\u0022\u003A\u005B\u007B\u0022start\u0022\u003A\u00222026\u002D05\u002D13T12\u003A00\u003A00\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022other_place\u0022\u003Anull\u007D\u005D\u007D,\u005B\u005D,\u007B\u0022title\u0022\u003A\u0022Schiaccianoci\u0020Kids\u0020\u0028scuole\u0029\u0022,\u0022start\u0022\u003A\u00222026\u002D05\u002D14T10\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/09\\\/c0b_SCHIACCIANOCI_KIDS.jpg\u0022,\u0022category\u0022\u003A\u0022Fenice\u0020education\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/schiaccianoci\u002Dkids\u002Dscuole\\\/\u0022,\u0022entrance\u0022\u003A\u0022school\u0022,\u0022next_events\u0022\u003A\u005B\u007B\u0022start\u0022\u003A\u00222026\u002D05\u002D14T12\u003A00\u003A00\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022other_place\u0022\u003Anull\u007D\u005D\u007D,\u005B\u005D,\u007B\u0022title\u0022\u003A\u0022Fenice\u0020e\u0020Conservatorio\u0022,\u0022start\u0022\u003A\u00222026\u002D05\u002D14T20\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2023\\\/02\\\/Screenshot\u002D2024\u002D02\u002D28\u002Dalle\u002D15.42.10.png\u0022,\u0022category\u0022\u003A\u0022collaborazioni\u0020istituzionali\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020Malibran\u0022,\u0022place_value\u0022\u003A\u0022theater_malibran\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/xxi\u002Dedizione\u002Dfenice\u002De\u002Dconservatorio\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Schiaccianoci\u0020Kids\u0020\u0028scuole\u0029\u0022,\u0022start\u0022\u003A\u00222026\u002D05\u002D15T10\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/09\\\/c0b_SCHIACCIANOCI_KIDS.jpg\u0022,\u0022category\u0022\u003A\u0022Fenice\u0020education\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/schiaccianoci\u002Dkids\u002Dscuole\\\/\u0022,\u0022entrance\u0022\u003A\u0022school\u0022,\u0022next_events\u0022\u003A\u005B\u007B\u0022start\u0022\u003A\u00222026\u002D05\u002D15T12\u003A00\u003A00\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022other_place\u0022\u003Anull\u007D\u005D\u007D,\u005B\u005D,\u007B\u0022title\u0022\u003A\u0022Schiaccianoci\u0020Kids\u0020\u0028famiglie\u0029\u0022,\u0022start\u0022\u003A\u00222026\u002D05\u002D16T10\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/09\\\/0cc_SCHIACCIANOCI.jpg\u0022,\u0022category\u0022\u003A\u0022Fenice\u0020education\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/schiaccianoci\u002Dkids\u002Dfamiglie\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022,\u0022next_events\u0022\u003A\u005B\u007B\u0022start\u0022\u003A\u00222026\u002D05\u002D16T12\u003A00\u003A00\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022other_place\u0022\u003Anull\u007D\u005D\u007D,\u005B\u005D,\u007B\u0022title\u0022\u003A\u0022Schiaccianoci\u0020Kids\u0020\u0028famiglie\u0029\u0022,\u0022start\u0022\u003A\u00222026\u002D05\u002D17T10\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/09\\\/0cc_SCHIACCIANOCI.jpg\u0022,\u0022category\u0022\u003A\u0022Fenice\u0020education\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/schiaccianoci\u002Dkids\u002Dfamiglie\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022,\u0022next_events\u0022\u003A\u005B\u007B\u0022start\u0022\u003A\u00222026\u002D05\u002D17T12\u003A00\u003A00\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022other_place\u0022\u003Anull\u007D\u005D\u007D,\u005B\u005D,\u007B\u0022title\u0022\u003A\u0022Quartetto\u0020Faur\\u00e9\u0022,\u0022start\u0022\u003A\u00222026\u002D05\u002D18T20\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/12\\\/Quartetto\u002DFaure\\u0301\u002Dfoto\u002D3\u002DTim\u002DKlo\\u0308ckner\u002Dscaled.jpg\u0022,\u0022category\u0022\u003A\u0022Musik\\u00e0mera\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/musikamera\u002Dquartetto\u002Dfaure\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Quartetto\u0020Faur\\u00e9\u0022,\u0022start\u0022\u003A\u00222026\u002D05\u002D19T20\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/12\\\/Quartetto\u002DFaure\\u0301\u002Dfoto\u002D3\u002DTim\u002DKlo\\u0308ckner\u002Dscaled.jpg\u0022,\u0022category\u0022\u003A\u0022Musik\\u00e0mera\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/musikamera\u002Dquartetto\u002Dfaure\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Incontro\u0020con\u0020l\u0026\u00238217\u003Bopera\u003A\u0020Carmen\u0022,\u0022start\u0022\u003A\u00222026\u002D05\u002D20T18\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2022\\\/02\\\/Schermata\u002D2022\u002D02\u002D17\u002Dalle\u002D11.00.58.png\u0022,\u0022category\u0022\u003A\u0022conferenze\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/incontro\u002Dcon\u002Dlopera\u002Dcarmen\\\/\u0022,\u0022entrance\u0022\u003A\u0022free\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Myriam\u0020Dal\u0020Don\u0020e\u0020Carlo\u0020Steno\u0020Rossi\u0022,\u0022start\u0022\u003A\u00222026\u002D05\u002D21T20\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/12\\\/DalDon\u002DRossi\u002Dscaled.png\u0022,\u0022category\u0022\u003A\u0022Musik\\u00e0mera\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/musikamera\u002Dmyriam\u002Ddal\u002Ddon\u002De\u002Dcarlo\u002Dsteno\u002Drossi\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Carmen\u0022,\u0022start\u0022\u003A\u00222026\u002D05\u002D24T19\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/eno_carmen_1112\u002De1775113819174.jpg\u0022,\u0022category\u0022\u003A\u0022Opera\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dcarmen\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Maya\u0020Oganyan\u0022,\u0022start\u0022\u003A\u00222026\u002D05\u002D25T20\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/11\\\/DSC4315\u002Dscaled.jpg\u0022,\u0022category\u0022\u003A\u0022Musik\\u00e0mera\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/musikamera\u002Dmaya\u002Doganyan\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Carmen\u0022,\u0022start\u0022\u003A\u00222026\u002D05\u002D26T19\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/eno_carmen_1112\u002De1775113819174.jpg\u0022,\u0022category\u0022\u003A\u0022Opera\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dcarmen\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Carmen\u0022,\u0022start\u0022\u003A\u00222026\u002D05\u002D27T19\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/eno_carmen_1112\u002De1775113819174.jpg\u0022,\u0022category\u0022\u003A\u0022Opera\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dcarmen\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Carmen\u0022,\u0022start\u0022\u003A\u00222026\u002D05\u002D28T19\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/eno_carmen_1112\u002De1775113819174.jpg\u0022,\u0022category\u0022\u003A\u0022Opera\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dcarmen\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Carmen\u0022,\u0022start\u0022\u003A\u00222026\u002D05\u002D29T19\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/eno_carmen_1112\u002De1775113819174.jpg\u0022,\u0022category\u0022\u003A\u0022Opera\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dcarmen\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Carmen\u0022,\u0022start\u0022\u003A\u00222026\u002D05\u002D30T15\u003A30\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/eno_carmen_1112\u002De1775113819174.jpg\u0022,\u0022category\u0022\u003A\u0022Opera\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dcarmen\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Carmen\u0022,\u0022start\u0022\u003A\u00222026\u002D05\u002D31T15\u003A30\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/eno_carmen_1112\u002De1775113819174.jpg\u0022,\u0022category\u0022\u003A\u0022Opera\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dcarmen\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022The\u0020King\u0026\u00238217\u003Bs\u0020Singers\u0022,\u0022start\u0022\u003A\u00222026\u002D06\u002D01T20\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/12\\\/KingsSingers1\u002Dscaled.png\u0022,\u0022category\u0022\u003A\u0022Musik\\u00e0mera\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/musikamera\u002Dthe\u002Dkings\u002Dsingers\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Carmen\u0022,\u0022start\u0022\u003A\u00222026\u002D06\u002D03T19\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/eno_carmen_1112\u002De1775113819174.jpg\u0022,\u0022category\u0022\u003A\u0022Opera\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dcarmen\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Paolo\u0020Carlini\u0020e\u0020Fabrizio\u0020Datteri\u0022,\u0022start\u0022\u003A\u00222026\u002D06\u002D04T20\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/12\\\/carlini\u002De\u002Ddatteri_musikamera\u002Dscaled.jpeg\u0022,\u0022category\u0022\u003A\u0022Musik\\u00e0mera\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/musikamera\u002Dpaolo\u002Dcarlini\u002De\u002Dfabrizio\u002Ddatteri\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Paolo\u0020Carlini\u0020e\u0020Fabrizio\u0020Datteri\u0022,\u0022start\u0022\u003A\u00222026\u002D06\u002D05T20\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/12\\\/carlini\u002De\u002Ddatteri_musikamera\u002Dscaled.jpeg\u0022,\u0022category\u0022\u003A\u0022Musik\\u00e0mera\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/musikamera\u002Dpaolo\u002Dcarlini\u002De\u002Dfabrizio\u002Ddatteri\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Bugge\u0020Wesseltoft\u0020\\u2013\u0020solo\u0022,\u0022start\u0022\u003A\u00222026\u002D06\u002D06T19\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2026\\\/02\\\/Bugge\u002DWesseltoft\u002D5\u002Dby\u002DEgil\u002DHansen.jpeg\u0022,\u0022category\u0022\u003A\u0022JAZZ\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/jazz\u002Dbugge\u002Dwesseltoft\u002Dsolo\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022,\u0022next_events\u0022\u003A\u005B\u007B\u0022start\u0022\u003A\u00222026\u002D06\u002D06T21\u003A00\u003A00\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022other_place\u0022\u003Anull\u007D\u005D\u007D,\u005B\u005D,\u007B\u0022title\u0022\u003A\u0022Dobrawa\u0020Czocher\u0020in\u0020concerto\u0022,\u0022start\u0022\u003A\u00222026\u002D06\u002D07T19\u003A30\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2026\\\/03\\\/Screenshot\u002D2026\u002D03\u002D26\u002Dalle\u002D11.53.30.png\u0022,\u0022category\u0022\u003A\u0022collaborazioni\u0020istituzionali\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/dobrawa\u002Dczocher\u002Din\u002Dconcerto\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Incontro\u0020con\u0020l\u0026\u00238217\u003Bopera\u003A\u0020Enrico\u0020di\u0020Borgogna\u0022,\u0022start\u0022\u003A\u00222026\u002D06\u002D09T18\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2022\\\/02\\\/Schermata\u002D2022\u002D02\u002D17\u002Dalle\u002D11.00.58.png\u0022,\u0022category\u0022\u003A\u0022conferenze\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/incontro\u002Dcon\u002Dlopera\u002Denrico\u002Ddi\u002Dborgogna\\\/\u0022,\u0022entrance\u0022\u003A\u0022free\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Enrico\u0020di\u0020Borgogna\u0022,\u0022start\u0022\u003A\u00222026\u002D06\u002D12T19\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/Enrico\u002Ddi\u002DBorgogna\u002DDonizetti\u002D2018\u002Dfoto\u002DRota\u002DGFR_5113\u002D1\u002Dscaled\u002De1749115403868.jpg\u0022,\u0022category\u0022\u003A\u0022Opera\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020Malibran\u0022,\u0022place_value\u0022\u003A\u0022theater_malibran\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Denrico\u002Ddi\u002Dborgogna\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Enrico\u0020di\u0020Borgogna\u0022,\u0022start\u0022\u003A\u00222026\u002D06\u002D14T17\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/Enrico\u002Ddi\u002DBorgogna\u002DDonizetti\u002D2018\u002Dfoto\u002DRota\u002DGFR_5113\u002D1\u002Dscaled\u002De1749115403868.jpg\u0022,\u0022category\u0022\u003A\u0022Opera\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020Malibran\u0022,\u0022place_value\u0022\u003A\u0022theater_malibran\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Denrico\u002Ddi\u002Dborgogna\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Kety\u0020Fusco\u0020in\u0020concerto\u0022,\u0022start\u0022\u003A\u00222026\u002D06\u002D15T19\u003A30\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2026\\\/03\\\/Screenshot\u002D2026\u002D03\u002D26\u002Dalle\u002D12.03.26\u002Dscaled.png\u0022,\u0022category\u0022\u003A\u0022collaborazioni\u0020istituzionali\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/kety\u002Dfusco\u002Din\u002Dconcerto\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Enrico\u0020di\u0020Borgogna\u0022,\u0022start\u0022\u003A\u00222026\u002D06\u002D16T19\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/Enrico\u002Ddi\u002DBorgogna\u002DDonizetti\u002D2018\u002Dfoto\u002DRota\u002DGFR_5113\u002D1\u002Dscaled\u002De1749115403868.jpg\u0022,\u0022category\u0022\u003A\u0022Opera\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020Malibran\u0022,\u0022place_value\u0022\u003A\u0022theater_malibran\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Denrico\u002Ddi\u002Dborgogna\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Trio\u0020Kobalt\u0022,\u0022start\u0022\u003A\u00222026\u002D06\u002D17T20\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2026\\\/02\\\/getpubthumb\u002Dscaled\u002De1770021485383.jpg\u0022,\u0022category\u0022\u003A\u0022Archivio\u0020Musicale\u0020Guido\u0020Alberto\u0020Fano\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/trio\u002Dkobalt\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Enrico\u0020di\u0020Borgogna\u0022,\u0022start\u0022\u003A\u00222026\u002D06\u002D18T19\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/Enrico\u002Ddi\u002DBorgogna\u002DDonizetti\u002D2018\u002Dfoto\u002DRota\u002DGFR_5113\u002D1\u002Dscaled\u002De1749115403868.jpg\u0022,\u0022category\u0022\u003A\u0022Opera\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020Malibran\u0022,\u0022place_value\u0022\u003A\u0022theater_malibran\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Denrico\u002Ddi\u002Dborgogna\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Concerto\u0020diretto\u0020da\u0020Corrado\u0020Rovaris\u0022,\u0022start\u0022\u003A\u00222026\u002D06\u002D19T20\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/Corrado\u002DRovaris_01.jpeg\u0022,\u0022category\u0022\u003A\u0022Concerti\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020Malibran\u0022,\u0022place_value\u0022\u003A\u0022theater_malibran\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dconcerto\u002Ddiretto\u002Dda\u002Dcorrado\u002Drovaris\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Enrico\u0020di\u0020Borgogna\u0022,\u0022start\u0022\u003A\u00222026\u002D06\u002D20T17\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/Enrico\u002Ddi\u002DBorgogna\u002DDonizetti\u002D2018\u002Dfoto\u002DRota\u002DGFR_5113\u002D1\u002Dscaled\u002De1749115403868.jpg\u0022,\u0022category\u0022\u003A\u0022Opera\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020Malibran\u0022,\u0022place_value\u0022\u003A\u0022theater_malibran\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Denrico\u002Ddi\u002Dborgogna\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Concerto\u0020diretto\u0020da\u0020Corrado\u0020Rovaris\u0022,\u0022start\u0022\u003A\u00222026\u002D06\u002D21T17\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/Corrado\u002DRovaris_01.jpeg\u0022,\u0022category\u0022\u003A\u0022Concerti\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020Malibran\u0022,\u0022place_value\u0022\u003A\u0022theater_malibran\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dconcerto\u002Ddiretto\u002Dda\u002Dcorrado\u002Drovaris\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Incontro\u0020con\u0020l\u0026\u00238217\u003Bopera\u003A\u0020Venere\u0020e\u0020Adone\u0022,\u0022start\u0022\u003A\u00222026\u002D06\u002D23T18\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2022\\\/02\\\/Schermata\u002D2022\u002D02\u002D17\u002Dalle\u002D11.00.58.png\u0022,\u0022category\u0022\u003A\u0022conferenze\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/incontro\u002Dcon\u002Dlopera\u002Dvenere\u002De\u002Dadone\\\/\u0022,\u0022entrance\u0022\u003A\u0022free\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Venere\u0020e\u0020Adone\u0022,\u0022start\u0022\u003A\u00222026\u002D06\u002D26T19\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/08_Venere_Sciarrino\u002D1\u002Dscaled\u002De1749116132406.jpg\u0022,\u0022category\u0022\u003A\u0022Opera\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/venere\u002De\u002Dadone\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Venere\u0020e\u0020Adone\u0022,\u0022start\u0022\u003A\u00222026\u002D06\u002D27T17\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/08_Venere_Sciarrino\u002D1\u002Dscaled\u002De1749116132406.jpg\u0022,\u0022category\u0022\u003A\u0022Opera\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/venere\u002De\u002Dadone\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Venere\u0020e\u0020Adone\u0022,\u0022start\u0022\u003A\u00222026\u002D06\u002D28T17\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/08_Venere_Sciarrino\u002D1\u002Dscaled\u002De1749116132406.jpg\u0022,\u0022category\u0022\u003A\u0022Opera\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/venere\u002De\u002Dadone\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Venere\u0020e\u0020Adone\u0022,\u0022start\u0022\u003A\u00222026\u002D06\u002D30T19\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/08_Venere_Sciarrino\u002D1\u002Dscaled\u002De1749116132406.jpg\u0022,\u0022category\u0022\u003A\u0022Opera\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/venere\u002De\u002Dadone\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Venere\u0020e\u0020Adone\u0022,\u0022start\u0022\u003A\u00222026\u002D07\u002D01T19\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/08_Venere_Sciarrino\u002D1\u002Dscaled\u002De1749116132406.jpg\u0022,\u0022category\u0022\u003A\u0022Opera\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/venere\u002De\u002Dadone\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022La\u0020Fenice\u0020in\u0020Piazza\u0020San\u0020Marco\u0022,\u0022start\u0022\u003A\u00222026\u002D07\u002D05T21\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2024\\\/05\\\/Conc_Valc\\u030cuh_San_Marco\u002D24\u002D70\u002D9626\u002Dcopia\u002De1750939648138.jpg\u0022,\u0022category\u0022\u003A\u0022Concerti\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Piazza\u0020San\u0020Marco\u0022,\u0022place_value\u0022\u003A\u0022san_marco\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/la\u002Dfenice\u002Din\u002Dpiazza\u002Dsan\u002Dmarco\u002D2026\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Sofi\u0020Paez\u0020in\u0020concerto\u0022,\u0022start\u0022\u003A\u00222026\u002D07\u002D08T19\u003A30\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2026\\\/03\\\/Screenshot\u002D2026\u002D03\u002D26\u002Dalle\u002D12.03.33\u002De1774523696821.png\u0022,\u0022category\u0022\u003A\u0022evento\u0020in\u0020collaborazione\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/sofi\u002Dpaez\u002Din\u002Dconcerto\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Concerto\u0020diretto\u0020da\u0020Cornelius\u0020Meister\u0022,\u0022start\u0022\u003A\u00222026\u002D07\u002D09T20\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/Cornelius\u002DMeister_01.jpg\u0022,\u0022category\u0022\u003A\u0022Concerti\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dconcerto\u002Ddiretto\u002Dda\u002Dcornelius\u002Dmeister\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Concerto\u0020diretto\u0020da\u0020Cornelius\u0020Meister\u0022,\u0022start\u0022\u003A\u00222026\u002D07\u002D10T20\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/Cornelius\u002DMeister_01.jpg\u0022,\u0022category\u0022\u003A\u0022Concerti\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dconcerto\u002Ddiretto\u002Dda\u002Dcornelius\u002Dmeister\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Grigory\u0020Sokolov\u0022,\u0022start\u0022\u003A\u00222026\u002D07\u002D11T20\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/12\\\/2021\u002D12\u002DSokolov\u002DC\u002DOscar\u002DTursunov\u002D1.jpg\u0022,\u0022category\u0022\u003A\u0022Musik\\u00e0mera\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/musikamera\u002Dgrigory\u002Dsokolov\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Lauryyn\u0020in\u0020concerto\u0022,\u0022start\u0022\u003A\u00222026\u002D07\u002D14T19\u003A30\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2026\\\/03\\\/Screenshot\u002D2026\u002D03\u002D26\u002Dalle\u002D12.21.01.png\u0022,\u0022category\u0022\u003A\u0022evento\u0020in\u0020collaborazione\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/lauryyn\u002Din\u002Dconcerto\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022L\u0026\u00238217\u003Belisir\u0020d\u0026\u00238217\u003Bamore\u0022,\u0022start\u0022\u003A\u00222026\u002D08\u002D26T19\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/elisir\u002D2\u002D1\u002De1749116654810.jpg\u0022,\u0022category\u0022\u003A\u0022Opera\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020Malibran\u0022,\u0022place_value\u0022\u003A\u0022theater_malibran\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dlelisir\u002Ddamore\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022L\u0026\u00238217\u003Belisir\u0020d\u0026\u00238217\u003Bamore\u0022,\u0022start\u0022\u003A\u00222026\u002D08\u002D28T19\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/elisir\u002D2\u002D1\u002De1749116654810.jpg\u0022,\u0022category\u0022\u003A\u0022Opera\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020Malibran\u0022,\u0022place_value\u0022\u003A\u0022theater_malibran\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dlelisir\u002Ddamore\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022L\u0026\u00238217\u003Belisir\u0020d\u0026\u00238217\u003Bamore\u0022,\u0022start\u0022\u003A\u00222026\u002D08\u002D30T17\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/elisir\u002D2\u002D1\u002De1749116654810.jpg\u0022,\u0022category\u0022\u003A\u0022Opera\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020Malibran\u0022,\u0022place_value\u0022\u003A\u0022theater_malibran\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dlelisir\u002Ddamore\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022L\u0026\u00238217\u003Belisir\u0020d\u0026\u00238217\u003Bamore\u0022,\u0022start\u0022\u003A\u00222026\u002D09\u002D01T19\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/elisir\u002D2\u002D1\u002De1749116654810.jpg\u0022,\u0022category\u0022\u003A\u0022Opera\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020Malibran\u0022,\u0022place_value\u0022\u003A\u0022theater_malibran\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dlelisir\u002Ddamore\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Incontro\u0020con\u0020l\u0026\u00238217\u003Bopera\u003A\u0020Pagliacci\u0022,\u0022start\u0022\u003A\u00222026\u002D09\u002D15T18\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2022\\\/02\\\/Schermata\u002D2022\u002D02\u002D17\u002Dalle\u002D11.00.58.png\u0022,\u0022category\u0022\u003A\u0022conferenze\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/incontro\u002Dcon\u002Dlopera\u002Dpagliacci\\\/\u0022,\u0022entrance\u0022\u003A\u0022free\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Ettore\u0020Pagano\u0020e\u0020Massimo\u0020Spada\u0022,\u0022start\u0022\u003A\u00222026\u002D09\u002D17T20\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2019\\\/08\\\/Schermata\u002D2019\u002D08\u002D28\u002Dalle\u002D11.36.33\u002D1.png\u0022,\u0022category\u0022\u003A\u0022Archivio\u0020Musicale\u0020Guido\u0020Alberto\u0020Fano\u0020Onlus\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/archivio\u002Dfano\u002Dettore\u002Dpagano\u002De\u002Dmassimo\u002Dspada\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Pagliacci\u0022,\u0022start\u0022\u003A\u00222026\u002D09\u002D18T19\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/yevgeniy\u002Dmironov\u002D9kRfwVHSsH0\u002Dunsplash1\u002D1.jpg\u0022,\u0022category\u0022\u003A\u0022Opera\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020Malibran\u0022,\u0022place_value\u0022\u003A\u0022theater_malibran\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dpagliacci\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Pagliacci\u0022,\u0022start\u0022\u003A\u00222026\u002D09\u002D20T17\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/yevgeniy\u002Dmironov\u002D9kRfwVHSsH0\u002Dunsplash1\u002D1.jpg\u0022,\u0022category\u0022\u003A\u0022Opera\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020Malibran\u0022,\u0022place_value\u0022\u003A\u0022theater_malibran\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dpagliacci\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Quartetto\u0020Rilke\u0022,\u0022start\u0022\u003A\u00222026\u002D09\u002D21T20\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/12\\\/Rilke130572\u002Dcopia\u002Dscaled.jpg\u0022,\u0022category\u0022\u003A\u0022Musik\\u00e0mera\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/musikamera\u002Dquartetto\u002Drilke\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Pagliacci\u0022,\u0022start\u0022\u003A\u00222026\u002D09\u002D22T19\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/yevgeniy\u002Dmironov\u002D9kRfwVHSsH0\u002Dunsplash1\u002D1.jpg\u0022,\u0022category\u0022\u003A\u0022Opera\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020Malibran\u0022,\u0022place_value\u0022\u003A\u0022theater_malibran\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dpagliacci\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Alessandro\u0020Carbonare,\u0020Francesca\u0020Dego\u0020e\u0020Alessandro\u0020Taverna\u0022,\u0022start\u0022\u003A\u00222026\u002D09\u002D23T20\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/12\\\/Dego\u002DTaverna.jpeg\u0022,\u0022category\u0022\u003A\u0022Musik\\u00e0mera\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/musikamera\u002Dalessandro\u002Dcarbonare\u002Dfrancesca\u002Ddego\u002De\u002Dalessandro\u002Dtaverna\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Pagliacci\u0022,\u0022start\u0022\u003A\u00222026\u002D09\u002D24T19\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/yevgeniy\u002Dmironov\u002D9kRfwVHSsH0\u002Dunsplash1\u002D1.jpg\u0022,\u0022category\u0022\u003A\u0022Opera\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020Malibran\u0022,\u0022place_value\u0022\u003A\u0022theater_malibran\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dpagliacci\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Alessandro\u0020Carbonare,\u0020Francesca\u0020Dego\u0020e\u0020Alessandro\u0020Taverna\u0022,\u0022start\u0022\u003A\u00222026\u002D09\u002D24T20\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/12\\\/Dego\u002DTaverna.jpeg\u0022,\u0022category\u0022\u003A\u0022Musik\\u00e0mera\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/musikamera\u002Dalessandro\u002Dcarbonare\u002Dfrancesca\u002Ddego\u002De\u002Dalessandro\u002Dtaverna\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Concerto\u0020diretto\u0020da\u0020Daniele\u0020Callegari\u0022,\u0022start\u0022\u003A\u00222026\u002D09\u002D25T20\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/Callegari\u002DDaniele_01.jpg\u0022,\u0022category\u0022\u003A\u0022Concerti\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020Malibran\u0022,\u0022place_value\u0022\u003A\u0022theater_malibran\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dconcerto\u002Ddiretto\u002Dda\u002Ddaniele\u002Dcallegari\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Pagliacci\u0022,\u0022start\u0022\u003A\u00222026\u002D09\u002D26T17\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/yevgeniy\u002Dmironov\u002D9kRfwVHSsH0\u002Dunsplash1\u002D1.jpg\u0022,\u0022category\u0022\u003A\u0022Opera\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020Malibran\u0022,\u0022place_value\u0022\u003A\u0022theater_malibran\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dpagliacci\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Concerto\u0020diretto\u0020da\u0020Daniele\u0020Callegari\u0022,\u0022start\u0022\u003A\u00222026\u002D09\u002D27T17\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/Callegari\u002DDaniele_01.jpg\u0022,\u0022category\u0022\u003A\u0022Concerti\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020Malibran\u0022,\u0022place_value\u0022\u003A\u0022theater_malibran\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dconcerto\u002Ddiretto\u002Dda\u002Ddaniele\u002Dcallegari\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Concerto\u0020diretto\u0020da\u0020Neil\u0020Thomson\u0022,\u0022start\u0022\u003A\u00222026\u002D10\u002D01T20\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/Thomson\u002DNeil_02_photo\u002DRafaella\u002DPessoa.jpg\u0022,\u0022category\u0022\u003A\u0022Concerti\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020Malibran\u0022,\u0022place_value\u0022\u003A\u0022theater_malibran\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dconcerto\u002Ddiretto\u002Dda\u002Dneil\u002Dthomson\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Stockhausen\u0020\u0026\u00238211\u003B\u0020Weber\u0020\u0026\u00238211\u003B\u0020Heral\u0020\u0026\u00238211\u003B\u0020INSIDE\u0020OUT\u0022,\u0022start\u0022\u003A\u00222026\u002D10\u002D02T19\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2026\\\/03\\\/IMG_3369.jpeg\u0022,\u0022category\u0022\u003A\u0022VENEZIA\u0020JAZZ\u0020FESTIVAL\u0020FALL\u0020EDITION\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stockhausen\u002Dweber\u002Dheral\u002Dinside\u002Dout\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Concerto\u0020diretto\u0020da\u0020Neil\u0020Thomson\u0022,\u0022start\u0022\u003A\u00222026\u002D10\u002D02T20\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/Thomson\u002DNeil_02_photo\u002DRafaella\u002DPessoa.jpg\u0022,\u0022category\u0022\u003A\u0022Concerti\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020Malibran\u0022,\u0022place_value\u0022\u003A\u0022theater_malibran\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dconcerto\u002Ddiretto\u002Dda\u002Dneil\u002Dthomson\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Stockhausen\u0020\u0026\u00238211\u003B\u0020Weber\u0020\u0026\u00238211\u003B\u0020Heral\u0020\u0026\u00238211\u003B\u0020INSIDE\u0020OUT\u0022,\u0022start\u0022\u003A\u00222026\u002D10\u002D03T19\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2026\\\/03\\\/IMG_3369.jpeg\u0022,\u0022category\u0022\u003A\u0022VENEZIA\u0020JAZZ\u0020FESTIVAL\u0020FALL\u0020EDITION\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stockhausen\u002Dweber\u002Dheral\u002Dinside\u002Dout\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Premio\u0020Venezia\u00202026\u0022,\u0022start\u0022\u003A\u00222026\u002D10\u002D06T09\u003A30\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2022\\\/10\\\/KLCC9867.jpg\u0022,\u0022category\u0022\u003A\u0022Altri\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/premio\u002Dvenezia\u002D2026\\\/\u0022,\u0022entrance\u0022\u003A\u0022invitation\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Incontro\u0020con\u0020l\u0026\u00238217\u003Bopera\u003A\u0020The\u0020Telephone\u0020\u007C\u0020Trouble\u0020in\u0020Tahiti\u0022,\u0022start\u0022\u003A\u00222026\u002D10\u002D06T18\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2022\\\/02\\\/Schermata\u002D2022\u002D02\u002D17\u002Dalle\u002D11.00.58.png\u0022,\u0022category\u0022\u003A\u0022conferenze\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/incontro\u002Dcon\u002Dlopera\u002Dthe\u002Dtelephone\u002Dtrouble\u002Din\u002Dtahiti\\\/\u0022,\u0022entrance\u0022\u003A\u0022free\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Premio\u0020Venezia\u00202026\u0022,\u0022start\u0022\u003A\u00222026\u002D10\u002D07T09\u003A30\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2022\\\/10\\\/KLCC9867.jpg\u0022,\u0022category\u0022\u003A\u0022Altri\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/premio\u002Dvenezia\u002D2026\\\/\u0022,\u0022entrance\u0022\u003A\u0022invitation\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Premio\u0020Venezia\u00202026\u0022,\u0022start\u0022\u003A\u00222026\u002D10\u002D08T09\u003A30\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2022\\\/10\\\/KLCC9867.jpg\u0022,\u0022category\u0022\u003A\u0022Altri\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/premio\u002Dvenezia\u002D2026\\\/\u0022,\u0022entrance\u0022\u003A\u0022invitation\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Premio\u0020Venezia\u00202026\u0022,\u0022start\u0022\u003A\u00222026\u002D10\u002D09T09\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2022\\\/10\\\/KLCC9867.jpg\u0022,\u0022category\u0022\u003A\u0022Altri\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/premio\u002Dvenezia\u002D2026\\\/\u0022,\u0022entrance\u0022\u003A\u0022invitation\u0022,\u0022next_events\u0022\u003A\u005B\u007B\u0022start\u0022\u003A\u00222026\u002D10\u002D09T15\u003A00\u003A00\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022other_place\u0022\u003Anull\u007D\u005D\u007D,\u005B\u005D,\u007B\u0022title\u0022\u003A\u0022The\u0020telephone\u0020\u0026\u0023038\u003B\u0020Trouble\u0020in\u0020Tahiti\u0022,\u0022start\u0022\u003A\u00222026\u002D10\u002D09T19\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/man\u002D7771583_1280\u002De1749117574808.jpg\u0022,\u0022category\u0022\u003A\u0022Opera\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Altre\u0020Sedi\u0022,\u0022place_value\u0022\u003A\u0022other_theaters\u0022,\u0022other_place\u0022\u003A\u0022Teatro\u0020Goldoni\u0022,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dthe\u002Dtelephone\u002Dtrouble\u002Din\u002Dtahiti\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Premio\u0020Venezia\u00202026\u0022,\u0022start\u0022\u003A\u00222026\u002D10\u002D10T15\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2022\\\/10\\\/KLCC9867.jpg\u0022,\u0022category\u0022\u003A\u0022Altri\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/premio\u002Dvenezia\u002D2026\\\/\u0022,\u0022entrance\u0022\u003A\u0022invitation\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022The\u0020telephone\u0020\u0026\u0023038\u003B\u0020Trouble\u0020in\u0020Tahiti\u0022,\u0022start\u0022\u003A\u00222026\u002D10\u002D10T19\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/man\u002D7771583_1280\u002De1749117574808.jpg\u0022,\u0022category\u0022\u003A\u0022Opera\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Altre\u0020Sedi\u0022,\u0022place_value\u0022\u003A\u0022other_theaters\u0022,\u0022other_place\u0022\u003A\u0022Teatro\u0020Goldoni\u0022,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dthe\u002Dtelephone\u002Dtrouble\u002Din\u002Dtahiti\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022The\u0020telephone\u0020\u0026\u0023038\u003B\u0020Trouble\u0020in\u0020Tahiti\u0022,\u0022start\u0022\u003A\u00222026\u002D10\u002D11T15\u003A30\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/man\u002D7771583_1280\u002De1749117574808.jpg\u0022,\u0022category\u0022\u003A\u0022Opera\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Altre\u0020Sedi\u0022,\u0022place_value\u0022\u003A\u0022other_theaters\u0022,\u0022other_place\u0022\u003A\u0022Teatro\u0020Goldoni\u0022,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dthe\u002Dtelephone\u002Dtrouble\u002Din\u002Dtahiti\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Premio\u0020Venezia\u00202026\u0022,\u0022start\u0022\u003A\u00222026\u002D10\u002D11T17\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2022\\\/10\\\/KLCC9867.jpg\u0022,\u0022category\u0022\u003A\u0022Altri\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/premio\u002Dvenezia\u002D2026\\\/\u0022,\u0022entrance\u0022\u003A\u0022invitation\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Incontro\u0020con\u0020la\u0020danza\u003A\u0020Hamburger\u0020Kammerballett\u0020\u007C\u0020Dear\u0020Son\u0022,\u0022start\u0022\u003A\u00222026\u002D10\u002D13T18\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2022\\\/02\\\/Schermata\u002D2022\u002D02\u002D17\u002Dalle\u002D11.00.58.png\u0022,\u0022category\u0022\u003A\u0022conferenze\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/incontro\u002Dcon\u002Dla\u002Ddanza\u002Dhamburger\u002Dkammerballett\u002Ddear\u002Dson\\\/\u0022,\u0022entrance\u0022\u003A\u0022free\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022The\u0020telephone\u0020\u0026\u0023038\u003B\u0020Trouble\u0020in\u0020Tahiti\u0022,\u0022start\u0022\u003A\u00222026\u002D10\u002D13T19\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/man\u002D7771583_1280\u002De1749117574808.jpg\u0022,\u0022category\u0022\u003A\u0022Opera\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Altre\u0020Sedi\u0022,\u0022place_value\u0022\u003A\u0022other_theaters\u0022,\u0022other_place\u0022\u003A\u0022Teatro\u0020Goldoni\u0022,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dthe\u002Dtelephone\u002Dtrouble\u002Din\u002Dtahiti\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022The\u0020telephone\u0020\u0026\u0023038\u003B\u0020Trouble\u0020in\u0020Tahiti\u0022,\u0022start\u0022\u003A\u00222026\u002D10\u002D14T19\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/man\u002D7771583_1280\u002De1749117574808.jpg\u0022,\u0022category\u0022\u003A\u0022Opera\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Altre\u0020Sedi\u0022,\u0022place_value\u0022\u003A\u0022other_theaters\u0022,\u0022other_place\u0022\u003A\u0022Teatro\u0020Goldoni\u0022,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dthe\u002Dtelephone\u002Dtrouble\u002Din\u002Dtahiti\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Hamburger\u0020Kammerballett\u0022,\u0022start\u0022\u003A\u00222026\u002D10\u002D16T19\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/Screenshot\u002D2025\u002D06\u002D05\u002Dalle\u002D10.53.58.png\u0022,\u0022category\u0022\u003A\u0022Danza\u00202025\\\/26\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020Malibran\u0022,\u0022place_value\u0022\u003A\u0022theater_malibran\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/danza\u002D25\u002D26\u002Dhamburger\u002Dkammerballett\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Hamburger\u0020Kammerballett\u0022,\u0022start\u0022\u003A\u00222026\u002D10\u002D17T17\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/Screenshot\u002D2025\u002D06\u002D05\u002Dalle\u002D10.53.58.png\u0022,\u0022category\u0022\u003A\u0022Danza\u00202025\\\/26\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020Malibran\u0022,\u0022place_value\u0022\u003A\u0022theater_malibran\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/danza\u002D25\u002D26\u002Dhamburger\u002Dkammerballett\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Trio\u0020Hermes\u0022,\u0022start\u0022\u003A\u00222026\u002D10\u002D20T20\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/12\\\/Hermes\u002Dscaled.png\u0022,\u0022category\u0022\u003A\u0022Musik\\u00e0mera\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/musikamera\u002Dtrio\u002Dhermes\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Dear\u0020Son\u0022,\u0022start\u0022\u003A\u00222026\u002D10\u002D23T19\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/dear\u002Dson_Flavia\u002DTartaglia\u002D6\u002Dscaled.jpg\u0022,\u0022category\u0022\u003A\u0022Danza\u00202025\\\/26\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020Malibran\u0022,\u0022place_value\u0022\u003A\u0022theater_malibran\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/danza\u002D25\u002D26\u002Ddear\u002Dson\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Pavel\u0020Berman\u0020e\u0020Maria\u0020Meerovitch\u0022,\u0022start\u0022\u003A\u00222026\u002D10\u002D23T20\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/12\\\/Berman2.png\u0022,\u0022category\u0022\u003A\u0022Musik\\u00e0mera\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/musikamera\u002Dpavel\u002Dberman\u002De\u002Dmaria\u002Dmeerovitch\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Dear\u0020Son\u0022,\u0022start\u0022\u003A\u00222026\u002D10\u002D24T17\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/dear\u002Dson_Flavia\u002DTartaglia\u002D6\u002Dscaled.jpg\u0022,\u0022category\u0022\u003A\u0022Danza\u00202025\\\/26\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020Malibran\u0022,\u0022place_value\u0022\u003A\u0022theater_malibran\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/danza\u002D25\u002D26\u002Ddear\u002Dson\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Pavel\u0020Berman\u0020e\u0020Maria\u0020Meerovitch\u0022,\u0022start\u0022\u003A\u00222026\u002D10\u002D24T20\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/12\\\/Berman2.png\u0022,\u0022category\u0022\u003A\u0022Musik\\u00e0mera\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/musikamera\u002Dpavel\u002Dberman\u002De\u002Dmaria\u002Dmeerovitch\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Concerto\u0020diretto\u0020da\u0020Alfonso\u0020Caiani\u0022,\u0022start\u0022\u003A\u00222026\u002D10\u002D30T20\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/Caiani\u002De\u002DCoro_01\u002De1749464053557.jpg\u0022,\u0022category\u0022\u003A\u0022Concerti\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020Malibran\u0022,\u0022place_value\u0022\u003A\u0022theater_malibran\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dconcerto\u002Ddiretto\u002Dda\u002Dalfonso\u002Dcaiani\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Concerto\u0020diretto\u0020da\u0020Alfonso\u0020Caiani\u0022,\u0022start\u0022\u003A\u00222026\u002D10\u002D31T20\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/06\\\/Caiani\u002De\u002DCoro_01\u002De1749464053557.jpg\u0022,\u0022category\u0022\u003A\u0022Concerti\u00202025\\\/\u002026\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020Malibran\u0022,\u0022place_value\u0022\u003A\u0022theater_malibran\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/stagione\u002D25\u002D26\u002Dconcerto\u002Ddiretto\u002Dda\u002Dalfonso\u002Dcaiani\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Musik\\u00e0mera\u0022,\u0022start\u0022\u003A\u00222026\u002D11\u002D03T20\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2023\\\/10\\\/1\u002D3.jpg\u0022,\u0022category\u0022\u003A\u0022Musik\\u00e0mera\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/musikamera\u002Ddebiasi\u002Dleonardi\u002Dlazari\u002Ddallavecchia\u002Ddivacri\u002Dtoffano\u002Derle\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Tribute\u0020to\u0020Hans\u0020Zimmer\u0020\u0020\u007C\u0020Ensemble\u0020Symphony\u0020Orchestra\u0022,\u0022start\u0022\u003A\u00222026\u002D11\u002D03T20\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/11\\\/ensemble\u002Dsymphony\u002Dorchestra.jpeg\u0022,\u0022category\u0022\u003A\u0022Veneto\u0020Jazz\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020Malibran\u0022,\u0022place_value\u0022\u003A\u0022theater_malibran\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/tribute\u002Dto\u002Dhans\u002Dzimmer\u002Densemble\u002Dsymphony\u002Dorchestra\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Musik\\u00e0mera\u0022,\u0022start\u0022\u003A\u00222026\u002D11\u002D04T20\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2023\\\/10\\\/1\u002D3.jpg\u0022,\u0022category\u0022\u003A\u0022Musik\\u00e0mera\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/musikamera\u002Ddebiasi\u002Dleonardi\u002Dlazari\u002Ddallavecchia\u002Ddivacri\u002Dtoffano\u002Derle\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Joshua\u0020Bell\u0020e\u0020Peter\u0020Dugan\u0022,\u0022start\u0022\u003A\u00222026\u002D11\u002D12T20\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/12\\\/Screenshot\u002D2026\u002D04\u002D01\u002Dalle\u002D09.07.47.png\u0022,\u0022category\u0022\u003A\u0022Musik\\u00e0mera\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020Malibran\u0022,\u0022place_value\u0022\u003A\u0022theater_malibran\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/musikamera\u002Djoshua\u002Dbell\u002Dpeter\u002Ddugan\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Percorsi\u0020della\u0020danza\u0020\u0026\u00238211\u003B\u0020Cinema\u0020e\u0020Danza\u003A\u0020il\u0020Musical\u0022,\u0022start\u0022\u003A\u00222026\u002D11\u002D25T18\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2025\\\/09\\\/fred1.jpg\u0022,\u0022category\u0022\u003A\u0022Danza\u0022,\u0022place\u0022\u003A\u0022Sale\u0020Apollinee\u0022,\u0022place_value\u0022\u003A\u0022theater_apollinee\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/percorsi\u002Ddella\u002Ddanza\u002Dcinema\u002De\u002Ddanza\u002Dil\u002Dmusical\\\/\u0022,\u0022entrance\u0022\u003A\u0022free\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Concerto\u0020di\u0020Capodanno\u00202027\u0022,\u0022start\u0022\u003A\u00222026\u002D12\u002D29T20\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2021\\\/01\\\/1.jpg\u0022,\u0022category\u0022\u003A\u0022Concerti\u00202026\\\/\u002027\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/concerto\u002Ddi\u002Dcapodanno\u002D2027\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Concerto\u0020di\u0020Capodanno\u00202027\u0022,\u0022start\u0022\u003A\u00222026\u002D12\u002D30T17\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2021\\\/01\\\/1.jpg\u0022,\u0022category\u0022\u003A\u0022Concerti\u00202026\\\/\u002027\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/concerto\u002Ddi\u002Dcapodanno\u002D2027\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Concerto\u0020di\u0020Capodanno\u00202027\u0022,\u0022start\u0022\u003A\u00222026\u002D12\u002D31T16\u003A00\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2021\\\/01\\\/1.jpg\u0022,\u0022category\u0022\u003A\u0022Concerti\u00202026\\\/\u002027\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/concerto\u002Ddi\u002Dcapodanno\u002D2027\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D,\u007B\u0022title\u0022\u003A\u0022Concerto\u0020di\u0020Capodanno\u00202027\u0022,\u0022start\u0022\u003A\u00222027\u002D01\u002D01T11\u003A15\u003A00\u0022,\u0022image\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/wp\u002Dcontent\\\/uploads\\\/2021\\\/01\\\/1.jpg\u0022,\u0022category\u0022\u003A\u0022Concerti\u00202026\\\/\u002027\u0022,\u0022place\u0022\u003A\u0022Teatro\u0020La\u0020Fenice\u0022,\u0022place_value\u0022\u003A\u0022theater_fenice\u0022,\u0022other_place\u0022\u003Anull,\u0022link\u0022\u003A\u0022https\u003A\\\/\\\/www.teatrolafenice.it\\\/event\\\/concerto\u002Ddi\u002Dcapodanno\u002D2027\\\/\u0022,\u0022entrance\u0022\u003A\u0022buy\u0022\u007D\u005D',
+			}
+		}">
+
+
+		<div class="container">
+
+							<div class="row">
+				<div class="col-12">
+					<div class="sn_calendar_block_head">
+						
+												<div class="sn_calendar_block_head_month_year_selector d-none d-lg-flex">
+							<div class="sn_calendar_block_head_month_year_selector_i __remove_selected mr-2">
+								<select class="d-none form-select ssnt-select2" id="select_month" aria-label="Default select example">
+									<option value="0">gennaio</option>
+									<option value="1">febbraio</option>
+									<option value="2">marzo</option>
+									<option value="3">aprile</option>
+									<option value="4">maggio</option>
+									<option value="5">giugno</option>
+									<option value="6">luglio</option>
+									<option value="7">agosto</option>
+									<option value="8">settembre</option>
+									<option value="9">ottobre</option>
+									<option value="10">novembre</option>
+									<option value="11">dicembre</option>
+								</select>
+							</div>
+							<div class="sn_calendar_block_head_month_year_selector_i">
+
+														
+								<select class="d-none form-select ssnt-select2" id="select_year" aria-label="Default select example">
+									<option value="2026" selected>2026</option>
+									<option value="2027">2027</option>
+								</select>
+							</div>
+						</div>
+
+												<div class="sn_calendar_block_head_datepicker d-lg-none">
+							<button class="btn btn-icon btn-calendar btn-outline-primary">
+								<div class="_icon_ct">
+									<div class="_icon">
+										  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+
+									</div>
+									<div class="_icon_ct_label">Calendario</div>
+								</div>
+							</button>
+							<div class="sn_calendar_block_head_datepicker_el">
+								<input type="text" readonly class="datepicker"/>
+							</div>
+						</div>
+
+						<div class="sn_calendar_block_head_view_selector">
+							<a href="javascript:;" data-view="table" class="_active">  <span class="sn_sprite _list ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#list" /></svg>
+  </span>
+Calendario</a>
+							<a href="javascript:;" data-view="list">  <span class="sn_sprite _list ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#list" /></svg>
+  </span>
+lista</a>
+						</div>
+					</div>
+				</div>
+			</div>
+				<div class="row _active" data-view-id="table">
+			<div class="col-12">
+				<div class="sn_calendar_block_table"></div>
+			</div>
+		</div>
+		<div class="row" data-view-id="list">
+			<div class="col-12">
+									<h3 class="h2 d-lg-none sn_calendar_block_list_month_name"></h3>
+								<div class="sn_calendar_block_list">
+					
+						<div class="sn_calendar_block_list_row " data-list-month="1" data-list-year="2026" data-list-id="01-01-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>01</strong>giovedì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">11:15</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2021/01/1.jpg" loading="lazy" alt="Michele Mariotti dirige il Concerto di Capodanno 2026"></figure>
+																				<div class="content">
+											<div class="category">Concerti 2025/ 26</div>
+											<div class="title">Michele Mariotti dirige il Concerto di Capodanno 2026</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/michele-mariotti-dirige-il-concerto-di-capodanno-2026/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="1" data-list-year="2026" data-list-id="01-04-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>04</strong>domenica</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">18:00</div>
+																				<div class="content">
+											<div class="category">tournée</div>
+											<div class="title">Concerto di Capodanno al Gran Teatre del Liceu</div>
+
+																						<div class="place">
+																									Gran Teatre del Liceu
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/concerto-di-capodanno-al-gran-teatre-del-liceu/">scopri di più  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="1" data-list-year="2026" data-list-id="01-07-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>07</strong>mercoledì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">18:00</div>
+																				<div class="content">
+											<div class="category">Presentazione libro</div>
+											<div class="title">Fenice. Mito, rinascita, metamorfosi</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/presentazione-libro-fenice-mito-rinascita-metamorfosi/">Ingresso libero  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="1" data-list-year="2026" data-list-id="01-10-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>10</strong>sabato</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">20:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/vincenzo-milletari-scaled-e1765889161785.jpg" loading="lazy" alt="Concerto diretto da Vincenzo Milletarì"></figure>
+																				<div class="content">
+											<div class="category">Concerti 2025/ 26</div>
+											<div class="title">Concerto diretto da Vincenzo Milletarì</div>
+
+																						<div class="place">
+																									Teatro Malibran
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-concerto-diretto-da-vincenzo-milletari/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="1" data-list-year="2026" data-list-id="01-11-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>11</strong>domenica</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">17:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/vincenzo-milletari-scaled-e1765889161785.jpg" loading="lazy" alt="Concerto diretto da Vincenzo Milletarì"></figure>
+																				<div class="content">
+											<div class="category">Concerti 2025/ 26</div>
+											<div class="title">Concerto diretto da Vincenzo Milletarì</div>
+
+																						<div class="place">
+																									Teatro Malibran
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-concerto-diretto-da-vincenzo-milletari/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="1" data-list-year="2026" data-list-id="01-19-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>19</strong>lunedì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">18:00</div>
+																				<div class="content">
+											<div class="category">Danza</div>
+											<div class="title">INCONTRO POSTICIPATO &#8211; Percorsi della danza &#8211; Temi, Varazioni e Code</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/percorsi-della-danza-temi-varazioni-e-code/">Ingresso libero  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="1" data-list-year="2026" data-list-id="01-20-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>20</strong>martedì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">18:00</div>
+																				<div class="content">
+											<div class="category">conferenze</div>
+											<div class="title">Incontro con l&#8217;opera: Simon Boccanegra</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/incontro-con-lopera-simon-boccanegra/">Ingresso libero  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="1" data-list-year="2026" data-list-id="01-21-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>21</strong>mercoledì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">10:00</div>
+																				<div class="content">
+											<div class="category">Fenice education</div>
+											<div class="title">Simon Boccanegra &#8211; mettiamoci all&#8217;opera</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/simon-boccanegra-mettiamoci-allopera/">Riservato alle scuole  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">12:00</div>
+																				<div class="content">
+											<div class="category">Fenice education</div>
+											<div class="title">Simon Boccanegra &#8211; mettiamoci all&#8217;opera</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/simon-boccanegra-mettiamoci-allopera/">Riservato alle scuole  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="1" data-list-year="2026" data-list-id="01-23-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>23</strong>venerdì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">19:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/Simon-Boccanegra_Piazzola_paginawebevento-scaled.png" loading="lazy" alt="Simon Boccanegra"></figure>
+																				<div class="content">
+											<div class="category">Opera 2025/ 26</div>
+											<div class="title">Simon Boccanegra</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-simon-boccanegra/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="1" data-list-year="2026" data-list-id="01-25-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>25</strong>domenica</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">10:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2022/01/giorno-della-memoria.jpg" loading="lazy" alt="Giorno della Memoria 2026"></figure>
+																				<div class="content">
+											<div class="category">Altri</div>
+											<div class="title">Giorno della Memoria 2026</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/giorno-della-memoria-2026/">Prenota  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">15:30</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/Simon-Boccanegra_Piazzola_paginawebevento-scaled.png" loading="lazy" alt="Simon Boccanegra"></figure>
+																				<div class="content">
+											<div class="category">Opera 2025/ 26</div>
+											<div class="title">Simon Boccanegra</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-simon-boccanegra/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="1" data-list-year="2026" data-list-id="01-27-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>27</strong>martedì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">19:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/Simon-Boccanegra_Piazzola_paginawebevento-scaled.png" loading="lazy" alt="Simon Boccanegra"></figure>
+																				<div class="content">
+											<div class="category">Opera 2025/ 26</div>
+											<div class="title">Simon Boccanegra</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-simon-boccanegra/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="1" data-list-year="2026" data-list-id="01-28-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>28</strong>mercoledì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">18:00</div>
+																				<div class="content">
+											<div class="category">conferenze</div>
+											<div class="title">Incontro con l&#8217;opera: Piccolo Orso e la Montagna di ghiaccio</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/incontro-con-lopera-piccolo-orso-e-la-montagna-di-ghiaccio/">Ingresso libero  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="1" data-list-year="2026" data-list-id="01-29-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>29</strong>giovedì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">09:30</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/777_PICCOLO_ORSO_banner.jpg" loading="lazy" alt="Piccolo Orso e la Montagna di ghiaccio (riservato alle scuole)"></figure>
+																				<div class="content">
+											<div class="category">Fenice education</div>
+											<div class="title">Piccolo Orso e la Montagna di ghiaccio (riservato alle scuole)</div>
+
+																						<div class="place">
+																									Teatro Malibran
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/piccolo-orso-e-la-montagna-di-ghiaccio-riservato-alle-scuole/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">12:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/777_PICCOLO_ORSO_banner.jpg" loading="lazy" alt="Piccolo Orso e la Montagna di ghiaccio (riservato alle scuole)"></figure>
+																				<div class="content">
+											<div class="category">Fenice education</div>
+											<div class="title">Piccolo Orso e la Montagna di ghiaccio (riservato alle scuole)</div>
+
+																						<div class="place">
+																									Teatro Malibran
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/piccolo-orso-e-la-montagna-di-ghiaccio-riservato-alle-scuole/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">19:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/Simon-Boccanegra_Piazzola_paginawebevento-scaled.png" loading="lazy" alt="Simon Boccanegra"></figure>
+																				<div class="content">
+											<div class="category">Opera 2025/ 26</div>
+											<div class="title">Simon Boccanegra</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-simon-boccanegra/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="1" data-list-year="2026" data-list-id="01-30-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>30</strong>venerdì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">09:30</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/777_PICCOLO_ORSO_banner.jpg" loading="lazy" alt="Piccolo Orso e la Montagna di ghiaccio (riservato alle scuole)"></figure>
+																				<div class="content">
+											<div class="category">Fenice education</div>
+											<div class="title">Piccolo Orso e la Montagna di ghiaccio (riservato alle scuole)</div>
+
+																						<div class="place">
+																									Teatro Malibran
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/piccolo-orso-e-la-montagna-di-ghiaccio-riservato-alle-scuole/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">12:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/777_PICCOLO_ORSO_banner.jpg" loading="lazy" alt="Piccolo Orso e la Montagna di ghiaccio (riservato alle scuole)"></figure>
+																				<div class="content">
+											<div class="category">Fenice education</div>
+											<div class="title">Piccolo Orso e la Montagna di ghiaccio (riservato alle scuole)</div>
+
+																						<div class="place">
+																									Teatro Malibran
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/piccolo-orso-e-la-montagna-di-ghiaccio-riservato-alle-scuole/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">20:00</div>
+																				<div class="content">
+											<div class="category">Musikàmera</div>
+											<div class="title">Quartetto Indaco</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/musikamera-quartetto-indaco/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="1" data-list-year="2026" data-list-id="01-31-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>31</strong>sabato</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">15:30</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/AZu7sJxc8dAugpnmz4ERpQ-AZu7sJxcKZkbU_FjIJz1VA.jpg" loading="lazy" alt="Piccolo Orso e la Montagna di ghiaccio"></figure>
+																				<div class="content">
+											<div class="category">Opera 2025/ 26</div>
+											<div class="title">Piccolo Orso e la Montagna di ghiaccio</div>
+
+																						<div class="place">
+																									Teatro Malibran
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/evento-25-26-piccolo-orso-e-la-montagna-di-ghiaccio/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">20:00</div>
+																				<div class="content">
+											<div class="category">Musikàmera</div>
+											<div class="title">Quartetto Indaco</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/musikamera-quartetto-indaco/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="2" data-list-year="2026" data-list-id="02-01-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>01</strong>domenica</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">11:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/AZu7sJxc8dAugpnmz4ERpQ-AZu7sJxcKZkbU_FjIJz1VA.jpg" loading="lazy" alt="Piccolo Orso e la Montagna di ghiaccio"></figure>
+																				<div class="content">
+											<div class="category">Opera 2025/ 26</div>
+											<div class="title">Piccolo Orso e la Montagna di ghiaccio</div>
+
+																						<div class="place">
+																									Teatro Malibran
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/evento-25-26-piccolo-orso-e-la-montagna-di-ghiaccio/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">15:30</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/Simon-Boccanegra_Piazzola_paginawebevento-scaled.png" loading="lazy" alt="Simon Boccanegra"></figure>
+																				<div class="content">
+											<div class="category">Opera 2025/ 26</div>
+											<div class="title">Simon Boccanegra</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-simon-boccanegra/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="2" data-list-year="2026" data-list-id="02-03-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>03</strong>martedì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">09:30</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/777_PICCOLO_ORSO_banner.jpg" loading="lazy" alt="Piccolo Orso e la Montagna di ghiaccio (riservato alle scuole)"></figure>
+																				<div class="content">
+											<div class="category">Fenice education</div>
+											<div class="title">Piccolo Orso e la Montagna di ghiaccio (riservato alle scuole)</div>
+
+																						<div class="place">
+																									Teatro Malibran
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/piccolo-orso-e-la-montagna-di-ghiaccio-riservato-alle-scuole/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">12:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/777_PICCOLO_ORSO_banner.jpg" loading="lazy" alt="Piccolo Orso e la Montagna di ghiaccio (riservato alle scuole)"></figure>
+																				<div class="content">
+											<div class="category">Fenice education</div>
+											<div class="title">Piccolo Orso e la Montagna di ghiaccio (riservato alle scuole)</div>
+
+																						<div class="place">
+																									Teatro Malibran
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/piccolo-orso-e-la-montagna-di-ghiaccio-riservato-alle-scuole/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">20:00</div>
+																				<div class="content">
+											<div class="category">Musikàmera</div>
+											<div class="title">Ian Bostridge e Roberto Prosseda</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/musikamera-ian-bostridge-e-roberto-prosseda/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="2" data-list-year="2026" data-list-id="02-04-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>04</strong>mercoledì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">09:30</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/777_PICCOLO_ORSO_banner.jpg" loading="lazy" alt="Piccolo Orso e la Montagna di ghiaccio (riservato alle scuole)"></figure>
+																				<div class="content">
+											<div class="category">Fenice education</div>
+											<div class="title">Piccolo Orso e la Montagna di ghiaccio (riservato alle scuole)</div>
+
+																						<div class="place">
+																									Teatro Malibran
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/piccolo-orso-e-la-montagna-di-ghiaccio-riservato-alle-scuole/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">12:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/777_PICCOLO_ORSO_banner.jpg" loading="lazy" alt="Piccolo Orso e la Montagna di ghiaccio (riservato alle scuole)"></figure>
+																				<div class="content">
+											<div class="category">Fenice education</div>
+											<div class="title">Piccolo Orso e la Montagna di ghiaccio (riservato alle scuole)</div>
+
+																						<div class="place">
+																									Teatro Malibran
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/piccolo-orso-e-la-montagna-di-ghiaccio-riservato-alle-scuole/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">20:00</div>
+																				<div class="content">
+											<div class="category">Musikàmera</div>
+											<div class="title">Ian Bostridge e Roberto Prosseda</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/musikamera-ian-bostridge-e-roberto-prosseda/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="2" data-list-year="2026" data-list-id="02-07-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>07</strong>sabato</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">20:00</div>
+																				<div class="content">
+											<div class="category">Musikàmera</div>
+											<div class="title">Davide Alogna e Enrico Pace</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/musikamera-davide-alogna-e-enrico-pace/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="2" data-list-year="2026" data-list-id="02-08-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>08</strong>domenica</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">19:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/03_Traviata-1-scaled-e1749112809878.jpg" loading="lazy" alt="La traviata"></figure>
+																				<div class="content">
+											<div class="category">Opera 2025/ 26</div>
+											<div class="title">La traviata</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-la-traviata/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="2" data-list-year="2026" data-list-id="02-09-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>09</strong>lunedì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">20:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/Angie-Kremer-Photography1-e1749460835330.jpg" loading="lazy" alt="Gidon Kremer &#038; Kremerata Baltica"></figure>
+																				<div class="content">
+											<div class="category">Concerti 2025/ 26</div>
+											<div class="title">Gidon Kremer &#038; Kremerata Baltica</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-gidon-kremer-kremerata-baltica/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="2" data-list-year="2026" data-list-id="02-10-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>10</strong>martedì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">19:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/Simon-Boccanegra_Piazzola_paginawebevento-scaled.png" loading="lazy" alt="Simon Boccanegra"></figure>
+																				<div class="content">
+											<div class="category">Opera 2025/ 26</div>
+											<div class="title">Simon Boccanegra</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-simon-boccanegra/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="2" data-list-year="2026" data-list-id="02-11-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>11</strong>mercoledì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">19:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/03_Traviata-1-scaled-e1749112809878.jpg" loading="lazy" alt="La traviata"></figure>
+																				<div class="content">
+											<div class="category">Opera 2025/ 26</div>
+											<div class="title">La traviata</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-la-traviata/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="2" data-list-year="2026" data-list-id="02-12-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>12</strong>giovedì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">19:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/Simon-Boccanegra_Piazzola_paginawebevento-scaled.png" loading="lazy" alt="Simon Boccanegra"></figure>
+																				<div class="content">
+											<div class="category">Opera 2025/ 26</div>
+											<div class="title">Simon Boccanegra</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-simon-boccanegra/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="2" data-list-year="2026" data-list-id="02-13-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>13</strong>venerdì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">19:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/03_Traviata-1-scaled-e1749112809878.jpg" loading="lazy" alt="La traviata"></figure>
+																				<div class="content">
+											<div class="category">Opera 2025/ 26</div>
+											<div class="title">La traviata</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-la-traviata/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="2" data-list-year="2026" data-list-id="02-14-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>14</strong>sabato</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">15:30</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/12/LaFenice_Carnevale-160n-scaled.jpg" loading="lazy" alt="Simon Boccanegra &#038; Carnival Cocktail"></figure>
+																				<div class="content">
+											<div class="category"></div>
+											<div class="title">Simon Boccanegra &#038; Carnival Cocktail</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/simon-boccanegra-carnival-cocktail/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">15:30</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/Simon-Boccanegra_Piazzola_paginawebevento-scaled.png" loading="lazy" alt="Simon Boccanegra"></figure>
+																				<div class="content">
+											<div class="category">Opera 2025/ 26</div>
+											<div class="title">Simon Boccanegra</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-simon-boccanegra/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="2" data-list-year="2026" data-list-id="02-15-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>15</strong>domenica</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">17:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/03_Traviata-1-scaled-e1749112809878.jpg" loading="lazy" alt="La traviata"></figure>
+																				<div class="content">
+											<div class="category">Opera 2025/ 26</div>
+											<div class="title">La traviata</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-la-traviata/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="2" data-list-year="2026" data-list-id="02-17-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>17</strong>martedì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">19:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/03_Traviata-1-scaled-e1749112809878.jpg" loading="lazy" alt="La traviata"></figure>
+																				<div class="content">
+											<div class="category">Opera 2025/ 26</div>
+											<div class="title">La traviata</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-la-traviata/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="2" data-list-year="2026" data-list-id="02-18-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>18</strong>mercoledì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">20:00</div>
+																				<div class="content">
+											<div class="category">Musikàmera</div>
+											<div class="title">Trio Orelon</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/musikamera-trio-orelon/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">20:30</div>
+																				<div class="content">
+											<div class="category">Altri</div>
+											<div class="title">XXI Concerto per il Mercoledì delle Ceneri</div>
+
+																						<div class="place">
+																									Chiesa di Santa Maria del Carmelo (Carmini)
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/xxi-concerto-per-il-mercoledi-delle-ceneri/">Ingresso libero  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="2" data-list-year="2026" data-list-id="02-19-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>19</strong>giovedì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">20:00</div>
+																				<div class="content">
+											<div class="category">Musikàmera</div>
+											<div class="title">Trio Orelon</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/musikamera-trio-orelon/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="2" data-list-year="2026" data-list-id="02-20-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>20</strong>venerdì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">18:00</div>
+																				<div class="content">
+											<div class="category">Danza</div>
+											<div class="title">Percorsi della danza &#8211; &#8220;1960 Passi di Danza&#8221;</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/percorsi-della-danza-libro-1960-passi-di-danza/">Ingresso libero  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="2" data-list-year="2026" data-list-id="02-21-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>21</strong>sabato</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">19:00</div>
+																				<div class="content">
+											<div class="category">JAZZ</div>
+											<div class="title">Andrés Barrios Trio</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/jazz-andres-barrios-trio/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="2" data-list-year="2026" data-list-id="02-24-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>24</strong>martedì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">10:00</div>
+																				<div class="content">
+											<div class="category">Fenice education</div>
+											<div class="title">Lo Schiaccianoci &#8211; mettiamoci all&#8217;opera</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/lo-schiaccianoci-mettiamoci-allopera/">Riservato alle scuole  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">12:00</div>
+																				<div class="content">
+											<div class="category">Fenice education</div>
+											<div class="title">Lo Schiaccianoci &#8211; mettiamoci all&#8217;opera</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/lo-schiaccianoci-mettiamoci-allopera/">Riservato alle scuole  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">18:00</div>
+																				<div class="content">
+											<div class="category">conferenze</div>
+											<div class="title">Incontro con il balletto: Lo schiaccianoci</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/incontro-con-il-balletto-lo-schiaccianoci/">Ingresso libero  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="2" data-list-year="2026" data-list-id="02-25-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>25</strong>mercoledì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">19:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/schiaccianoci_operanazionalebudapest_stagione2526.jpg" loading="lazy" alt="Lo schiaccianoci"></figure>
+																				<div class="content">
+											<div class="category">Danza 2025/26</div>
+											<div class="title">Lo schiaccianoci</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/danza-25-26-lo-schiaccianoci/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="2" data-list-year="2026" data-list-id="02-26-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>26</strong>giovedì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">19:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/schiaccianoci_operanazionalebudapest_stagione2526.jpg" loading="lazy" alt="Lo schiaccianoci"></figure>
+																				<div class="content">
+											<div class="category">Danza 2025/26</div>
+											<div class="title">Lo schiaccianoci</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/danza-25-26-lo-schiaccianoci/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="2" data-list-year="2026" data-list-id="02-27-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>27</strong>venerdì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">19:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/schiaccianoci_operanazionalebudapest_stagione2526.jpg" loading="lazy" alt="Lo schiaccianoci"></figure>
+																				<div class="content">
+											<div class="category">Danza 2025/26</div>
+											<div class="title">Lo schiaccianoci</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/danza-25-26-lo-schiaccianoci/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="2" data-list-year="2026" data-list-id="02-28-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>28</strong>sabato</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">15:30</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/schiaccianoci_operanazionalebudapest_stagione2526.jpg" loading="lazy" alt="Lo schiaccianoci"></figure>
+																				<div class="content">
+											<div class="category">Danza 2025/26</div>
+											<div class="title">Lo schiaccianoci</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/danza-25-26-lo-schiaccianoci/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="3" data-list-year="2026" data-list-id="03-01-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>01</strong>domenica</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">15:30</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/schiaccianoci_operanazionalebudapest_stagione2526.jpg" loading="lazy" alt="Lo schiaccianoci"></figure>
+																				<div class="content">
+											<div class="category">Danza 2025/26</div>
+											<div class="title">Lo schiaccianoci</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/danza-25-26-lo-schiaccianoci/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="3" data-list-year="2026" data-list-id="03-02-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>02</strong>lunedì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">20:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/1-3.jpg" loading="lazy" alt="Recital lirico (Francesco Meli, Luca Salsi)"></figure>
+																				<div class="content">
+											<div class="category">Concerti 2025/ 26</div>
+											<div class="title">Recital lirico (Francesco Meli, Luca Salsi)</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-recital-lirico-francesco-meli-luca-salsi-e-nelson-calzi/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="3" data-list-year="2026" data-list-id="03-03-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>03</strong>martedì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">20:00</div>
+																				<div class="content">
+											<div class="category">Musikàmera</div>
+											<div class="title">Chaos String Quartet</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/musikamera-chaos-string-quartet/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="3" data-list-year="2026" data-list-id="03-04-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>04</strong>mercoledì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">20:00</div>
+																				<div class="content">
+											<div class="category">Musikàmera</div>
+											<div class="title">Chaos String Quartet</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/musikamera-chaos-string-quartet/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="3" data-list-year="2026" data-list-id="03-05-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>05</strong>giovedì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">10:00</div>
+																				<div class="content">
+											<div class="category">Fenice education</div>
+											<div class="title">Duo di percussioni (lezione-concerto)</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/duo-di-percussioni-lezione-concerto/">Riservato alle scuole  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">12:00</div>
+																				<div class="content">
+											<div class="category">Fenice education</div>
+											<div class="title">Duo di percussioni (lezione-concerto)</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/duo-di-percussioni-lezione-concerto/">Riservato alle scuole  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="3" data-list-year="2026" data-list-id="03-06-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>06</strong>venerdì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">20:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/Y_260517-Constantinos-High-res-Thomas-Brill_YMCK_R-e1749462878865.jpg" loading="lazy" alt="Concerto diretto da Constantinos Carydis"></figure>
+																				<div class="content">
+											<div class="category">Concerti 2025/ 26</div>
+											<div class="title">Concerto diretto da Constantinos Carydis</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-concerto-diretto-da-constantinos-carydis/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="3" data-list-year="2026" data-list-id="03-07-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>07</strong>sabato</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">20:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2026/03/under35_raimondo_slide.jpg" loading="lazy" alt="Concerto diretto da Constantinos Carydis &#8211; PROMO UNDER35"></figure>
+																				<div class="content">
+											<div class="category">Concerti 2025/ 26</div>
+											<div class="title">Concerto diretto da Constantinos Carydis &#8211; PROMO UNDER35</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/under35-concerto-diretto-da-constantinos-carydis/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">20:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/Y_260517-Constantinos-High-res-Thomas-Brill_YMCK_R-e1749462878865.jpg" loading="lazy" alt="Concerto diretto da Constantinos Carydis"></figure>
+																				<div class="content">
+											<div class="category">Concerti 2025/ 26</div>
+											<div class="title">Concerto diretto da Constantinos Carydis</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-concerto-diretto-da-constantinos-carydis/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="3" data-list-year="2026" data-list-id="03-08-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>08</strong>domenica</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">17:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/Y_260517-Constantinos-High-res-Thomas-Brill_YMCK_R-e1749462878865.jpg" loading="lazy" alt="Concerto diretto da Constantinos Carydis"></figure>
+																				<div class="content">
+											<div class="category">Concerti 2025/ 26</div>
+											<div class="title">Concerto diretto da Constantinos Carydis</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-concerto-diretto-da-constantinos-carydis/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="3" data-list-year="2026" data-list-id="03-09-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>09</strong>lunedì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">18:00</div>
+																				<div class="content">
+											<div class="category">Danza</div>
+											<div class="title">Percorsi della danza &#8211; Temi, Variazioni e Code</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/percorsi-della-danza-temi-variazioni-e-code/">Ingresso libero  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="3" data-list-year="2026" data-list-id="03-10-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>10</strong>martedì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">20:00</div>
+																				<div class="content">
+											<div class="category">Musikàmera</div>
+											<div class="title">Enrico Bronzi in concerto</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/musikamer-enrico-bronzi/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="3" data-list-year="2026" data-list-id="03-11-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>11</strong>mercoledì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">20:00</div>
+																				<div class="content">
+											<div class="category">Musikàmera</div>
+											<div class="title">Enrico Bronzi in concerto</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/musikamer-enrico-bronzi/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="3" data-list-year="2026" data-list-id="03-14-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>14</strong>sabato</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">19:00</div>
+																				<div class="content">
+											<div class="category">JAZZ</div>
+											<div class="title">Tom Ollendorff Quartet &#8211; Where in the World</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/veneto-jazz-tom-ollendorff-quartet-where-in-the-world/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="3" data-list-year="2026" data-list-id="03-15-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>15</strong>domenica</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">20:00</div>
+																				<div class="content">
+											<div class="category">Archivio Musicale Guido Alberto Fano</div>
+											<div class="title">Axel Trolese in recital</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/axel-trolese-in-recital/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="3" data-list-year="2026" data-list-id="03-17-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>17</strong>martedì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">10:00</div>
+																				<div class="content">
+											<div class="category">Fenice education</div>
+											<div class="title">Ottone in villa &#8211; mettiamoci all&#8217;opera</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/ottone-in-villa-mettiamoci-allopera/">Riservato alle scuole  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">12:00</div>
+																				<div class="content">
+											<div class="category">Fenice education</div>
+											<div class="title">Ottone in villa &#8211; mettiamoci all&#8217;opera</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/ottone-in-villa-mettiamoci-allopera/">Riservato alle scuole  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">18:00</div>
+																				<div class="content">
+											<div class="category">conferenze</div>
+											<div class="title">Incontro con l&#8217;opera: Ottone in villa</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/incontro-con-lopera-ottone-in-villa/">Ingresso libero  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="3" data-list-year="2026" data-list-id="03-20-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>20</strong>venerdì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">18:00</div>
+																				<div class="content">
+											<div class="category">Presentazione libro</div>
+											<div class="title">Tentarmi è vanità</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/libro-tentarmi-e-vanita/">Ingresso libero  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">19:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/ottone-in-villa_evento_web-scaled.png" loading="lazy" alt="Ottone in villa"></figure>
+																				<div class="content">
+											<div class="category">Opera 2025/ 26</div>
+											<div class="title">Ottone in villa</div>
+
+																						<div class="place">
+																									Teatro Malibran
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-ottone-in-villa/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="3" data-list-year="2026" data-list-id="03-21-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>21</strong>sabato</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">19:00</div>
+																				<div class="content">
+											<div class="category">venezia piano festival</div>
+											<div class="title">Antonii Baryshevskyi in recital</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/antonii-baryshevskyi-in-recital/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="3" data-list-year="2026" data-list-id="03-22-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>22</strong>domenica</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">15:30</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/ottone-in-villa_evento_web-scaled.png" loading="lazy" alt="Ottone in villa"></figure>
+																				<div class="content">
+											<div class="category">Opera 2025/ 26</div>
+											<div class="title">Ottone in villa</div>
+
+																						<div class="place">
+																									Teatro Malibran
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-ottone-in-villa/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">20:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/12/Evgeny_Kissin_in_2021-scaled.jpg" loading="lazy" alt="Evgeny Kissin in concerto"></figure>
+																				<div class="content">
+											<div class="category">Musikàmera</div>
+											<div class="title">Evgeny Kissin in concerto</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/musikamera-evgeny-kissin-in-concerto/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="3" data-list-year="2026" data-list-id="03-24-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>24</strong>martedì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">10:00</div>
+																				<div class="content">
+											<div class="category">Fenice education</div>
+											<div class="title">Duo violoncello e pianoforte (lezione-concerto)</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/duo-violoncello-e-pianoforte-lezione-concerto/">Riservato alle scuole  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">12:00</div>
+																				<div class="content">
+											<div class="category">Fenice education</div>
+											<div class="title">Duo violoncello e pianoforte (lezione-concerto)</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/duo-violoncello-e-pianoforte-lezione-concerto/">Riservato alle scuole  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">19:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/ottone-in-villa_evento_web-scaled.png" loading="lazy" alt="Ottone in villa"></figure>
+																				<div class="content">
+											<div class="category">Opera 2025/ 26</div>
+											<div class="title">Ottone in villa</div>
+
+																						<div class="place">
+																									Teatro Malibran
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-ottone-in-villa/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="3" data-list-year="2026" data-list-id="03-25-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>25</strong>mercoledì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">20:00</div>
+																				<div class="content">
+											<div class="category">Musikàmera</div>
+											<div class="title">Ars Trio di Roma</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/musikamera-ars-trio-di-roma/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="3" data-list-year="2026" data-list-id="03-26-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>26</strong>giovedì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">19:00</div>
+																				<div class="content">
+											<div class="category">venezia piano festival</div>
+											<div class="title">Elia Cecino in recital</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/venezia-piano-festival-elia-cecino-in-recital/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">19:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/ottone-in-villa_evento_web-scaled.png" loading="lazy" alt="Ottone in villa"></figure>
+																				<div class="content">
+											<div class="category">Opera 2025/ 26</div>
+											<div class="title">Ottone in villa</div>
+
+																						<div class="place">
+																									Teatro Malibran
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-ottone-in-villa/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="3" data-list-year="2026" data-list-id="03-27-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>27</strong>venerdì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">18:00</div>
+																				<div class="content">
+											<div class="category">Presentazione libro</div>
+											<div class="title">Schipilliti, &#8220;Giuseppe Tartini&#8221; &#8211; PRESENTAZIONE LIBRO</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/schipilliti-giuseppe-tartini-presentazione-libro/">Ingresso libero  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="3" data-list-year="2026" data-list-id="03-28-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>28</strong>sabato</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">19:00</div>
+																				<div class="content">
+											<div class="category">JAZZ</div>
+											<div class="title">David Helbock / Julia Hofer Duo</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/david-helbock-julia-hofer-duo/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="3" data-list-year="2026" data-list-id="03-29-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>29</strong>domenica</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">15:30</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/ottone-in-villa_evento_web-scaled.png" loading="lazy" alt="Ottone in villa"></figure>
+																				<div class="content">
+											<div class="category">Opera 2025/ 26</div>
+											<div class="title">Ottone in villa</div>
+
+																						<div class="place">
+																									Teatro Malibran
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-ottone-in-villa/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="3" data-list-year="2026" data-list-id="03-31-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>31</strong>martedì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">20:00</div>
+																				<div class="content">
+											<div class="category">Musikàmera</div>
+											<div class="title">Federico Fiorio e Karalis Antiqua Ensemble</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/musikamera-federico-fiorio-e-karalis-antiqua-ensemble/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row _active" data-list-month="4" data-list-year="2026" data-list-id="04-01-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>01</strong>mercoledì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">20:00</div>
+																				<div class="content">
+											<div class="category">Musikàmera</div>
+											<div class="title">Federico Fiorio e Karalis Antiqua Ensemble</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/musikamera-federico-fiorio-e-karalis-antiqua-ensemble/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row _active" data-list-month="4" data-list-year="2026" data-list-id="04-02-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>02</strong>giovedì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">18:00</div>
+																				<div class="content">
+											<div class="category">conferenze</div>
+											<div class="title">Incontro con l&#8217;opera: Lohengrin</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/incontro-con-lopera-lohengrin/">Ingresso libero  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row _active" data-list-month="4" data-list-year="2026" data-list-id="04-03-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>03</strong>venerdì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">20:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/Michael-Hofstetter_ph-Stuart-Armitt-e1774854105993.jpg" loading="lazy" alt="Concerto diretto da Michael Hofstetter"></figure>
+																				<div class="content">
+											<div class="category">Concerti 2025/ 26</div>
+											<div class="title">Concerto diretto da Michael Hofstetter</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-concerto-diretto-da-michael-hofstetter/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row _active" data-list-month="4" data-list-year="2026" data-list-id="04-04-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>04</strong>sabato</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">17:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/Michael-Hofstetter_ph-Stuart-Armitt-e1774854105993.jpg" loading="lazy" alt="Concerto diretto da Michael Hofstetter"></figure>
+																				<div class="content">
+											<div class="category">Concerti 2025/ 26</div>
+											<div class="title">Concerto diretto da Michael Hofstetter</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-concerto-diretto-da-michael-hofstetter/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row _active" data-list-month="4" data-list-year="2026" data-list-id="04-07-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>07</strong>martedì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">10:30</div>
+																				<div class="content">
+											<div class="category"></div>
+											<div class="title">Concerto per la giornata internazionale della Popolazione Romani</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/concerto-per-la-giornata-internazionale-della-popolazione-romani/">Ingresso libero  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row _active" data-list-month="4" data-list-year="2026" data-list-id="04-08-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>08</strong>mercoledì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">20:00</div>
+																				<div class="content">
+											<div class="category">Musikàmera</div>
+											<div class="title">Marina de Liso, Francesco Galligioni e Roberto Loreggian</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/musikamera-marina-de-liso-francesco-galligioni-e-roberto-loreggian/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row _active" data-list-month="4" data-list-year="2026" data-list-id="04-09-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>09</strong>giovedì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">10:00</div>
+																				<div class="content">
+											<div class="category">Fenice education</div>
+											<div class="title">Lohengrin &#8211; mettiamoci all&#8217;opera</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/lohengrin-mettiamoci-allopera/">Riservato alle scuole  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">12:00</div>
+																				<div class="content">
+											<div class="category">Fenice education</div>
+											<div class="title">Lohengrin &#8211; mettiamoci all&#8217;opera</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/lohengrin-mettiamoci-allopera/">Riservato alle scuole  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row _active" data-list-month="4" data-list-year="2026" data-list-id="04-11-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>11</strong>sabato</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">19:00</div>
+																				<div class="content">
+											<div class="category">JAZZ</div>
+											<div class="title">Danny Grissett trio </div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/danny-grissett-trio%e2%80%a8/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row _active" data-list-month="4" data-list-year="2026" data-list-id="04-12-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>12</strong>domenica</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">18:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/Screenshot-2026-04-02-alle-09.03.32-scaled.png" loading="lazy" alt="Lohengrin"></figure>
+																				<div class="content">
+											<div class="category">Opera 2025/ 26</div>
+											<div class="title">Lohengrin</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-lohengrin/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row _active" data-list-month="4" data-list-year="2026" data-list-id="04-13-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>13</strong>lunedì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">18:00</div>
+																				<div class="content">
+											<div class="category">conferenze</div>
+											<div class="title">Incontro con l&#8217;opera: Il piccolo principe</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/incontro-con-lopera-il-piccolo-principe/">Ingresso libero  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row _active" data-list-month="4" data-list-year="2026" data-list-id="04-15-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>15</strong>mercoledì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">11:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/c5a_PICCOLO_PRINCIPE.jpg" loading="lazy" alt="Il piccolo principe (riservato alle scuole)"></figure>
+																				<div class="content">
+											<div class="category">Fenice education</div>
+											<div class="title">Il piccolo principe (riservato alle scuole)</div>
+
+																						<div class="place">
+																									Teatro Malibran
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/education-25-26-il-piccolo-principe-riservato-alle-scuole/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">18:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/Screenshot-2026-04-02-alle-09.03.32-scaled.png" loading="lazy" alt="Lohengrin"></figure>
+																				<div class="content">
+											<div class="category">Opera 2025/ 26</div>
+											<div class="title">Lohengrin</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-lohengrin/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row _active" data-list-month="4" data-list-year="2026" data-list-id="04-16-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>16</strong>giovedì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">11:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/c5a_PICCOLO_PRINCIPE.jpg" loading="lazy" alt="Il piccolo principe (riservato alle scuole)"></figure>
+																				<div class="content">
+											<div class="category">Fenice education</div>
+											<div class="title">Il piccolo principe (riservato alle scuole)</div>
+
+																						<div class="place">
+																									Teatro Malibran
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/education-25-26-il-piccolo-principe-riservato-alle-scuole/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row _active" data-list-month="4" data-list-year="2026" data-list-id="04-17-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>17</strong>venerdì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">11:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/c5a_PICCOLO_PRINCIPE.jpg" loading="lazy" alt="Il piccolo principe (riservato alle scuole)"></figure>
+																				<div class="content">
+											<div class="category">Fenice education</div>
+											<div class="title">Il piccolo principe (riservato alle scuole)</div>
+
+																						<div class="place">
+																									Teatro Malibran
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/education-25-26-il-piccolo-principe-riservato-alle-scuole/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">20:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/Markus-Stenz-dirige-l-Orchestra-La-Fenice.jpg" loading="lazy" alt="Concerto diretto da Markus Stenz"></figure>
+																				<div class="content">
+											<div class="category">Concerti 2025/ 26</div>
+											<div class="title">Concerto diretto da Markus Stenz</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-concerto-diretto-da-markus-stenz/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row _active" data-list-month="4" data-list-year="2026" data-list-id="04-18-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>18</strong>sabato</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">15:30</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/PICCOLO-PRINCIPE.jpg" loading="lazy" alt="Il piccolo principe"></figure>
+																				<div class="content">
+											<div class="category">Opera 2025/ 26</div>
+											<div class="title">Il piccolo principe</div>
+
+																						<div class="place">
+																									Teatro Malibran
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/evento-25-26-il-piccolo-principe/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">17:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/Markus-Stenz-dirige-l-Orchestra-La-Fenice.jpg" loading="lazy" alt="Concerto diretto da Markus Stenz"></figure>
+																				<div class="content">
+											<div class="category">Concerti 2025/ 26</div>
+											<div class="title">Concerto diretto da Markus Stenz</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-concerto-diretto-da-markus-stenz/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row _active" data-list-month="4" data-list-year="2026" data-list-id="04-19-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>19</strong>domenica</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">15:30</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/Screenshot-2026-04-02-alle-09.03.32-scaled.png" loading="lazy" alt="Lohengrin"></figure>
+																				<div class="content">
+											<div class="category">Opera 2025/ 26</div>
+											<div class="title">Lohengrin</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-lohengrin/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row _active" data-list-month="4" data-list-year="2026" data-list-id="04-21-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>21</strong>martedì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">20:00</div>
+																				<div class="content">
+											<div class="category">Musikàmera</div>
+											<div class="title">Sara Mingardo, Zoreslava Vynnyk, Edoardo Blasetti e Valeria Montanari</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/musikamera-sara-mingardo-zoreslava-vynnyk-edoardo-blasetti-e-valeria-montanari/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row _active" data-list-month="4" data-list-year="2026" data-list-id="04-22-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>22</strong>mercoledì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">10:00</div>
+																				<div class="content">
+											<div class="category">Fenice education</div>
+											<div class="title">Anche l&#8217;Argentina suona! (lezione-concerto)</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/anche-largentina-suona-lezione-concerto/">Riservato alle scuole  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">12:00</div>
+																				<div class="content">
+											<div class="category">Fenice education</div>
+											<div class="title">Anche l&#8217;Argentina suona! (lezione-concerto)</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/anche-largentina-suona-lezione-concerto/">Riservato alle scuole  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">18:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/Screenshot-2026-04-02-alle-09.03.32-scaled.png" loading="lazy" alt="Lohengrin"></figure>
+																				<div class="content">
+											<div class="category">Opera 2025/ 26</div>
+											<div class="title">Lohengrin</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-lohengrin/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row _active" data-list-month="4" data-list-year="2026" data-list-id="04-23-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>23</strong>giovedì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">18:00</div>
+																				<div class="content">
+											<div class="category">Danza</div>
+											<div class="title">Percorsi della danza &#8211; Rudolf Nureyev vs Marius Petipa</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/percorsi-della-danza-rudolph-nureev-vs-marius-petipa/">Ingresso libero  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">20:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2026/01/Screenshot-2026-01-14-alle-08.51.45.png" loading="lazy" alt="Dulce Pontes 35 Anos Tour"></figure>
+																				<div class="content">
+											<div class="category">Veneto Jazz</div>
+											<div class="title">Dulce Pontes 35 Anos Tour</div>
+
+																						<div class="place">
+																									Teatro Malibran
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/dulce-pontes-35-anos-tour/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row _active" data-list-month="4" data-list-year="2026" data-list-id="04-24-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>24</strong>venerdì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">20:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/Alpesh_Chauhan_foto_di_C-Michele-Monasta.-e1773052762936.jpg" loading="lazy" alt="Concerto diretto da Alpesh Chauhan"></figure>
+																				<div class="content">
+											<div class="category">Concerti 2025/ 26</div>
+											<div class="title">Concerto diretto da Alpesh Chauhan</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-concerto-diretto-da-alpesh-chauhan/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row _active" data-list-month="4" data-list-year="2026" data-list-id="04-26-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>26</strong>domenica</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">15:30</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/Screenshot-2026-04-02-alle-09.03.32-scaled.png" loading="lazy" alt="Lohengrin"></figure>
+																				<div class="content">
+											<div class="category">Opera 2025/ 26</div>
+											<div class="title">Lohengrin</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-lohengrin/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row _active" data-list-month="4" data-list-year="2026" data-list-id="04-28-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>28</strong>martedì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">20:00</div>
+																				<div class="content">
+											<div class="category">Musikàmera</div>
+											<div class="title">Sophia Liù</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/musikamera-sophia-liu/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row _active" data-list-month="4" data-list-year="2026" data-list-id="04-29-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>29</strong>mercoledì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">20:00</div>
+																				<div class="content">
+											<div class="category">Musikàmera</div>
+											<div class="title">Sophia Liù</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/musikamera-sophia-liu/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row _active" data-list-month="4" data-list-year="2026" data-list-id="04-30-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>30</strong>giovedì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">18:00</div>
+																				<div class="content">
+											<div class="category">Danza</div>
+											<div class="title">Percorsi della danza &#8211; Ballando con Pina</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/percorsi-della-danza-ballando-con-pina/">Ingresso libero  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="5" data-list-year="2026" data-list-id="05-02-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>02</strong>sabato</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">19:00</div>
+																				<div class="content">
+											<div class="category">JAZZ</div>
+											<div class="title">Magenta e Francesco Olivato Trio</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/jazz-magenta-e-francesco-olivato-trio/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">20:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2019/07/1-7.jpg" loading="lazy" alt="Concerto diretto da Ton Koopman"></figure>
+																				<div class="content">
+											<div class="category">Concerti 2025/ 26</div>
+											<div class="title">Concerto diretto da Ton Koopman</div>
+
+																						<div class="place">
+																									Teatro Malibran
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-concerto-diretto-da-ton-koopman/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="5" data-list-year="2026" data-list-id="05-03-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>03</strong>domenica</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">17:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2019/07/1-7.jpg" loading="lazy" alt="Concerto diretto da Ton Koopman"></figure>
+																				<div class="content">
+											<div class="category">Concerti 2025/ 26</div>
+											<div class="title">Concerto diretto da Ton Koopman</div>
+
+																						<div class="place">
+																									Teatro Malibran
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-concerto-diretto-da-ton-koopman/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="5" data-list-year="2026" data-list-id="05-04-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>04</strong>lunedì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">18:00</div>
+																				<div class="content">
+											<div class="category">conferenze</div>
+											<div class="title">Incontro con la danza: Martha Graham Dance Company</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/incontro-con-la-danza-martha-graham-dance-company/">Ingresso libero  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="5" data-list-year="2026" data-list-id="05-06-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>06</strong>mercoledì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">19:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/Screenshot-2026-04-02-alle-08.50.39-scaled.png" loading="lazy" alt="Martha Graham Dance Company"></figure>
+																				<div class="content">
+											<div class="category">Danza 2025/26</div>
+											<div class="title">Martha Graham Dance Company</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/danza-25-26-martha-graham-dance-company/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="5" data-list-year="2026" data-list-id="05-07-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>07</strong>giovedì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">19:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/Screenshot-2026-04-02-alle-08.50.39-scaled.png" loading="lazy" alt="Martha Graham Dance Company"></figure>
+																				<div class="content">
+											<div class="category">Danza 2025/26</div>
+											<div class="title">Martha Graham Dance Company</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/danza-25-26-martha-graham-dance-company/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="5" data-list-year="2026" data-list-id="05-08-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>08</strong>venerdì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">19:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/Screenshot-2026-04-02-alle-08.50.39-scaled.png" loading="lazy" alt="Martha Graham Dance Company"></figure>
+																				<div class="content">
+											<div class="category">Danza 2025/26</div>
+											<div class="title">Martha Graham Dance Company</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/danza-25-26-martha-graham-dance-company/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">20:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/Screenshot-2026-04-02-alle-08.59.21-e1775113217526.png" loading="lazy" alt="Concerto diretto da John Axelrod"></figure>
+																				<div class="content">
+											<div class="category">Concerti 2025/ 26</div>
+											<div class="title">Concerto diretto da John Axelrod</div>
+
+																						<div class="place">
+																									Teatro Malibran
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-concerto-diretto-da-john-axelrod/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="5" data-list-year="2026" data-list-id="05-09-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>09</strong>sabato</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">15:30</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/Screenshot-2026-04-02-alle-08.50.39-scaled.png" loading="lazy" alt="Martha Graham Dance Company"></figure>
+																				<div class="content">
+											<div class="category">Danza 2025/26</div>
+											<div class="title">Martha Graham Dance Company</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/danza-25-26-martha-graham-dance-company/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">20:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/Screenshot-2026-04-02-alle-08.59.21-e1775113217526.png" loading="lazy" alt="Concerto diretto da John Axelrod"></figure>
+																				<div class="content">
+											<div class="category">Concerti 2025/ 26</div>
+											<div class="title">Concerto diretto da John Axelrod</div>
+
+																						<div class="place">
+																									Teatro Malibran
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-concerto-diretto-da-john-axelrod/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="5" data-list-year="2026" data-list-id="05-10-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>10</strong>domenica</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">15:30</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/Screenshot-2026-04-02-alle-08.50.39-scaled.png" loading="lazy" alt="Martha Graham Dance Company"></figure>
+																				<div class="content">
+											<div class="category">Danza 2025/26</div>
+											<div class="title">Martha Graham Dance Company</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/danza-25-26-martha-graham-dance-company/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">17:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/Screenshot-2026-04-02-alle-08.59.21-e1775113217526.png" loading="lazy" alt="Concerto diretto da John Axelrod"></figure>
+																				<div class="content">
+											<div class="category">Concerti 2025/ 26</div>
+											<div class="title">Concerto diretto da John Axelrod</div>
+
+																						<div class="place">
+																									Teatro Malibran
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-concerto-diretto-da-john-axelrod/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="5" data-list-year="2026" data-list-id="05-13-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>13</strong>mercoledì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">10:00</div>
+																				<div class="content">
+											<div class="category">Fenice education</div>
+											<div class="title">Schiaccianoci Kids (scuole)</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/schiaccianoci-kids-scuole/">Riservato alle scuole  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">12:00</div>
+																				<div class="content">
+											<div class="category">Fenice education</div>
+											<div class="title">Schiaccianoci Kids (scuole)</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/schiaccianoci-kids-scuole/">Riservato alle scuole  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="5" data-list-year="2026" data-list-id="05-14-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>14</strong>giovedì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">10:00</div>
+																				<div class="content">
+											<div class="category">Fenice education</div>
+											<div class="title">Schiaccianoci Kids (scuole)</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/schiaccianoci-kids-scuole/">Riservato alle scuole  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">12:00</div>
+																				<div class="content">
+											<div class="category">Fenice education</div>
+											<div class="title">Schiaccianoci Kids (scuole)</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/schiaccianoci-kids-scuole/">Riservato alle scuole  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">20:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2023/02/Screenshot-2024-02-28-alle-15.42.10.png" loading="lazy" alt="Fenice e Conservatorio"></figure>
+																				<div class="content">
+											<div class="category">collaborazioni istituzionali</div>
+											<div class="title">Fenice e Conservatorio</div>
+
+																						<div class="place">
+																									Teatro Malibran
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/xxi-edizione-fenice-e-conservatorio/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="5" data-list-year="2026" data-list-id="05-15-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>15</strong>venerdì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">10:00</div>
+																				<div class="content">
+											<div class="category">Fenice education</div>
+											<div class="title">Schiaccianoci Kids (scuole)</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/schiaccianoci-kids-scuole/">Riservato alle scuole  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">12:00</div>
+																				<div class="content">
+											<div class="category">Fenice education</div>
+											<div class="title">Schiaccianoci Kids (scuole)</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/schiaccianoci-kids-scuole/">Riservato alle scuole  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="5" data-list-year="2026" data-list-id="05-16-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>16</strong>sabato</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">10:00</div>
+																				<div class="content">
+											<div class="category">Fenice education</div>
+											<div class="title">Schiaccianoci Kids (famiglie)</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/schiaccianoci-kids-famiglie/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">12:00</div>
+																				<div class="content">
+											<div class="category">Fenice education</div>
+											<div class="title">Schiaccianoci Kids (famiglie)</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/schiaccianoci-kids-famiglie/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="5" data-list-year="2026" data-list-id="05-17-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>17</strong>domenica</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">10:00</div>
+																				<div class="content">
+											<div class="category">Fenice education</div>
+											<div class="title">Schiaccianoci Kids (famiglie)</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/schiaccianoci-kids-famiglie/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">12:00</div>
+																				<div class="content">
+											<div class="category">Fenice education</div>
+											<div class="title">Schiaccianoci Kids (famiglie)</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/schiaccianoci-kids-famiglie/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="5" data-list-year="2026" data-list-id="05-18-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>18</strong>lunedì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">20:00</div>
+																				<div class="content">
+											<div class="category">Musikàmera</div>
+											<div class="title">Quartetto Fauré</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/musikamera-quartetto-faure/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="5" data-list-year="2026" data-list-id="05-19-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>19</strong>martedì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">20:00</div>
+																				<div class="content">
+											<div class="category">Musikàmera</div>
+											<div class="title">Quartetto Fauré</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/musikamera-quartetto-faure/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="5" data-list-year="2026" data-list-id="05-20-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>20</strong>mercoledì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">18:00</div>
+																				<div class="content">
+											<div class="category">conferenze</div>
+											<div class="title">Incontro con l&#8217;opera: Carmen</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/incontro-con-lopera-carmen/">Ingresso libero  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="5" data-list-year="2026" data-list-id="05-21-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>21</strong>giovedì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">20:00</div>
+																				<div class="content">
+											<div class="category">Musikàmera</div>
+											<div class="title">Myriam Dal Don e Carlo Steno Rossi</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/musikamera-myriam-dal-don-e-carlo-steno-rossi/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="5" data-list-year="2026" data-list-id="05-24-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>24</strong>domenica</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">19:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/eno_carmen_1112-e1775113819174.jpg" loading="lazy" alt="Carmen"></figure>
+																				<div class="content">
+											<div class="category">Opera 2025/ 26</div>
+											<div class="title">Carmen</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-carmen/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="5" data-list-year="2026" data-list-id="05-25-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>25</strong>lunedì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">20:00</div>
+																				<div class="content">
+											<div class="category">Musikàmera</div>
+											<div class="title">Maya Oganyan</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/musikamera-maya-oganyan/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="5" data-list-year="2026" data-list-id="05-26-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>26</strong>martedì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">19:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/eno_carmen_1112-e1775113819174.jpg" loading="lazy" alt="Carmen"></figure>
+																				<div class="content">
+											<div class="category">Opera 2025/ 26</div>
+											<div class="title">Carmen</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-carmen/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="5" data-list-year="2026" data-list-id="05-27-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>27</strong>mercoledì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">19:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/eno_carmen_1112-e1775113819174.jpg" loading="lazy" alt="Carmen"></figure>
+																				<div class="content">
+											<div class="category">Opera 2025/ 26</div>
+											<div class="title">Carmen</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-carmen/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="5" data-list-year="2026" data-list-id="05-28-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>28</strong>giovedì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">19:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/eno_carmen_1112-e1775113819174.jpg" loading="lazy" alt="Carmen"></figure>
+																				<div class="content">
+											<div class="category">Opera 2025/ 26</div>
+											<div class="title">Carmen</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-carmen/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="5" data-list-year="2026" data-list-id="05-29-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>29</strong>venerdì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">19:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/eno_carmen_1112-e1775113819174.jpg" loading="lazy" alt="Carmen"></figure>
+																				<div class="content">
+											<div class="category">Opera 2025/ 26</div>
+											<div class="title">Carmen</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-carmen/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="5" data-list-year="2026" data-list-id="05-30-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>30</strong>sabato</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">15:30</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/eno_carmen_1112-e1775113819174.jpg" loading="lazy" alt="Carmen"></figure>
+																				<div class="content">
+											<div class="category">Opera 2025/ 26</div>
+											<div class="title">Carmen</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-carmen/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="5" data-list-year="2026" data-list-id="05-31-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>31</strong>domenica</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">15:30</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/eno_carmen_1112-e1775113819174.jpg" loading="lazy" alt="Carmen"></figure>
+																				<div class="content">
+											<div class="category">Opera 2025/ 26</div>
+											<div class="title">Carmen</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-carmen/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="6" data-list-year="2026" data-list-id="06-01-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>01</strong>lunedì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">20:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/12/KingsSingers1-scaled.png" loading="lazy" alt="The King&#8217;s Singers"></figure>
+																				<div class="content">
+											<div class="category">Musikàmera</div>
+											<div class="title">The King&#8217;s Singers</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/musikamera-the-kings-singers/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="6" data-list-year="2026" data-list-id="06-03-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>03</strong>mercoledì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">19:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/eno_carmen_1112-e1775113819174.jpg" loading="lazy" alt="Carmen"></figure>
+																				<div class="content">
+											<div class="category">Opera 2025/ 26</div>
+											<div class="title">Carmen</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-carmen/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="6" data-list-year="2026" data-list-id="06-04-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>04</strong>giovedì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">20:00</div>
+																				<div class="content">
+											<div class="category">Musikàmera</div>
+											<div class="title">Paolo Carlini e Fabrizio Datteri</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/musikamera-paolo-carlini-e-fabrizio-datteri/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="6" data-list-year="2026" data-list-id="06-05-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>05</strong>venerdì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">20:00</div>
+																				<div class="content">
+											<div class="category">Musikàmera</div>
+											<div class="title">Paolo Carlini e Fabrizio Datteri</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/musikamera-paolo-carlini-e-fabrizio-datteri/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="6" data-list-year="2026" data-list-id="06-06-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>06</strong>sabato</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">19:00</div>
+																				<div class="content">
+											<div class="category">JAZZ</div>
+											<div class="title">Bugge Wesseltoft – solo</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/jazz-bugge-wesseltoft-solo/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">21:00</div>
+																				<div class="content">
+											<div class="category">JAZZ</div>
+											<div class="title">Bugge Wesseltoft – solo</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/jazz-bugge-wesseltoft-solo/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="6" data-list-year="2026" data-list-id="06-07-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>07</strong>domenica</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">19:30</div>
+																				<div class="content">
+											<div class="category">collaborazioni istituzionali</div>
+											<div class="title">Dobrawa Czocher in concerto</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/dobrawa-czocher-in-concerto/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="6" data-list-year="2026" data-list-id="06-09-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>09</strong>martedì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">18:00</div>
+																				<div class="content">
+											<div class="category">conferenze</div>
+											<div class="title">Incontro con l&#8217;opera: Enrico di Borgogna</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/incontro-con-lopera-enrico-di-borgogna/">Ingresso libero  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="6" data-list-year="2026" data-list-id="06-12-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>12</strong>venerdì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">19:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/Enrico-di-Borgogna-Donizetti-2018-foto-Rota-GFR_5113-1-scaled-e1749115403868.jpg" loading="lazy" alt="Enrico di Borgogna"></figure>
+																				<div class="content">
+											<div class="category">Opera 2025/ 26</div>
+											<div class="title">Enrico di Borgogna</div>
+
+																						<div class="place">
+																									Teatro Malibran
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-enrico-di-borgogna/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="6" data-list-year="2026" data-list-id="06-14-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>14</strong>domenica</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">17:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/Enrico-di-Borgogna-Donizetti-2018-foto-Rota-GFR_5113-1-scaled-e1749115403868.jpg" loading="lazy" alt="Enrico di Borgogna"></figure>
+																				<div class="content">
+											<div class="category">Opera 2025/ 26</div>
+											<div class="title">Enrico di Borgogna</div>
+
+																						<div class="place">
+																									Teatro Malibran
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-enrico-di-borgogna/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="6" data-list-year="2026" data-list-id="06-15-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>15</strong>lunedì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">19:30</div>
+																				<div class="content">
+											<div class="category">collaborazioni istituzionali</div>
+											<div class="title">Kety Fusco in concerto</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/kety-fusco-in-concerto/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="6" data-list-year="2026" data-list-id="06-16-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>16</strong>martedì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">19:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/Enrico-di-Borgogna-Donizetti-2018-foto-Rota-GFR_5113-1-scaled-e1749115403868.jpg" loading="lazy" alt="Enrico di Borgogna"></figure>
+																				<div class="content">
+											<div class="category">Opera 2025/ 26</div>
+											<div class="title">Enrico di Borgogna</div>
+
+																						<div class="place">
+																									Teatro Malibran
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-enrico-di-borgogna/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="6" data-list-year="2026" data-list-id="06-17-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>17</strong>mercoledì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">20:00</div>
+																				<div class="content">
+											<div class="category">Archivio Musicale Guido Alberto Fano</div>
+											<div class="title">Trio Kobalt</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/trio-kobalt/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="6" data-list-year="2026" data-list-id="06-18-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>18</strong>giovedì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">19:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/Enrico-di-Borgogna-Donizetti-2018-foto-Rota-GFR_5113-1-scaled-e1749115403868.jpg" loading="lazy" alt="Enrico di Borgogna"></figure>
+																				<div class="content">
+											<div class="category">Opera 2025/ 26</div>
+											<div class="title">Enrico di Borgogna</div>
+
+																						<div class="place">
+																									Teatro Malibran
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-enrico-di-borgogna/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="6" data-list-year="2026" data-list-id="06-19-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>19</strong>venerdì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">20:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/Corrado-Rovaris_01.jpeg" loading="lazy" alt="Concerto diretto da Corrado Rovaris"></figure>
+																				<div class="content">
+											<div class="category">Concerti 2025/ 26</div>
+											<div class="title">Concerto diretto da Corrado Rovaris</div>
+
+																						<div class="place">
+																									Teatro Malibran
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-concerto-diretto-da-corrado-rovaris/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="6" data-list-year="2026" data-list-id="06-20-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>20</strong>sabato</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">17:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/Enrico-di-Borgogna-Donizetti-2018-foto-Rota-GFR_5113-1-scaled-e1749115403868.jpg" loading="lazy" alt="Enrico di Borgogna"></figure>
+																				<div class="content">
+											<div class="category">Opera 2025/ 26</div>
+											<div class="title">Enrico di Borgogna</div>
+
+																						<div class="place">
+																									Teatro Malibran
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-enrico-di-borgogna/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="6" data-list-year="2026" data-list-id="06-21-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>21</strong>domenica</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">17:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/Corrado-Rovaris_01.jpeg" loading="lazy" alt="Concerto diretto da Corrado Rovaris"></figure>
+																				<div class="content">
+											<div class="category">Concerti 2025/ 26</div>
+											<div class="title">Concerto diretto da Corrado Rovaris</div>
+
+																						<div class="place">
+																									Teatro Malibran
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-concerto-diretto-da-corrado-rovaris/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="6" data-list-year="2026" data-list-id="06-23-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>23</strong>martedì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">18:00</div>
+																				<div class="content">
+											<div class="category">conferenze</div>
+											<div class="title">Incontro con l&#8217;opera: Venere e Adone</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/incontro-con-lopera-venere-e-adone/">Ingresso libero  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="6" data-list-year="2026" data-list-id="06-26-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>26</strong>venerdì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">19:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/08_Venere_Sciarrino-1-scaled-e1749116132406.jpg" loading="lazy" alt="Venere e Adone"></figure>
+																				<div class="content">
+											<div class="category">Opera 2025/ 26</div>
+											<div class="title">Venere e Adone</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/venere-e-adone/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="6" data-list-year="2026" data-list-id="06-27-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>27</strong>sabato</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">17:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/08_Venere_Sciarrino-1-scaled-e1749116132406.jpg" loading="lazy" alt="Venere e Adone"></figure>
+																				<div class="content">
+											<div class="category">Opera 2025/ 26</div>
+											<div class="title">Venere e Adone</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/venere-e-adone/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="6" data-list-year="2026" data-list-id="06-28-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>28</strong>domenica</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">17:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/08_Venere_Sciarrino-1-scaled-e1749116132406.jpg" loading="lazy" alt="Venere e Adone"></figure>
+																				<div class="content">
+											<div class="category">Opera 2025/ 26</div>
+											<div class="title">Venere e Adone</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/venere-e-adone/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="6" data-list-year="2026" data-list-id="06-30-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>30</strong>martedì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">19:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/08_Venere_Sciarrino-1-scaled-e1749116132406.jpg" loading="lazy" alt="Venere e Adone"></figure>
+																				<div class="content">
+											<div class="category">Opera 2025/ 26</div>
+											<div class="title">Venere e Adone</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/venere-e-adone/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="7" data-list-year="2026" data-list-id="07-01-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>01</strong>mercoledì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">19:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/08_Venere_Sciarrino-1-scaled-e1749116132406.jpg" loading="lazy" alt="Venere e Adone"></figure>
+																				<div class="content">
+											<div class="category">Opera 2025/ 26</div>
+											<div class="title">Venere e Adone</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/venere-e-adone/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="7" data-list-year="2026" data-list-id="07-05-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>05</strong>domenica</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">21:00</div>
+																				<div class="content">
+											<div class="category">Concerti 2025/ 26</div>
+											<div class="title">La Fenice in Piazza San Marco</div>
+
+																						<div class="place">
+																									Piazza San Marco
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/la-fenice-in-piazza-san-marco-2026/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="7" data-list-year="2026" data-list-id="07-08-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>08</strong>mercoledì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">19:30</div>
+																				<div class="content">
+											<div class="category">evento in collaborazione</div>
+											<div class="title">Sofi Paez in concerto</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/sofi-paez-in-concerto/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="7" data-list-year="2026" data-list-id="07-09-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>09</strong>giovedì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">20:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/Cornelius-Meister_01.jpg" loading="lazy" alt="Concerto diretto da Cornelius Meister"></figure>
+																				<div class="content">
+											<div class="category">Concerti 2025/ 26</div>
+											<div class="title">Concerto diretto da Cornelius Meister</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-concerto-diretto-da-cornelius-meister/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="7" data-list-year="2026" data-list-id="07-10-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>10</strong>venerdì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">20:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/Cornelius-Meister_01.jpg" loading="lazy" alt="Concerto diretto da Cornelius Meister"></figure>
+																				<div class="content">
+											<div class="category">Concerti 2025/ 26</div>
+											<div class="title">Concerto diretto da Cornelius Meister</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-concerto-diretto-da-cornelius-meister/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="7" data-list-year="2026" data-list-id="07-11-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>11</strong>sabato</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">20:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/12/2021-12-Sokolov-C-Oscar-Tursunov-1.jpg" loading="lazy" alt="Grigory Sokolov"></figure>
+																				<div class="content">
+											<div class="category">Musikàmera</div>
+											<div class="title">Grigory Sokolov</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/musikamera-grigory-sokolov/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="7" data-list-year="2026" data-list-id="07-14-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>14</strong>martedì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">19:30</div>
+																				<div class="content">
+											<div class="category">evento in collaborazione</div>
+											<div class="title">Lauryyn in concerto</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/lauryyn-in-concerto/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="8" data-list-year="2026" data-list-id="08-26-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>26</strong>mercoledì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">19:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/elisir-2-1-e1749116654810.jpg" loading="lazy" alt="L&#8217;elisir d&#8217;amore"></figure>
+																				<div class="content">
+											<div class="category">Opera 2025/ 26</div>
+											<div class="title">L&#8217;elisir d&#8217;amore</div>
+
+																						<div class="place">
+																									Teatro Malibran
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-lelisir-damore/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="8" data-list-year="2026" data-list-id="08-28-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>28</strong>venerdì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">19:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/elisir-2-1-e1749116654810.jpg" loading="lazy" alt="L&#8217;elisir d&#8217;amore"></figure>
+																				<div class="content">
+											<div class="category">Opera 2025/ 26</div>
+											<div class="title">L&#8217;elisir d&#8217;amore</div>
+
+																						<div class="place">
+																									Teatro Malibran
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-lelisir-damore/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="8" data-list-year="2026" data-list-id="08-30-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>30</strong>domenica</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">17:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/elisir-2-1-e1749116654810.jpg" loading="lazy" alt="L&#8217;elisir d&#8217;amore"></figure>
+																				<div class="content">
+											<div class="category">Opera 2025/ 26</div>
+											<div class="title">L&#8217;elisir d&#8217;amore</div>
+
+																						<div class="place">
+																									Teatro Malibran
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-lelisir-damore/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="9" data-list-year="2026" data-list-id="09-01-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>01</strong>martedì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">19:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/elisir-2-1-e1749116654810.jpg" loading="lazy" alt="L&#8217;elisir d&#8217;amore"></figure>
+																				<div class="content">
+											<div class="category">Opera 2025/ 26</div>
+											<div class="title">L&#8217;elisir d&#8217;amore</div>
+
+																						<div class="place">
+																									Teatro Malibran
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-lelisir-damore/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="9" data-list-year="2026" data-list-id="09-15-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>15</strong>martedì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">18:00</div>
+																				<div class="content">
+											<div class="category">conferenze</div>
+											<div class="title">Incontro con l&#8217;opera: Pagliacci</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/incontro-con-lopera-pagliacci/">Ingresso libero  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="9" data-list-year="2026" data-list-id="09-17-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>17</strong>giovedì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">20:00</div>
+																				<div class="content">
+											<div class="category">Archivio Musicale Guido Alberto Fano Onlus</div>
+											<div class="title">Ettore Pagano e Massimo Spada</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/archivio-fano-ettore-pagano-e-massimo-spada/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="9" data-list-year="2026" data-list-id="09-18-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>18</strong>venerdì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">19:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/yevgeniy-mironov-9kRfwVHSsH0-unsplash1-1.jpg" loading="lazy" alt="Pagliacci"></figure>
+																				<div class="content">
+											<div class="category">Opera 2025/ 26</div>
+											<div class="title">Pagliacci</div>
+
+																						<div class="place">
+																									Teatro Malibran
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-pagliacci/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="9" data-list-year="2026" data-list-id="09-20-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>20</strong>domenica</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">17:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/yevgeniy-mironov-9kRfwVHSsH0-unsplash1-1.jpg" loading="lazy" alt="Pagliacci"></figure>
+																				<div class="content">
+											<div class="category">Opera 2025/ 26</div>
+											<div class="title">Pagliacci</div>
+
+																						<div class="place">
+																									Teatro Malibran
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-pagliacci/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="9" data-list-year="2026" data-list-id="09-21-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>21</strong>lunedì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">20:00</div>
+																				<div class="content">
+											<div class="category">Musikàmera</div>
+											<div class="title">Quartetto Rilke</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/musikamera-quartetto-rilke/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="9" data-list-year="2026" data-list-id="09-22-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>22</strong>martedì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">19:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/yevgeniy-mironov-9kRfwVHSsH0-unsplash1-1.jpg" loading="lazy" alt="Pagliacci"></figure>
+																				<div class="content">
+											<div class="category">Opera 2025/ 26</div>
+											<div class="title">Pagliacci</div>
+
+																						<div class="place">
+																									Teatro Malibran
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-pagliacci/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="9" data-list-year="2026" data-list-id="09-23-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>23</strong>mercoledì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">20:00</div>
+																				<div class="content">
+											<div class="category">Musikàmera</div>
+											<div class="title">Alessandro Carbonare, Francesca Dego e Alessandro Taverna</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/musikamera-alessandro-carbonare-francesca-dego-e-alessandro-taverna/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="9" data-list-year="2026" data-list-id="09-24-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>24</strong>giovedì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">19:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/yevgeniy-mironov-9kRfwVHSsH0-unsplash1-1.jpg" loading="lazy" alt="Pagliacci"></figure>
+																				<div class="content">
+											<div class="category">Opera 2025/ 26</div>
+											<div class="title">Pagliacci</div>
+
+																						<div class="place">
+																									Teatro Malibran
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-pagliacci/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">20:00</div>
+																				<div class="content">
+											<div class="category">Musikàmera</div>
+											<div class="title">Alessandro Carbonare, Francesca Dego e Alessandro Taverna</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/musikamera-alessandro-carbonare-francesca-dego-e-alessandro-taverna/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="9" data-list-year="2026" data-list-id="09-25-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>25</strong>venerdì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">20:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/Callegari-Daniele_01.jpg" loading="lazy" alt="Concerto diretto da Daniele Callegari"></figure>
+																				<div class="content">
+											<div class="category">Concerti 2025/ 26</div>
+											<div class="title">Concerto diretto da Daniele Callegari</div>
+
+																						<div class="place">
+																									Teatro Malibran
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-concerto-diretto-da-daniele-callegari/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="9" data-list-year="2026" data-list-id="09-26-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>26</strong>sabato</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">17:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/yevgeniy-mironov-9kRfwVHSsH0-unsplash1-1.jpg" loading="lazy" alt="Pagliacci"></figure>
+																				<div class="content">
+											<div class="category">Opera 2025/ 26</div>
+											<div class="title">Pagliacci</div>
+
+																						<div class="place">
+																									Teatro Malibran
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-pagliacci/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="9" data-list-year="2026" data-list-id="09-27-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>27</strong>domenica</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">17:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/Callegari-Daniele_01.jpg" loading="lazy" alt="Concerto diretto da Daniele Callegari"></figure>
+																				<div class="content">
+											<div class="category">Concerti 2025/ 26</div>
+											<div class="title">Concerto diretto da Daniele Callegari</div>
+
+																						<div class="place">
+																									Teatro Malibran
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-concerto-diretto-da-daniele-callegari/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="10" data-list-year="2026" data-list-id="10-01-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>01</strong>giovedì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">20:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/Thomson-Neil_02_photo-Rafaella-Pessoa.jpg" loading="lazy" alt="Concerto diretto da Neil Thomson"></figure>
+																				<div class="content">
+											<div class="category">Concerti 2025/ 26</div>
+											<div class="title">Concerto diretto da Neil Thomson</div>
+
+																						<div class="place">
+																									Teatro Malibran
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-concerto-diretto-da-neil-thomson/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="10" data-list-year="2026" data-list-id="10-02-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>02</strong>venerdì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">19:00</div>
+																				<div class="content">
+											<div class="category">VENEZIA JAZZ FESTIVAL FALL EDITION</div>
+											<div class="title">Stockhausen &#8211; Weber &#8211; Heral &#8211; INSIDE OUT</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stockhausen-weber-heral-inside-out/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">20:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/Thomson-Neil_02_photo-Rafaella-Pessoa.jpg" loading="lazy" alt="Concerto diretto da Neil Thomson"></figure>
+																				<div class="content">
+											<div class="category">Concerti 2025/ 26</div>
+											<div class="title">Concerto diretto da Neil Thomson</div>
+
+																						<div class="place">
+																									Teatro Malibran
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-concerto-diretto-da-neil-thomson/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="10" data-list-year="2026" data-list-id="10-03-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>03</strong>sabato</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">19:00</div>
+																				<div class="content">
+											<div class="category">VENEZIA JAZZ FESTIVAL FALL EDITION</div>
+											<div class="title">Stockhausen &#8211; Weber &#8211; Heral &#8211; INSIDE OUT</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stockhausen-weber-heral-inside-out/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="10" data-list-year="2026" data-list-id="10-06-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>06</strong>martedì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">09:30</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2022/10/KLCC9867.jpg" loading="lazy" alt="Premio Venezia 2026"></figure>
+																				<div class="content">
+											<div class="category">Altri</div>
+											<div class="title">Premio Venezia 2026</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/premio-venezia-2026/">Su invito  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">18:00</div>
+																				<div class="content">
+											<div class="category">conferenze</div>
+											<div class="title">Incontro con l&#8217;opera: The Telephone | Trouble in Tahiti</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/incontro-con-lopera-the-telephone-trouble-in-tahiti/">Ingresso libero  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="10" data-list-year="2026" data-list-id="10-07-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>07</strong>mercoledì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">09:30</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2022/10/KLCC9867.jpg" loading="lazy" alt="Premio Venezia 2026"></figure>
+																				<div class="content">
+											<div class="category">Altri</div>
+											<div class="title">Premio Venezia 2026</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/premio-venezia-2026/">Su invito  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="10" data-list-year="2026" data-list-id="10-08-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>08</strong>giovedì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">09:30</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2022/10/KLCC9867.jpg" loading="lazy" alt="Premio Venezia 2026"></figure>
+																				<div class="content">
+											<div class="category">Altri</div>
+											<div class="title">Premio Venezia 2026</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/premio-venezia-2026/">Su invito  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="10" data-list-year="2026" data-list-id="10-09-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>09</strong>venerdì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">09:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2022/10/KLCC9867.jpg" loading="lazy" alt="Premio Venezia 2026"></figure>
+																				<div class="content">
+											<div class="category">Altri</div>
+											<div class="title">Premio Venezia 2026</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/premio-venezia-2026/">Su invito  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">15:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2022/10/KLCC9867.jpg" loading="lazy" alt="Premio Venezia 2026"></figure>
+																				<div class="content">
+											<div class="category">Altri</div>
+											<div class="title">Premio Venezia 2026</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/premio-venezia-2026/">Su invito  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">19:00</div>
+																				<div class="content">
+											<div class="category">Opera 2025/ 26</div>
+											<div class="title">The telephone &#038; Trouble in Tahiti</div>
+
+																						<div class="place">
+																									Teatro Goldoni
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-the-telephone-trouble-in-tahiti/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="10" data-list-year="2026" data-list-id="10-10-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>10</strong>sabato</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">15:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2022/10/KLCC9867.jpg" loading="lazy" alt="Premio Venezia 2026"></figure>
+																				<div class="content">
+											<div class="category">Altri</div>
+											<div class="title">Premio Venezia 2026</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/premio-venezia-2026/">Su invito  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">19:00</div>
+																				<div class="content">
+											<div class="category">Opera 2025/ 26</div>
+											<div class="title">The telephone &#038; Trouble in Tahiti</div>
+
+																						<div class="place">
+																									Teatro Goldoni
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-the-telephone-trouble-in-tahiti/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="10" data-list-year="2026" data-list-id="10-11-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>11</strong>domenica</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">15:30</div>
+																				<div class="content">
+											<div class="category">Opera 2025/ 26</div>
+											<div class="title">The telephone &#038; Trouble in Tahiti</div>
+
+																						<div class="place">
+																									Teatro Goldoni
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-the-telephone-trouble-in-tahiti/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">17:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2022/10/KLCC9867.jpg" loading="lazy" alt="Premio Venezia 2026"></figure>
+																				<div class="content">
+											<div class="category">Altri</div>
+											<div class="title">Premio Venezia 2026</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/premio-venezia-2026/">Su invito  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="10" data-list-year="2026" data-list-id="10-13-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>13</strong>martedì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">18:00</div>
+																				<div class="content">
+											<div class="category">conferenze</div>
+											<div class="title">Incontro con la danza: Hamburger Kammerballett | Dear Son</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/incontro-con-la-danza-hamburger-kammerballett-dear-son/">Ingresso libero  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">19:00</div>
+																				<div class="content">
+											<div class="category">Opera 2025/ 26</div>
+											<div class="title">The telephone &#038; Trouble in Tahiti</div>
+
+																						<div class="place">
+																									Teatro Goldoni
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-the-telephone-trouble-in-tahiti/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="10" data-list-year="2026" data-list-id="10-14-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>14</strong>mercoledì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">19:00</div>
+																				<div class="content">
+											<div class="category">Opera 2025/ 26</div>
+											<div class="title">The telephone &#038; Trouble in Tahiti</div>
+
+																						<div class="place">
+																									Teatro Goldoni
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-the-telephone-trouble-in-tahiti/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="10" data-list-year="2026" data-list-id="10-16-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>16</strong>venerdì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">19:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/Screenshot-2025-06-05-alle-10.53.58.png" loading="lazy" alt="Hamburger Kammerballett"></figure>
+																				<div class="content">
+											<div class="category">Danza 2025/26</div>
+											<div class="title">Hamburger Kammerballett</div>
+
+																						<div class="place">
+																									Teatro Malibran
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/danza-25-26-hamburger-kammerballett/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="10" data-list-year="2026" data-list-id="10-17-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>17</strong>sabato</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">17:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/Screenshot-2025-06-05-alle-10.53.58.png" loading="lazy" alt="Hamburger Kammerballett"></figure>
+																				<div class="content">
+											<div class="category">Danza 2025/26</div>
+											<div class="title">Hamburger Kammerballett</div>
+
+																						<div class="place">
+																									Teatro Malibran
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/danza-25-26-hamburger-kammerballett/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="10" data-list-year="2026" data-list-id="10-20-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>20</strong>martedì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">20:00</div>
+																				<div class="content">
+											<div class="category">Musikàmera</div>
+											<div class="title">Trio Hermes</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/musikamera-trio-hermes/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="10" data-list-year="2026" data-list-id="10-23-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>23</strong>venerdì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">19:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/dear-son_Flavia-Tartaglia-6-scaled.jpg" loading="lazy" alt="Dear Son"></figure>
+																				<div class="content">
+											<div class="category">Danza 2025/26</div>
+											<div class="title">Dear Son</div>
+
+																						<div class="place">
+																									Teatro Malibran
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/danza-25-26-dear-son/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">20:00</div>
+																				<div class="content">
+											<div class="category">Musikàmera</div>
+											<div class="title">Pavel Berman e Maria Meerovitch</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/musikamera-pavel-berman-e-maria-meerovitch/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="10" data-list-year="2026" data-list-id="10-24-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>24</strong>sabato</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">17:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/dear-son_Flavia-Tartaglia-6-scaled.jpg" loading="lazy" alt="Dear Son"></figure>
+																				<div class="content">
+											<div class="category">Danza 2025/26</div>
+											<div class="title">Dear Son</div>
+
+																						<div class="place">
+																									Teatro Malibran
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/danza-25-26-dear-son/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">20:00</div>
+																				<div class="content">
+											<div class="category">Musikàmera</div>
+											<div class="title">Pavel Berman e Maria Meerovitch</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/musikamera-pavel-berman-e-maria-meerovitch/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="10" data-list-year="2026" data-list-id="10-30-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>30</strong>venerdì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">20:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/Caiani-e-Coro_01-e1749464053557.jpg" loading="lazy" alt="Concerto diretto da Alfonso Caiani"></figure>
+																				<div class="content">
+											<div class="category">Concerti 2025/ 26</div>
+											<div class="title">Concerto diretto da Alfonso Caiani</div>
+
+																						<div class="place">
+																									Teatro Malibran
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-concerto-diretto-da-alfonso-caiani/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="10" data-list-year="2026" data-list-id="10-31-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>31</strong>sabato</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">20:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/06/Caiani-e-Coro_01-e1749464053557.jpg" loading="lazy" alt="Concerto diretto da Alfonso Caiani"></figure>
+																				<div class="content">
+											<div class="category">Concerti 2025/ 26</div>
+											<div class="title">Concerto diretto da Alfonso Caiani</div>
+
+																						<div class="place">
+																									Teatro Malibran
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/stagione-25-26-concerto-diretto-da-alfonso-caiani/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="11" data-list-year="2026" data-list-id="11-03-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>03</strong>martedì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">20:00</div>
+																				<div class="content">
+											<div class="category">Musikàmera</div>
+											<div class="title">Musikàmera</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/musikamera-debiasi-leonardi-lazari-dallavecchia-divacri-toffano-erle/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">20:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/11/ensemble-symphony-orchestra.jpeg" loading="lazy" alt="Tribute to Hans Zimmer  | Ensemble Symphony Orchestra"></figure>
+																				<div class="content">
+											<div class="category">Veneto Jazz</div>
+											<div class="title">Tribute to Hans Zimmer  | Ensemble Symphony Orchestra</div>
+
+																						<div class="place">
+																									Teatro Malibran
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/tribute-to-hans-zimmer-ensemble-symphony-orchestra/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="11" data-list-year="2026" data-list-id="11-04-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>04</strong>mercoledì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">20:00</div>
+																				<div class="content">
+											<div class="category">Musikàmera</div>
+											<div class="title">Musikàmera</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/musikamera-debiasi-leonardi-lazari-dallavecchia-divacri-toffano-erle/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="11" data-list-year="2026" data-list-id="11-12-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>12</strong>giovedì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">20:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2025/12/Screenshot-2026-04-01-alle-09.07.47.png" loading="lazy" alt="Joshua Bell e Peter Dugan"></figure>
+																				<div class="content">
+											<div class="category">Musikàmera</div>
+											<div class="title">Joshua Bell e Peter Dugan</div>
+
+																						<div class="place">
+																									Teatro Malibran
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/musikamera-joshua-bell-peter-dugan/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="11" data-list-year="2026" data-list-id="11-25-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>25</strong>mercoledì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">18:00</div>
+																				<div class="content">
+											<div class="category">Danza</div>
+											<div class="title">Percorsi della danza &#8211; Cinema e Danza: il Musical</div>
+
+																						<div class="place">
+																									Sale Apollinee
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/percorsi-della-danza-cinema-e-danza-il-musical/">Ingresso libero  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="12" data-list-year="2026" data-list-id="12-29-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>29</strong>martedì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">20:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2021/01/1.jpg" loading="lazy" alt="Concerto di Capodanno 2027"></figure>
+																				<div class="content">
+											<div class="category">Concerti 2026/ 27</div>
+											<div class="title">Concerto di Capodanno 2027</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/concerto-di-capodanno-2027/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="12" data-list-year="2026" data-list-id="12-30-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>30</strong>mercoledì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">17:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2021/01/1.jpg" loading="lazy" alt="Concerto di Capodanno 2027"></figure>
+																				<div class="content">
+											<div class="category">Concerti 2026/ 27</div>
+											<div class="title">Concerto di Capodanno 2027</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/concerto-di-capodanno-2027/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="12" data-list-year="2026" data-list-id="12-31-2026">
+							<div class="sn_calendar_block_list_row_date"><strong>31</strong>giovedì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">16:00</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2021/01/1.jpg" loading="lazy" alt="Concerto di Capodanno 2027"></figure>
+																				<div class="content">
+											<div class="category">Concerti 2026/ 27</div>
+											<div class="title">Concerto di Capodanno 2027</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/concerto-di-capodanno-2027/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+					
+						<div class="sn_calendar_block_list_row " data-list-month="1" data-list-year="2027" data-list-id="01-01-2027">
+							<div class="sn_calendar_block_list_row_date"><strong>01</strong>venerdì</div>
+							<div class="sn_calendar_block_list_row_group">
+																	<div class="sn_calendar_block_list_row_group_i">
+										<div class="time">11:15</div>
+																					<figure><img src="https://www.teatrolafenice.it/wp-content/uploads/2021/01/1.jpg" loading="lazy" alt="Concerto di Capodanno 2027"></figure>
+																				<div class="content">
+											<div class="category">Concerti 2026/ 27</div>
+											<div class="title">Concerto di Capodanno 2027</div>
+
+																						<div class="place">
+																									Teatro La Fenice
+																							</div>
+										</div>
+										<div class="link">
+																																		
+											<a href="https://www.teatrolafenice.it/event/concerto-di-capodanno-2027/">ACQUISTA  <span class="sn_sprite _calendar ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#calendar" /></svg>
+  </span>
+</a>
+										</div>
+									</div>
+															</div>
+						</div>
+									</div>
+			</div>
+		</div>
+	</div>
+
+</section>
+
+<div class="sn_calendar_block_popup_wrap">
+	<div class="sn_calendar_block_popup">
+		<a href="javascript:;" class="sn_calendar_block_popup_close">  <span class="sn_sprite _cross ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#cross" /></svg>
+  </span>
+</a>
+
+		<figure class="sn_calendar_block_popup_figure">
+			<img>
+		</figure>
+
+		<div class="sn_calendar_block_popup_category"></div>
+		<div class="sn_calendar_block_popup_title"></div>
+		<div class="sn_calendar_block_popup_info">
+					</div>
+		<div>
+			<a class="sn_calendar_block_popup_button">ACQUISTA</a>
+		</div>
+	</div>
+</div>
+
+			<section class="sn_slider_explore   _gray">
+		<div class="container">
+
+					<div class="sn_slider_explore_text"><h2>Esplora</h2>
+<p>Ti potrebbero interessare..</p>
+</div>
+		
+		<div
+			class="sn_slider_explore_ct swiper-container"
+			data-module="swiper-slider"
+			data-module-args="{
+				params: {
+					speed: 600,
+					slidesPerView: 2,
+					spaceBetween: 18,
+					navigation: {
+						nextEl: '.sn_swiper_controls .sn_swiper_button._next',
+						prevEl: '.sn_swiper_controls .sn_swiper_button._prev',
+					},
+					pagination: {
+						el: '.sn_swiper_controls .sn_swiper_pagination',
+						type: 'fraction',
+					},
+					breakpoints: {
+						991: {
+							slidesPerView: 1
+						}
+					}
+				}
+			}">
+			<div class="swiper-wrapper">
+									<div class="swiper-slide">
+						<a href="https://www.teatrolafenice.it/fondazione-teatro-la-fenice/storia/" class="sn_explore_i" style="background-image: url('https://www.teatrolafenice.it/wp-content/uploads/2023/01/Schermata-2023-01-16-alle-14.31.37-e1673964157907.png')">
+							<div class="sn_explore_i_in">
+								<div class="inner">
+																		<div class="title">La Fenice & il Teatro Malibran: la storia</div>									<div class="subtitle">La Fenice e il Teatro Malibran: un viaggio attraverso i secoli</div>								</div>
+							</div>
+						</a>
+					</div>
+									<div class="swiper-slide">
+						<a href="https://www.teatrolafenice.it/fondazione-teatro-la-fenice/chi-siamo/mecenati/" class="sn_explore_i" style="background-image: url('https://www.teatrolafenice.it/wp-content/uploads/2019/02/Banner-SociSostenitori-700x540.jpg')">
+							<div class="sn_explore_i_in">
+								<div class="inner">
+																		<div class="title">Mecenati</div>									<div class="subtitle">Tutti i Mecenati che hanno scelto di investire nel nostro Teatro, permettendoci di proporre una stagione sempre più ricca e di elevato contenuto artistico</div>								</div>
+							</div>
+						</a>
+					</div>
+							</div>
+
+			<div class="sn_swiper_controls">
+				<div class="sn_swiper_controls_in">
+
+					<div class="sn_swiper_pagination"></div>
+
+					<div class="sn_swiper_button _prev">  <span class="sn_sprite _arrow-left ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#arrow-left" /></svg>
+  </span>
+</div>
+					<div class="sn_swiper_button _next">  <span class="sn_sprite _arrow-right ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#arrow-right" /></svg>
+  </span>
+</div>
+
+				</div>
+			</div>
+		</div>
+
+	</div>
+</section>
+
+
+							<footer class="sn_footer ">
+
+	<div class="swiper-container sn_footer_menu_top"
+			data-module="swiper-slider"
+			data-module-args="{
+				params: {
+					slidesPerView: 3,
+					simulateTouch: true,
+					breakpoints: {
+						991: {
+							slidesPerView: 'auto'
+						}
+					}
+      	}
+			}">
+		<div class="swiper-wrapper">
+							<div class="swiper-slide">
+								  		<a href="https://www.teatrolafenice.it/area-stampa-generale/" target="">Area Stampa</a>
+									</div>
+							<div class="swiper-slide">
+								  		<a href="https://www.teatrolafenice.it/la-fenice-card/" target="">La Fenice Card</a>
+									</div>
+							<div class="swiper-slide">
+								  		<a href="https://www.teatrolafenice.it/dona-alla-fenice/" target="">Dona alla Fenice</a>
+									</div>
+					</div>
+	</div>
+	<div class="container sn_footer_wr">
+		<div class="row">
+			<div class="col-lg-4 col-xl-5 d-flex flex-column justify-content-between">
+				<ul class="sn_footer_menu_left">
+															  <li class="_simple menu-item menu-item-type-post_type menu-item-object-page menu-item-39863"><a href="https://www.teatrolafenice.it/area-stampa-generale/">Area Stampa</a></li>
+										  <li class="_simple menu-item menu-item-type-post_type menu-item-object-page menu-item-31659"><a href="https://www.teatrolafenice.it/info-biglietteria-abbigliamento-disabili/">La biglietteria</a></li>
+										  <li class="_simple menu-item menu-item-type-custom menu-item-object-custom menu-item-52411"><a href="https://education.teatrolafenice.it/">Fenice education</a></li>
+										  <li class="_simple menu-item menu-item-type-custom menu-item-object-custom menu-item-40866"><a href="https://www.teatrolafenice.it/fondazione-teatro-la-fenice/visita-la-fenice/">Visita La Fenice</a></li>
+										  <li class="_simple menu-item menu-item-type-post_type menu-item-object-page menu-item-44823"><a href="https://www.teatrolafenice.it/newsletter/">Iscriviti alla newsletter</a></li>
+									</ul>
+
+				<ul class="sn_footer_socials d-none d-lg-block mt-0">
+																		<li><a href="https://www.facebook.com/teatrolafenice/" target="_blank">  <span class="sn_sprite _facebook ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#facebook" /></svg>
+  </span>
+</a></li>
+																								<li><a href="https://www.instagram.com/teatrolafenice/?hl=it" target="_blank">  <span class="sn_sprite _instagram ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#instagram" /></svg>
+  </span>
+</a></li>
+																								<li><a href="https://twitter.com/teatrolafenice" target="_blank">  <span class="sn_sprite _twitter ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#twitter" /></svg>
+  </span>
+</a></li>
+																								<li><a href="https://www.linkedin.com/company/teatro-la-fenice/" target="_blank">  <span class="sn_sprite _linkedin ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#linkedin" /></svg>
+  </span>
+</a></li>
+																								<li><a href="https://www.youtube.com/c/TeatrolafeniceIt" target="_blank">  <span class="sn_sprite _youtube ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#youtube" /></svg>
+  </span>
+</a></li>
+																								<li><a href="https://www.tripadvisor.it/Attraction_Review-g187870-d207094-Reviews-Teatro_La_Fenice-Venice_Veneto.html" target="_blank">  <span class="sn_sprite _tripadvisor ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#tripadvisor" /></svg>
+  </span>
+</a></li>
+																								<li><a href="https://www.tiktok.com/@teatrolafenice?is_from_webapp=1&sender_device=pc" target="_blank">  <span class="sn_sprite _tiktok ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#tiktok" /></svg>
+  </span>
+</a></li>
+															</ul>
+			</div>
+			<div class="col-lg-8 col-xl-7">
+
+				<ul class="sn_footer_menu_right" id="sn_footer_menu_right">
+											<li>
+							<a href="https://www.teatrolafenice.it/fondazione-teatro-la-fenice/">Fondazione Teatro La Fenice</a>
+							<div class="toggle collapsed" data-toggle="collapse" data-target="#sn_footer_menu_right_collapse_1">
+								  <span class="sn_sprite _angle-down ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#angle-down" /></svg>
+  </span>
+
+							</div>
+															<ul id="sn_footer_menu_right_collapse_1" class="collapse" data-parent=".sn_footer_menu_right">
+																			<li><a href="https://www.teatrolafenice.it/fondazione-teatro-la-fenice/chi-siamo/">Chi siamo</a></li>
+																			<li><a href="https://www.teatrolafenice.it/fondazione-teatro-la-fenice/storia/">La Fenice & il Teatro Malibran</a></li>
+																			<li><a href="https://www.teatrolafenice.it/fondazione-teatro-la-fenice/storia-coro-e-orchestra/">Storia del Coro e Orchestra</a></li>
+																			<li><a href="https://www.teatrolafenice.it/la-fenice-istituzioni-venezia/">La Fenice e le Istituzioni di Venezia</a></li>
+																			<li><a href="https://www.teatrolafenice.it/info-biglietteria-abbigliamento-disabili/">La biglietteria</a></li>
+																			<li><a href="https://www.teatrolafenice.it/abbonamenti/">Abbonamenti</a></li>
+																			<li><a href="https://www.teatrolafenice.it/come-arrivare-abbigliamento-regole/">Preparati per il Teatro</a></li>
+																			<li><a href="https://www.teatrolafenice.it/area-stampa-generale/">Area Stampa</a></li>
+																			<li><a href="https://www.teatrolafenice.it/libretti/">Libretti</a></li>
+																			<li><a href="https://www.teatrolafenice.it/la-fenice-online/">La Fenice online</a></li>
+																			<li><a href="https://www.teatrolafenice.it/archivio-storico/">Archivio Storico</a></li>
+																			<li><a href="https://www.teatrolafenice.it/media-e-social-partner/">Media Partner e Social</a></li>
+																			<li><a href="https://education.teatrolafenice.it/">Fenice Education</a></li>
+																			<li><a href="https://www.teatrolafenice.it/la-fenice-per-i-giovani/">La Fenice per i giovani</a></li>
+																	</ul>
+													</li>
+											<li>
+							<a href="https://www.teatrolafenice.it/fondazione-teatro-la-fenice/visita-la-fenice/">Visita La Fenice</a>
+							<div class="toggle collapsed" data-toggle="collapse" data-target="#sn_footer_menu_right_collapse_2">
+								  <span class="sn_sprite _angle-down ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#angle-down" /></svg>
+  </span>
+
+							</div>
+															<ul id="sn_footer_menu_right_collapse_2" class="collapse" data-parent=".sn_footer_menu_right">
+																			<li><a href="https://festfenice.com/orari">Orari visite</a></li>
+																			<li><a href="https://www.teatrolafenice.it/il-bookshop-del-teatro-la-fenice/">Il bookshop</a></li>
+																			<li><a href="https://www.teatrolafenice.it/la-fenice-app/">La Fenice App</a></li>
+																			<li><a href="https://www.teatrolafenice.it/la-fenice-card/">La Fenice Card</a></li>
+																	</ul>
+													</li>
+					
+											<li>
+							<a href="https://www.teatrolafenice.it/amministrazione-trasparente/">Amministrazione trasparente</a>
+							<div class="toggle collapsed" data-toggle="collapse" data-target="#sn_footer_menu_right_sec_collapse_1">
+								  <span class="sn_sprite _angle-down ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#angle-down" /></svg>
+  </span>
+
+							</div>
+															<ul id="sn_footer_menu_right_sec_collapse_1" class="collapse" data-parent=".sn_footer_menu_right">
+																			<li><a href="https://www.teatrolafenice.it/fondazione-teatro-la-fenice/chi-siamo/mecenati/">Fondatori, Mecenati, Partner, Collaborazioni</a></li>
+																			<li><a href="https://artbonus.gov.it/116-16-fondazione-teatro-la-fenice-di-venezia.html">Art Bonus</a></li>
+																			<li><a href="https://www.teatrolafenice.it/cartadellacultura-cartadelmerito-cartadeldocente/">Bonus Cultura</a></li>
+																			<li><a href="https://www.teatrolafenice.it/amministrazione-trasparente/bandi-di-gara-e-contratti/">Bandi di gara</a></li>
+																			<li><a href="https://www.teatrolafenice.it/amministrazione-trasparente/fornitori/">Fornitori e Professionisti</a></li>
+																			<li><a href="https://www.teatrolafenice.it/fondazione-teatro-la-fenice/lavora-con-noi/">Lavora con noi</a></li>
+																			<li><a href="https://www.teatrolafenice.it/info-e-contatti/">Contatti</a></li>
+																			<li><a href="https://www.teatrolafenice.it/newsletter/">Newsletter</a></li>
+																	</ul>
+													</li>
+					
+									</ul>
+			</div>
+		</div>
+	</div>
+
+
+
+	<div class="sn_footer_banners">
+		<div class="container">
+			<div class="row">
+
+				<div class="col-12 logos">
+											<a href="https://www.beniculturali.it/" target="_blank" title="MiC">
+							<img src="https://www.teatrolafenice.it/wp-content/uploads/2023/10/Ministero-Cultura-MIC_quadr-e1696945105438.png" alt=""/>
+						</a>
+											<a href="http://www.regione.veneto.it/" target="_blank" title="Regione del Veneto">
+							<img src="https://www.teatrolafenice.it/wp-content/uploads/2022/11/veneto_regione.png" alt=""/>
+						</a>
+											<a href="https://www.comune.venezia.it/" target="_blank" title="Città di Venezia">
+							<img src="https://www.teatrolafenice.it/wp-content/uploads/2022/11/citta-di-venezia.png" alt=""/>
+						</a>
+					
+											<a href="https://www.anfols.it/" target="_blank" title="Anfols" class="">
+							<img src="https://www.teatrolafenice.it/wp-content/uploads/2022/11/cropped-Logo-Anfols-1.png" alt=""/>
+						</a>
+											<a href="https://www.fondazionedivenezia.org/" target="_blank" title="Fondazione venezia" class="">
+							<img src="https://www.teatrolafenice.it/wp-content/uploads/2022/11/FondazioneVenezia-1.png" alt=""/>
+						</a>
+											<a href="https://group.intesasanpaolo.com/it/" target="_blank" title="Intesa San Paolo" class="">
+							<img src="https://www.teatrolafenice.it/wp-content/uploads/2022/11/ISP_FullColor.png" alt=""/>
+						</a>
+									</div>
+			</div>
+
+
+		
+			<div class="row">
+				<div class="col-12 d-lg-none">
+					<ul class="sn_footer_socials">
+																					<li><a href="https://www.facebook.com/teatrolafenice/" target="_blank">  <span class="sn_sprite _facebook ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#facebook" /></svg>
+  </span>
+</a></li>
+																												<li><a href="https://www.instagram.com/teatrolafenice/?hl=it" target="_blank">  <span class="sn_sprite _instagram ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#instagram" /></svg>
+  </span>
+</a></li>
+																												<li><a href="https://twitter.com/teatrolafenice" target="_blank">  <span class="sn_sprite _twitter ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#twitter" /></svg>
+  </span>
+</a></li>
+																												<li><a href="https://www.linkedin.com/company/teatro-la-fenice/" target="_blank">  <span class="sn_sprite _linkedin ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#linkedin" /></svg>
+  </span>
+</a></li>
+																												<li><a href="https://www.youtube.com/c/TeatrolafeniceIt" target="_blank">  <span class="sn_sprite _youtube ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#youtube" /></svg>
+  </span>
+</a></li>
+																												<li><a href="https://www.tripadvisor.it/Attraction_Review-g187870-d207094-Reviews-Teatro_La_Fenice-Venice_Veneto.html" target="_blank">  <span class="sn_sprite _tripadvisor ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#tripadvisor" /></svg>
+  </span>
+</a></li>
+																												<li><a href="https://www.tiktok.com/@teatrolafenice?is_from_webapp=1&sender_device=pc" target="_blank">  <span class="sn_sprite _tiktok ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#tiktok" /></svg>
+  </span>
+</a></li>
+																		</ul>
+				</div>
+
+			</div>
+		</div>
+	</div>
+
+	
+	<div class="sn_footer_copyright">
+		<div class="container">
+			<div class="row">
+				<div class="col-12">
+					<div class="sn_footer_copyright_in">
+						<p><strong>© 2019 &#8211; Fondazione Teatro La Fenice</strong> &#8211; P.IVA 00187480272 &#8211; Tutti i diritti riservati &#8211; Campo San Fantin 1965, San Marco &#8211; 30124 Venezia</p>
+
+
+						<ul class="sn_footer_menu_bottom">
+															<li><a href="https://www.teatrolafenice.it/privacy-policy/" target="">Privacy Policy</a></li>
+															<li><a href="https://www.teatrolafenice.it/cookie-policy/" target="">Cookie Policy</a></li>
+															<li><a href="https://www.teatrolafenice.it/fondazione-teatro-la-fenice/lavora-con-noi/" target="">Lavora con noi</a></li>
+														<li><a href="javascript:;" data-toggle="modal" data-target="#credits_modal">Credits</a></li>
+						</ul>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</footer>
+
+<div class="sn_modal _credits modal fade" tabindex="-1" id="credits_modal">
+	<div class="modal-dialog">
+		<div class="modal-content">
+			<div class="modal-header">
+				<h5 class="modal-title sn_modal_title">
+					<div>Powered by</div>
+				</h5>
+				<a href="javascript:;" data-dismiss="modal" class="sn_modal_close">
+					  <span class="sn_sprite _cross ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#cross" /></svg>
+  </span>
+
+				</a>
+			</div>
+			<div class="sn_modal_body modal-body">
+				<div class="sn_modal_body_in">
+					<a href="https://www.seisnet.it/" target="_blank" title="SEISNET srl">
+						<img src="/wp-content/themes/teatro-la-fenice/assets/images/obj/seisnet.svg" alt="" />
+					</a>
+					<a href="http://www.efesto.studio" target="_blank" title="EFESTO">
+						<img src="/wp-content/themes/teatro-la-fenice/assets/images/obj/efesto.svg" alt="" />
+					</a>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+
+
+			
+							<div class="sn_modal modal fade" id="sn_modal_share" tabindex="-1">
+					<div class="modal-dialog">
+						<div class="modal-content">
+							<div class="modal-header">
+								<h5 class="modal-title sn_modal_title">Condividi</h5>
+								<a href="javascript:;" data-dismiss="modal" class="sn_modal_close">
+									  <span class="sn_sprite _cross ">
+    <svg viewBox="0 0 80 80"><use xlink:href="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/images/icons.svg#cross" /></svg>
+  </span>
+
+								</a>
+							</div>
+							<div class="sn_modal_body modal-body text-center">
+
+								<div class="addthis_inline_share_toolbox"></div>
+
+							</div>
+						</div>
+					</div>
+				</div>
+			
+		</div>
+
+		<script type='text/javascript' src='https://www.teatrolafenice.it/wp-includes/js/wp-embed.min.js'></script>
+
+		<script data-cookieconsent="ignore" src="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/javascripts/shared.js"></script>
+		<script data-cookieconsent="ignore" src="https://www.teatrolafenice.it/wp-content/themes/teatro-la-fenice/assets/javascripts/main.js?v=2"></script>
+
+
+		<!-- Go to www.addthis.com/dashboard to customize your tools -->
+		
+	</body>
+</html>
+
+<!--
+Performance optimized by W3 Total Cache. Learn more: https://www.boldgrid.com/w3-total-cache/
+
+Page Caching using Disk: Enhanced 
+Database Caching 1323/1882 queries in 1,451 seconds using Disk
+
+Served from: www.teatrolafenice.it @ 2026-04-03 06:07:47 by W3 Total Cache
+-->

--- a/src/scrapers/__tests__/teatro-la-fenice.test.ts
+++ b/src/scrapers/__tests__/teatro-la-fenice.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { describe, it, expect } from 'vitest';
 import { TeatroLaFeniceScraper } from '../teatro-la-fenice.js';
+import { testDbIntegration } from './helpers/db-integration.js';
 
 const fixture = readFileSync(new URL('../__fixtures__/teatro-la-fenice.html', import.meta.url), 'utf8');
 const scraper = new TeatroLaFeniceScraper({ fetchHtml: async () => fixture });
@@ -58,4 +59,6 @@ describe('TeatroLaFeniceScraper', () => {
       expect(e).toHaveProperty('url');
     }
   });
+
+  testDbIntegration(scraper);
 });

--- a/src/scrapers/__tests__/teatro-la-fenice.test.ts
+++ b/src/scrapers/__tests__/teatro-la-fenice.test.ts
@@ -1,0 +1,61 @@
+import { readFileSync } from 'node:fs';
+import { describe, it, expect } from 'vitest';
+import { TeatroLaFeniceScraper } from '../teatro-la-fenice.js';
+
+const fixture = readFileSync(new URL('../__fixtures__/teatro-la-fenice.html', import.meta.url), 'utf8');
+const scraper = new TeatroLaFeniceScraper({ fetchHtml: async () => fixture });
+
+describe('TeatroLaFeniceScraper', () => {
+  it('parses events from fixture', async () => {
+    const events = await scraper.scrape();
+    expect(events.length).toBeGreaterThan(0);
+  });
+
+  it('parses date in YYYY-MM-DD format', async () => {
+    const events = await scraper.scrape();
+    for (const e of events) {
+      expect(e.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    }
+  });
+
+  it('parses time in HH:MM format or null', async () => {
+    const events = await scraper.scrape();
+    for (const e of events) {
+      if (e.time !== null) {
+        expect(e.time).toMatch(/^\d{2}:\d{2}$/);
+      }
+    }
+  });
+
+  it('includes event URLs', async () => {
+    const events = await scraper.scrape();
+    const withUrl = events.filter((e) => e.url !== null);
+    expect(withUrl.length).toBeGreaterThan(0);
+    for (const e of withUrl) {
+      expect(e.url).toMatch(/^https:\/\/www\.teatrolafenice\.it\//);
+    }
+  });
+
+  it('includes location when available', async () => {
+    const events = await scraper.scrape();
+    const withLocation = events.filter((e) => e.location !== null);
+    expect(withLocation.length).toBeGreaterThan(0);
+  });
+
+  it('sets all required Event fields', async () => {
+    const events = await scraper.scrape();
+    for (const e of events) {
+      expect(e.id).toBeTruthy();
+      expect(e.venue_id).toBe('teatro-la-fenice');
+      expect(e.title).toBeTruthy();
+      expect(e.date).toBeTruthy();
+      expect(e.scraped_at).toBeTruthy();
+      // Optional fields can be null but must be present
+      expect(e).toHaveProperty('time');
+      expect(e).toHaveProperty('conductor');
+      expect(e).toHaveProperty('cast');
+      expect(e).toHaveProperty('location');
+      expect(e).toHaveProperty('url');
+    }
+  });
+});

--- a/src/scrapers/teatro-la-fenice.ts
+++ b/src/scrapers/teatro-la-fenice.ts
@@ -1,0 +1,90 @@
+import { load } from 'cheerio';
+import type { Event } from '../types.js';
+import { generateEventId, USER_AGENT, type Scraper, type VenueMeta } from './base.js';
+
+type FetchHtml = () => Promise<string>;
+
+const BASE_URL = 'https://www.teatrolafenice.it';
+
+export class TeatroLaFeniceScraper implements Scraper {
+  readonly venue: VenueMeta = {
+    venueId: 'teatro-la-fenice',
+    venueName: 'Teatro La Fenice',
+    cityId: 'venezia',
+    cityName: 'Venezia',
+    country: 'IT',
+    scheduleUrl: 'https://www.teatrolafenice.it/calendario/',
+  };
+
+  get venueId(): string { return this.venue.venueId; }
+
+  constructor(private readonly opts: { fetchHtml?: FetchHtml } = {}) {}
+
+  async scrape(): Promise<Event[]> {
+    const html = this.opts.fetchHtml
+      ? await this.opts.fetchHtml()
+      : await fetch(this.venue.scheduleUrl, {
+          headers: { 'User-Agent': USER_AGENT },
+        }).then((r) => {
+          if (!r.ok) throw new Error(`HTTP ${r.status} from ${this.venue.scheduleUrl}`);
+          return r.text();
+        });
+    return this.parse(html);
+  }
+
+  parse(html: string): Event[] {
+    const $ = load(html);
+    const events: Event[] = [];
+    const now = new Date().toISOString();
+
+    $('div.sn_calendar_block_list_row').each((_, row) => {
+      try {
+        const $row = $(row);
+
+        // Parse date from data attributes: data-list-id="MM-DD-YYYY"
+        const listId = $row.attr('data-list-id') ?? '';
+        const dateMatch = listId.match(/^(\d{2})-(\d{2})-(\d{4})$/);
+        if (!dateMatch) return;
+        const [, mm, dd, yyyy] = dateMatch;
+        const date = `${yyyy}-${mm}-${dd}`;
+
+        // Each row can contain multiple events (group items)
+        $row.find('div.sn_calendar_block_list_row_group_i').each((_, el) => {
+          try {
+            const $el = $(el);
+
+            const title = $el.find('div.title').text().trim();
+            if (!title) return;
+
+            const timeText = $el.find('div.time').text().trim();
+            const time = /^\d{2}:\d{2}$/.test(timeText) ? timeText : null;
+
+            const location = $el.find('div.place').text().trim() || null;
+
+            const href = $el.find('div.link a').attr('href') ?? '';
+            const url = href ? new URL(href, BASE_URL + '/').href : null;
+
+            events.push({
+              id: generateEventId(this.venueId, date, time, title),
+              venue_id: this.venueId,
+              title,
+              date,
+              time,
+              conductor: null,
+              cast: null,
+              location,
+              url,
+              scraped_at: now,
+            });
+          } catch {
+            // skip malformed entries silently
+          }
+        });
+      } catch {
+        // skip malformed rows silently
+      }
+    });
+
+    return events;
+  }
+}


### PR DESCRIPTION
## Summary
- Add scraper for **Teatro La Fenice** (Venezia, IT) — Closes #6
- **Schedule URL:** https://www.teatrolafenice.it/calendario/
- Parses the Italian calendar page which lists all season events with date, time, title, location, and event detail links
- Fixture-based tests (6 tests) verify date/time format, URLs, locations, and all required Event fields

## Test plan
- [x] `npm test` passes (25 tests including 6 new ones)
- [ ] `npm run scrape` — verify `scrape_success` for `teatro-la-fenice`
- [ ] Spot-check parsed events against live schedule page

🤖 Generated with [Claude Code](https://claude.com/claude-code)