### PR TITLE
Switch structured logging from Axiom to Seq

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -2,15 +2,15 @@ PORT=3000
 DB_PATH=./data/leporello.db
 SCRAPE_CRON=0 3 * * *
 
-# Axiom log shipping (optional — leave AXIOM_TOKEN blank to disable)
-AXIOM_TOKEN=
-AXIOM_DATASET=leporello-mcp
+# Seq log shipping (optional — leave SEQ_URL blank to disable)
+SEQ_URL=
+SEQ_API_KEY=
 
 # Salt for hashing client IPs in MCP usage events. Generate with:
 #   node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 # Rotate yearly.
 HASH_SALT=
 
-# Tag every Axiom event with env=<value>.
+# Tag every Seq event with env=<value>.
 # Local: leave as "dev". On the deploy host: set to "production".
 LEPORELLO_ENV=dev

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ SQLite at `DB_PATH` env var (default `./data/leporello.db`). Initialized on `get
 | `list_venues` | `country?`, `city?` | Cascading filter: country → city |
 | `list_events` | `country?`, `city?`, `venue_id?`, `days_ahead?` | `days_ahead` default 30, max 90; returns `data_age` map |
 
-When a filter value isn't in the catalog (e.g. `city: "paris"`), `list_cities` / `list_venues` / `list_events` add a `note` field to the response telling the agent which filter is uncovered and which tool to call to discover what's available. The same miss is also logged on the `mcp_tool_call` event as `unmatched: {city: "paris"}` for Axiom monitoring — useful to see which cities/countries agents are asking for so we can prioritize new scrapers.
+When a filter value isn't in the catalog (e.g. `city: "paris"`), `list_cities` / `list_venues` / `list_events` add a `note` field to the response telling the agent which filter is uncovered and which tool to call to discover what's available. The same miss is also logged on the `mcp_tool_call` event as `unmatched: {city: "paris"}` for Seq monitoring — useful to see which cities/countries agents are asking for so we can prioritize new scrapers.
 
 ## Scraper pattern
 
@@ -94,14 +94,14 @@ npm test -- philharmoniker  # Run one scraper
 
 ## Logging
 
-All logs are structured JSON on stdout/stderr via `src/logger.ts`. When `AXIOM_TOKEN` and `AXIOM_DATASET` are set, events are also shipped to Axiom (batched, flushed on shutdown). When unset, Axiom is a no-op — local dev and tests need no config.
+All logs are structured JSON on stdout/stderr via `src/logger.ts`. When `SEQ_URL` and `SEQ_API_KEY` are set, events are also shipped to Seq as CLEF (buffered, flushed on shutdown). When unset, Seq is a no-op — local dev and tests need no config.
 
 Env vars (see `.env.sample`):
-- `AXIOM_TOKEN` — Axiom ingest token (optional; absent = stdout only)
-- `AXIOM_DATASET` — Axiom dataset name, e.g. `leporello-mcp`
+- `SEQ_URL` — Seq server URL, e.g. `https://seq.phib.io` (optional; absent = stdout only)
+- `SEQ_API_KEY` — Seq API key for ingestion
 - `HASH_SALT` — secret for hashing client IPs in MCP usage events; rotate yearly
 - `SERVICE_NAME` — `web` or `scraper`, set per container in `docker-compose.yml` (and per `npm` script for local dev)
-- `LEPORELLO_ENV` — set in `.env` on each host: `dev` locally, `production` on the deploy host. Tagged on every Axiom event as `env` so you can filter dev vs prod.
+- `LEPORELLO_ENV` — set in `.env` on each host: `dev` locally, `production` on the deploy host. Tagged on every Seq event as `env` so you can filter dev vs prod.
 
 Events:
 
@@ -119,8 +119,9 @@ Events:
 {"event":"mcp_tool_call","tool":"list_events","duration_ms":12,"result_count":47,"args":{"country":"DE"},"client_ua":"Claude/1.2.3","client_ip_hash":"a3f1b2c4d5e6f708"}
 {"event":"mcp_tool_call","tool":"list_events","duration_ms":3,"result_count":0,"unmatched":{"city":"paris"},"args":{"city":"paris"},"client_ua":"...","client_ip_hash":"..."}
 {"event":"mcp_tool_error","tool":"list_events","duration_ms":3,"args":{...},"error":"..."}
-{"event":"axiom_disabled","reason":"no_token"}
-{"event":"axiom_ingest_error","error":"..."}
+{"event":"seq_disabled","reason":"no_url"}
+{"event":"seq_ingest_error","error":"..."}
+{"event":"seq_flush_error","error":"..."}
 ```
 
 To add a new logger call: import `log` / `logError` from `./logger.js` (or `../logger.js`) — never use `console.log(JSON.stringify(...))` directly.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "leporello-mcp",
       "version": "0.1.0",
       "dependencies": {
-        "@axiomhq/js": "^1.6.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "better-sqlite3": "^12.0.0",
         "cheerio": "^1.0.0",
@@ -26,18 +25,6 @@
       },
       "engines": {
         "node": ">=22.0.0"
-      }
-    },
-    "node_modules/@axiomhq/js": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@axiomhq/js/-/js-1.6.0.tgz",
-      "integrity": "sha512-qm0ObduIpI6PJUOYwakH5WV3E7IF0qXE/wh5N1JWGAzxKtCZryk+YwA0aW3lPZSGPQeLHyEzN+9pXsOIjoPiRg==",
-      "license": "MIT",
-      "dependencies": {
-        "fetch-retry": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=20"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1855,12 +1842,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/fetch-retry": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/fetch-retry/-/fetch-retry-6.0.0.tgz",
-      "integrity": "sha512-BUFj1aMubgib37I3v4q78fYo63Po7t4HUPTpQ6/QE6yK6cIQrP+W43FYToeTEyg5m2Y7eFUtijUuAv/PDlWuag==",
-      "license": "MIT"
     },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@axiomhq/js": "^1.6.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "better-sqlite3": "^12.0.0",
     "cheerio": "^1.0.0",

--- a/src/__tests__/logger.test.ts
+++ b/src/__tests__/logger.test.ts
@@ -94,23 +94,33 @@ describe('logger (with Seq)', () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it('Seq flush errors do not throw to caller', async () => {
+  it('Seq flush errors do not throw and re-queue events', async () => {
     fetchMock.mockRejectedValueOnce(new Error('network down'));
+    fetchMock.mockResolvedValueOnce({ ok: true });
     const { log, flush } = await import('../logger.js');
     log('hi', {});
     await expect(flush()).resolves.toBeUndefined();
     const stderrCalls = stderrSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
     expect(stderrCalls).toContain('seq_flush_error');
+    // Re-queued event is sent on next flush
+    await flush();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const body = fetchMock.mock.calls[1][1].body as string;
+    expect(body).toContain('"hi"');
   });
 
-  it('Seq non-2xx response is reported as flush error', async () => {
+  it('Seq non-2xx response re-queues events', async () => {
     fetchMock.mockResolvedValueOnce({ ok: false, status: 500, text: async () => 'Internal Server Error' });
+    fetchMock.mockResolvedValueOnce({ ok: true });
     const { log, flush } = await import('../logger.js');
     log('hi', {});
     await expect(flush()).resolves.toBeUndefined();
     const stderrCalls = stderrSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
     expect(stderrCalls).toContain('seq_flush_error');
     expect(stderrCalls).toContain('500');
+    // Re-queued event is sent on next flush
+    await flush();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/src/__tests__/logger.test.ts
+++ b/src/__tests__/logger.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
-describe('logger (no Axiom token)', () => {
+describe('logger (no Seq config)', () => {
   let stdoutSpy: ReturnType<typeof vi.spyOn>;
   let stderrSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
-    delete process.env.AXIOM_TOKEN;
-    delete process.env.AXIOM_DATASET;
+    delete process.env.SEQ_URL;
+    delete process.env.SEQ_API_KEY;
     process.env.SERVICE_NAME = 'test';
     vi.resetModules();
     stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
@@ -41,30 +41,24 @@ describe('logger (no Axiom token)', () => {
     expect(parsed.error).toBe('nope');
   });
 
-  it('flush() resolves immediately when Axiom is disabled', async () => {
+  it('flush() resolves immediately when Seq is disabled', async () => {
     const { flush } = await import('../logger.js');
     await expect(flush()).resolves.toBeUndefined();
   });
 });
 
-describe('logger (with Axiom)', () => {
+describe('logger (with Seq)', () => {
   let stdoutSpy: ReturnType<typeof vi.spyOn>;
   let stderrSpy: ReturnType<typeof vi.spyOn>;
-  const ingestMock = vi.fn();
-  const flushMock = vi.fn().mockResolvedValue(undefined);
+  let fetchMock: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
-    process.env.AXIOM_TOKEN = 'test-token';
-    process.env.AXIOM_DATASET = 'test-dataset';
+    process.env.SEQ_URL = 'https://seq.test';
+    process.env.SEQ_API_KEY = 'test-key';
     process.env.SERVICE_NAME = 'web';
-    ingestMock.mockReset();
-    flushMock.mockClear();
     vi.resetModules();
-    vi.doMock('@axiomhq/js', () => ({
-      Axiom: vi.fn().mockImplementation(function () {
-        return { ingest: ingestMock, flush: flushMock };
-      }),
-    }));
+    fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', fetchMock);
     stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
     stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
   });
@@ -72,37 +66,51 @@ describe('logger (with Axiom)', () => {
   afterEach(() => {
     stdoutSpy.mockRestore();
     stderrSpy.mockRestore();
-    vi.doUnmock('@axiomhq/js');
-    delete process.env.AXIOM_TOKEN;
-    delete process.env.AXIOM_DATASET;
+    vi.unstubAllGlobals();
+    delete process.env.SEQ_URL;
+    delete process.env.SEQ_API_KEY;
   });
 
-  it('forwards events to Axiom with service tag and _time', async () => {
-    const { log } = await import('../logger.js');
+  it('buffers events and sends CLEF to Seq on flush', async () => {
+    const { log, flush } = await import('../logger.js');
     log('hello', { x: 1 });
-    expect(ingestMock).toHaveBeenCalledTimes(1);
-    const [dataset, events] = ingestMock.mock.calls[0];
-    expect(dataset).toBe('test-dataset');
-    expect(events).toHaveLength(1);
-    expect(events[0]).toMatchObject({ event: 'hello', x: 1, service: 'web' });
-    expect(events[0]._time).toMatch(/^\d{4}-\d{2}-\d{2}T/);
-  });
-
-  it('flush() awaits Axiom flush', async () => {
-    const { flush } = await import('../logger.js');
+    log('world', { y: 2 });
     await flush();
-    expect(flushMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, opts] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://seq.test/api/events/raw?clef');
+    expect(opts.headers['X-Seq-ApiKey']).toBe('test-key');
+    expect(opts.headers['Content-Type']).toBe('application/vnd.serilog.clef');
+    const lines = (opts.body as string).split('\n');
+    expect(lines).toHaveLength(2);
+    const first = JSON.parse(lines[0]);
+    expect(first).toMatchObject({ event: 'hello', x: 1, service: 'web', app: 'leporello' });
+    expect(first['@t']).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(first['@mt']).toBe('hello');
   });
 
-  it('Axiom ingest errors do not throw to caller', async () => {
-    ingestMock.mockImplementation(() => {
-      throw new Error('axiom down');
-    });
-    const { log } = await import('../logger.js');
-    expect(() => log('hi', {})).not.toThrow();
-    // Error reported to stderr
+  it('flush() is a no-op when buffer is empty', async () => {
+    await (await import('../logger.js')).flush();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('Seq flush errors do not throw to caller', async () => {
+    fetchMock.mockRejectedValueOnce(new Error('network down'));
+    const { log, flush } = await import('../logger.js');
+    log('hi', {});
+    await expect(flush()).resolves.toBeUndefined();
     const stderrCalls = stderrSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
-    expect(stderrCalls).toContain('axiom_ingest_error');
+    expect(stderrCalls).toContain('seq_flush_error');
+  });
+
+  it('Seq non-2xx response is reported as flush error', async () => {
+    fetchMock.mockResolvedValueOnce({ ok: false, status: 500, text: async () => 'Internal Server Error' });
+    const { log, flush } = await import('../logger.js');
+    log('hi', {});
+    await expect(flush()).resolves.toBeUndefined();
+    const stderrCalls = stderrSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+    expect(stderrCalls).toContain('seq_flush_error');
+    expect(stderrCalls).toContain('500');
   });
 });
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,36 +1,48 @@
 import { createHash } from 'node:crypto';
-import { Axiom } from '@axiomhq/js';
 
 const SERVICE_NAME = process.env.SERVICE_NAME ?? 'unknown';
 const ENV_NAME = process.env.LEPORELLO_ENV ?? 'dev';
-const AXIOM_TOKEN = process.env.AXIOM_TOKEN;
-const AXIOM_DATASET = process.env.AXIOM_DATASET;
+const SEQ_URL = process.env.SEQ_URL;
+const SEQ_API_KEY = process.env.SEQ_API_KEY;
 const HASH_SALT = process.env.HASH_SALT ?? '';
 
-const axiom: Axiom | null =
-  AXIOM_TOKEN && AXIOM_DATASET ? new Axiom({ token: AXIOM_TOKEN }) : null;
+// Buffer CLEF lines and auto-flush every 5 seconds to Seq
+const seqEnabled = !!(SEQ_URL && SEQ_API_KEY);
+const buffer: string[] = [];
+let flushTimer: ReturnType<typeof setInterval> | null = null;
 
-if (!axiom) {
+if (seqEnabled) {
+  flushTimer = setInterval(() => { flush(); }, 5_000);
+  flushTimer.unref(); // don't keep process alive just for logging
+}
+
+if (!seqEnabled) {
   process.stdout.write(
     JSON.stringify({
-      event: 'axiom_disabled',
-      reason: AXIOM_TOKEN ? 'no_dataset' : 'no_token',
+      event: 'seq_disabled',
+      reason: SEQ_URL ? 'no_api_key' : 'no_url',
       timestamp: new Date().toISOString(),
     }) + '\n',
   );
 }
 
-function sendToAxiom(event: string, fields: Record<string, unknown>): void {
-  if (!axiom) return;
+function sendToSeq(event: string, fields: Record<string, unknown>): void {
+  if (!seqEnabled) return;
   try {
-    axiom.ingest(AXIOM_DATASET!, [
-      { event, ...fields, _time: new Date().toISOString(), app: 'leporello', service: SERVICE_NAME, env: ENV_NAME },
-    ]);
+    const clefEvent = JSON.stringify({
+      '@t': new Date().toISOString(),
+      '@mt': event,
+      event,
+      ...fields,
+      app: 'leporello',
+      service: SERVICE_NAME,
+      env: ENV_NAME,
+    });
+    buffer.push(clefEvent);
   } catch (err) {
-    // Never re-throw, never re-send to Axiom (avoid loops)
     process.stderr.write(
       JSON.stringify({
-        event: 'axiom_ingest_error',
+        event: 'seq_ingest_error',
         error: String(err),
         timestamp: new Date().toISOString(),
       }) + '\n',
@@ -45,22 +57,33 @@ function writeLine(stream: NodeJS.WriteStream, event: string, fields: Record<str
 
 export function log(event: string, fields: Record<string, unknown> = {}): void {
   writeLine(process.stdout, event, fields);
-  sendToAxiom(event, fields);
+  sendToSeq(event, fields);
 }
 
 export function logError(event: string, fields: Record<string, unknown> = {}): void {
   writeLine(process.stderr, event, fields);
-  sendToAxiom(event, fields);
+  sendToSeq(event, fields);
 }
 
 export async function flush(): Promise<void> {
-  if (!axiom) return;
+  if (!seqEnabled || buffer.length === 0) return;
+  const body = buffer.splice(0).join('\n');
   try {
-    await axiom.flush();
+    const res = await fetch(`${SEQ_URL}/api/events/raw?clef`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/vnd.serilog.clef',
+        'X-Seq-ApiKey': SEQ_API_KEY!,
+      },
+      body,
+    });
+    if (!res.ok) {
+      throw new Error(`Seq responded ${res.status}: ${await res.text()}`);
+    }
   } catch (err) {
     process.stderr.write(
       JSON.stringify({
-        event: 'axiom_flush_error',
+        event: 'seq_flush_error',
         error: String(err),
         timestamp: new Date().toISOString(),
       }) + '\n',

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -9,14 +9,11 @@ const HASH_SALT = process.env.HASH_SALT ?? '';
 // Buffer CLEF lines and auto-flush every 5 seconds to Seq
 const seqEnabled = !!(SEQ_URL && SEQ_API_KEY);
 const buffer: string[] = [];
-let flushTimer: ReturnType<typeof setInterval> | null = null;
+let flushing = false;
 
 if (seqEnabled) {
-  flushTimer = setInterval(() => { flush(); }, 5_000);
-  flushTimer.unref(); // don't keep process alive just for logging
-}
-
-if (!seqEnabled) {
+  setInterval(() => { if (!flushing) flush(); }, 5_000).unref();
+} else {
   process.stdout.write(
     JSON.stringify({
       event: 'seq_disabled',
@@ -66,8 +63,9 @@ export function logError(event: string, fields: Record<string, unknown> = {}): v
 }
 
 export async function flush(): Promise<void> {
-  if (!seqEnabled || buffer.length === 0) return;
-  const body = buffer.splice(0).join('\n');
+  if (!seqEnabled || buffer.length === 0 || flushing) return;
+  const batch = buffer.splice(0);
+  flushing = true;
   try {
     const res = await fetch(`${SEQ_URL}/api/events/raw?clef`, {
       method: 'POST',
@@ -75,12 +73,13 @@ export async function flush(): Promise<void> {
         'Content-Type': 'application/vnd.serilog.clef',
         'X-Seq-ApiKey': SEQ_API_KEY!,
       },
-      body,
+      body: batch.join('\n'),
     });
     if (!res.ok) {
       throw new Error(`Seq responded ${res.status}: ${await res.text()}`);
     }
   } catch (err) {
+    buffer.unshift(...batch);
     process.stderr.write(
       JSON.stringify({
         event: 'seq_flush_error',
@@ -88,6 +87,8 @@ export async function flush(): Promise<void> {
         timestamp: new Date().toISOString(),
       }) + '\n',
     );
+  } finally {
+    flushing = false;
   }
 }
 


### PR DESCRIPTION
## Summary

- Replace `@axiomhq/js` with Seq client in `src/logger.ts`
- Update env vars from `AXIOM_TOKEN`/`AXIOM_DATASET` to `SEQ_URL`/`SEQ_API_KEY`
- Keep the `log`/`logError`/`flush` public API unchanged — no call-site changes needed

Closes #73

## Test plan

- [ ] `npm test` passes with updated logger mocks
- [ ] Local Seq instance receives structured events from `npm run dev`
- [ ] Scraper container logs appear in Seq after `docker compose run --rm scraper`
- [ ] Graceful degradation works when `SEQ_URL` is unset (stdout-only mode)
- [ ] Flush-on-shutdown delivers buffered events before process exits

🤖 Generated with [Claude Code](https://claude.com/claude-code)